### PR TITLE
Feat: Add close_market function for admin to remove markets from persistent storage

### DIFF
--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -633,5 +633,24 @@ impl PredictifyHybrid {
         // Return the final result
         final_result
     }
+
+    // Clean up market storage
+    pub fn close_market(env: Env, admin: Address, market_id: Symbol) {
+        admin.require_auth();
+
+        // Verify admin
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, "Admin"))
+            .expect("Admin not set");
+
+        if admin != stored_admin {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        // Remove market from storage
+        env.storage().persistent().remove(&market_id);
+    }
 }
 mod test;


### PR DESCRIPTION
## Summary

This pull request introduces the `close_market` function, addressing Issue #23. The feature allows the admin to clean up and permanently remove a market from persistent storage.

## Details

- **Admin Authentication:**  
  Ensures that only the authorized admin can invoke market closure by verifying admin rights via storage.

- **Market Removal:**  
  Removes the specified market from persistent storage, ensuring no residual state remains.

- **Error Handling:**  
  Handles unauthorized attempts by non-admin users and ensures robust checks for missing admin configuration.

---

Closes #23