### PR TITLE
Feat: Implement Integration Tests for `resolve_market`

### DIFF
--- a/contracts/predictify-hybrid/Cargo.toml
+++ b/contracts/predictify-hybrid/Cargo.toml
@@ -10,10 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-alloc = { version = "1.0", optional = true }
 
-[features]
-default = ["alloc"]
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -347,7 +347,7 @@ impl PredictifyHybrid {
             oracle_result
         } else {
             // If they disagree, check if community votes are significant
-            let total_votes: u32 = vote_counts.values().fold(0, |acc, count| acc + count);
+            let total_votes: u32 = vote_counts.values().into_iter().fold(0, |acc, count| acc + count);
             
             if total_votes == 0 {
                 // No community votes, use oracle result


### PR DESCRIPTION
## Summary

This PR introduces comprehensive tests for the `resolve_market` function in the `PredictifyHybrid` contract to ensure its correctness and robustness according to the specified requirements.

## Task Validation

This PR directly addresses the following validation tasks for `pub fn resolve_market(env: Env, market_id: Symbol) -> String`:

1.  **Ensure that the function cannot be called before the market end time:**
    *   The test `test_resolve_market_before_end_time` verifies that calling `resolve_market` before the market's `end_time` results in the expected `Error::MarketClosed` panic.

2.  **Validate correct calculation of weighted results:**
    *   The tests `test_resolve_market_oracle_wins_weighted` and `test_resolve_market_community_wins_weighted` specifically validate the 70/30 weighted resolution logic when the oracle and community results disagree and community votes are significant.
    *   These tests manipulate the ledger timestamp and sequence number to control the pseudo-random outcome of the weighting, confirming that the correct winner (oracle or community) is chosen based on the 30% threshold.

3.  **Check if the correct winner is determined based on oracle and community votes:**
    *   `test_resolve_market_oracle_and_community_agree`: Confirms that when the oracle and the community consensus match, that outcome is correctly chosen as the final result.
    *   `test_resolve_market_oracle_wins_low_votes`: Verifies that if the oracle and community disagree, but the total community vote count is below the significance threshold (currently 5), the oracle's result is correctly chosen.
    *   `test_resolve_market_oracle_wins_weighted` / `test_resolve_market_community_wins_weighted`: Further validate winner determination under the weighted scenario as described above.

## Additional Context

These tests were added as part of a larger effort that also included refactoring dependencies (removing `alloc`) and fixing prerequisite issues in the test suite environment (imports, types, protocol version, etc.) to enable accurate testing of `resolve_market`. All tests now pass.
<img width="1470" alt="Screenshot 2025-04-26 at 11 04 26 PM" src="https://github.com/user-attachments/assets/de7f62df-86a3-4308-aa81-e6cbdd0bf86a" />
