### PR TITLE
Feat: Implement claim_winnings function and enhance market resolution logic

### DIFF
--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -241,6 +241,11 @@ impl PredictifyHybrid {
             // Calculate user's share (minus 2% fee)
             let user_share = (user_stake * 98) / 100;
             let total_pool = market.total_staked;
+
+            // Ensure winning_total is non-zero
+            if winning_total == 0 {
+                panic_with_error!(env, Error::NothingToClaim);
+            }
             let payout = (user_share * total_pool) / winning_total;
 
             // Get token client

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -238,8 +238,8 @@ impl PredictifyHybrid {
                 }
             }
 
-            // Calculate user's share (minus 2% fee)
-            let user_share = (user_stake * 98) / 100;
+            // Calculate user's share (minus fee percentage)
+            let user_share = (user_stake * (PERCENTAGE_DENOMINATOR - FEE_PERCENTAGE)) / PERCENTAGE_DENOMINATOR;
             let total_pool = market.total_staked;
 
             // Ensure winning_total is non-zero

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -217,7 +217,7 @@ impl PredictifyHybrid {
         // Check if market is resolved
         let winning_outcome = match &market.winning_outcome {
             Some(outcome) => outcome,
-            None => panic_with_error!(env, Error::MarketAlreadyResolved),
+            None => panic_with_error!(env, Error::MarketNotResolved),
         };
 
         // Get user's vote and stake


### PR DESCRIPTION
## Summary

This PR introduces the `claim_winnings` function to the Predictify Hybrid contract, allowing users to claim their winnings from a resolved market. It also adds new fields to the `Market` struct to support secure and accurate claim tracking.

## Details

- **New Functionality:**  
  - Added `claim_winnings(env, user, market_id)` to allow users to claim winnings if they voted for the winning outcome.
  - Payouts are calculated based on the user’s stake relative to the total winning stakes, minus a 2% fee.
  - Uses the token client to transfer winnings securely to the user.

- **State Management Enhancements:**  
  - Added `stakes` (user-to-stake mapping), `claimed` (user-to-claim status), and `winning_outcome` (resolved outcome) fields to the `Market` struct.
  - Users can only claim if they haven’t already, and only if their vote matches the winning outcome.
  - The market’s state is persistently updated after each claim.

---

Closes #20 