### PR TITLE
feat: add event archive and historical query functionality

### DIFF
--- a/contracts/predictify-hybrid/src/event_archive.rs
+++ b/contracts/predictify-hybrid/src/event_archive.rs
@@ -1,0 +1,232 @@
+//! Event archive and historical query support.
+//!
+//! Provides archiving of resolved/cancelled events (markets) and gas-efficient,
+//! paginated historical query functions for analytics and UI. Exposes only
+//! public metadata and outcome; no sensitive data (votes, stakes, addresses).
+
+use crate::errors::Error;
+use crate::market_id_generator::MarketIdGenerator;
+use crate::types::{EventHistoryEntry, Market, MarketState};
+use soroban_sdk::{panic_with_error, Address, Env, String, Symbol, Vec};
+
+/// Maximum number of events returned per query (gas safety).
+pub const MAX_QUERY_LIMIT: u32 = 30;
+
+/// Storage key for archived event timestamps (market_id -> archived_at).
+const ARCHIVED_TS_KEY: &str = "evt_archived";
+
+/// Event archive and historical query manager.
+pub struct EventArchive;
+
+impl EventArchive {
+    /// Mark a resolved or cancelled event as archived (admin only).
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `admin` - Caller must be contract admin
+    /// * `market_id` - Market/event to archive
+    ///
+    /// # Errors
+    /// * `Unauthorized` - Caller is not admin
+    /// * `MarketNotFound` - Market does not exist
+    /// * `MarketNotEligibleForArchive` - Market must be Resolved or Cancelled
+    /// * `AlreadyArchived` - Event is already archived
+    pub fn archive_event(env: &Env, admin: &Address, market_id: &Symbol) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(env, "Admin"))
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
+
+        if admin != &stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let market: Market = env
+            .storage()
+            .persistent()
+            .get(market_id)
+            .ok_or(Error::MarketNotFound)?;
+
+        if market.state != MarketState::Resolved && market.state != MarketState::Cancelled {
+            return Err(Error::InvalidState);
+        }
+
+        let key = Symbol::new(env, ARCHIVED_TS_KEY);
+        let mut archived: soroban_sdk::Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(soroban_sdk::Map::new(env));
+
+        if archived.get(market_id.clone()).is_some() {
+            return Err(Error::AlreadyClaimed);
+        }
+
+        let now = env.ledger().timestamp();
+        archived.set(market_id.clone(), now);
+        env.storage().persistent().set(&key, &archived);
+
+        Ok(())
+    }
+
+    /// Check if an event is archived.
+    pub fn is_archived(env: &Env, market_id: &Symbol) -> bool {
+        let key = Symbol::new(env, ARCHIVED_TS_KEY);
+        let archived: soroban_sdk::Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(soroban_sdk::Map::new(env));
+        archived.get(market_id.clone()).is_some()
+    }
+
+    /// Get archived_at timestamp for a market (None if not archived).
+    fn get_archived_at(env: &Env, market_id: &Symbol) -> Option<u64> {
+        let key = Symbol::new(env, ARCHIVED_TS_KEY);
+        let archived: soroban_sdk::Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(soroban_sdk::Map::new(env));
+        archived.get(market_id.clone())
+    }
+
+    /// Build EventHistoryEntry from market and registry entry (public metadata only).
+    fn market_to_history_entry(
+        env: &Env,
+        market_id: &Symbol,
+        market: &Market,
+        created_at: u64,
+    ) -> EventHistoryEntry {
+        let archived_at = Self::get_archived_at(env, market_id);
+        let category = market.oracle_config.feed_id.clone();
+
+        EventHistoryEntry {
+            market_id: market_id.clone(),
+            question: market.question.clone(),
+            outcomes: market.outcomes.clone(),
+            end_time: market.end_time,
+            created_at,
+            state: market.state,
+            winning_outcome: market.winning_outcome.clone(),
+            total_staked: market.total_staked,
+            archived_at,
+            category,
+        }
+    }
+
+    /// Query events by creation time range (paginated, bounded).
+    ///
+    /// Returns events whose creation timestamp is in [from_ts, to_ts].
+    /// Only public metadata and outcome are returned.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `from_ts` - Start of time range (inclusive)
+    /// * `to_ts` - End of time range (inclusive)
+    /// * `cursor` - Pagination cursor (start index in registry)
+    /// * `limit` - Max results (capped at MAX_QUERY_LIMIT)
+    ///
+    /// # Returns
+    /// (entries, next_cursor). next_cursor is cursor + number of registry entries scanned.
+    pub fn query_events_history(
+        env: &Env,
+        from_ts: u64,
+        to_ts: u64,
+        cursor: u32,
+        limit: u32,
+    ) -> (Vec<EventHistoryEntry>, u32) {
+        let limit = core::cmp::min(limit, MAX_QUERY_LIMIT);
+        let registry_page = MarketIdGenerator::get_market_id_registry(env, cursor, limit);
+        let mut result = Vec::new(env);
+        let mut scanned = 0u32;
+
+        for i in 0..registry_page.len() {
+            if let Some(entry) = registry_page.get(i) {
+                scanned += 1;
+                let created_at = entry.timestamp;
+                if created_at >= from_ts && created_at <= to_ts {
+                    if let Some(market) = env.storage().persistent().get::<Symbol, Market>(&entry.market_id) {
+                        result.push_back(Self::market_to_history_entry(
+                            env,
+                            &entry.market_id,
+                            &market,
+                            created_at,
+                        ));
+                    }
+                }
+            }
+        }
+
+        (result, cursor + scanned)
+    }
+
+    /// Query events by resolution status (paginated, bounded).
+    ///
+    /// Returns events in the given state (e.g. Resolved, Cancelled, Active).
+    pub fn query_events_by_resolution_status(
+        env: &Env,
+        status: MarketState,
+        cursor: u32,
+        limit: u32,
+    ) -> (Vec<EventHistoryEntry>, u32) {
+        let limit = core::cmp::min(limit, MAX_QUERY_LIMIT);
+        let registry_page = MarketIdGenerator::get_market_id_registry(env, cursor, limit);
+        let mut result = Vec::new(env);
+        let mut scanned = 0u32;
+
+        for i in 0..registry_page.len() {
+            if let Some(entry) = registry_page.get(i) {
+                scanned += 1;
+                if let Some(market) = env.storage().persistent().get::<Symbol, Market>(&entry.market_id) {
+                    if market.state == status {
+                        result.push_back(Self::market_to_history_entry(
+                            env,
+                            &entry.market_id,
+                            &market,
+                            entry.timestamp,
+                        ));
+                    }
+                }
+            }
+        }
+
+        (result, cursor + scanned)
+    }
+
+    /// Query events by category (e.g. oracle feed_id) (paginated, bounded).
+    ///
+    /// Returns events whose oracle feed_id matches the given category string.
+    pub fn query_events_by_category(
+        env: &Env,
+        category: &String,
+        cursor: u32,
+        limit: u32,
+    ) -> (Vec<EventHistoryEntry>, u32) {
+        let limit = core::cmp::min(limit, MAX_QUERY_LIMIT);
+        let registry_page = MarketIdGenerator::get_market_id_registry(env, cursor, limit);
+        let mut result = Vec::new(env);
+        let mut scanned = 0u32;
+
+        for i in 0..registry_page.len() {
+            if let Some(entry) = registry_page.get(i) {
+                scanned += 1;
+                if let Some(market) = env.storage().persistent().get::<Symbol, Market>(&entry.market_id) {
+                    if market.oracle_config.feed_id == *category {
+                        result.push_back(Self::market_to_history_entry(
+                            env,
+                            &entry.market_id,
+                            &market,
+                            entry.timestamp,
+                        ));
+                    }
+                }
+            }
+        }
+
+        (result, cursor + scanned)
+    }
+}

--- a/contracts/predictify-hybrid/src/types.rs
+++ b/contracts/predictify-hybrid/src/types.rs
@@ -738,6 +738,37 @@ pub struct Market {
     pub extension_history: Vec<MarketExtension>,
 }
 
+// ===== EVENT ARCHIVE / HISTORICAL QUERY TYPES =====
+
+/// Summary of an event (market) for historical queries and analytics.
+///
+/// Contains only public metadata and outcome; no sensitive data (no votes, stakes, or addresses).
+/// Used by `query_events_history`, `query_events_by_resolution_status`, and `query_events_by_category`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventHistoryEntry {
+    /// Market/event ID
+    pub market_id: Symbol,
+    /// Question text (public)
+    pub question: String,
+    /// Outcome names (public)
+    pub outcomes: Vec<String>,
+    /// Market end time (Unix timestamp)
+    pub end_time: u64,
+    /// Creation timestamp (from registry)
+    pub created_at: u64,
+    /// Current market state (Active, Resolved, Cancelled, etc.)
+    pub state: MarketState,
+    /// Winning outcome if resolved
+    pub winning_outcome: Option<String>,
+    /// Total amount staked (public aggregate)
+    pub total_staked: i128,
+    /// When archived (if any); None if not archived
+    pub archived_at: Option<u64>,
+    /// Category / feed identifier (e.g. oracle feed_id) for filtering
+    pub category: String,
+}
+
 impl Market {
     /// Create a new market
     pub fn new(


### PR DESCRIPTION
## Summary
Implements event archive and historical query support for resolved/cancelled markets and fixes three existing payout tests that were failing because `resolve_market_manual` already calls `distribute_payouts` internally.

## Changes

### Test fixes (existing failures)
- **Cause:** `resolve_market_manual` calls `distribute_payouts` internally, so a second call saw all winners as claimed and returned 0.
- **Update:** In `test_automatic_payout_distribution`, `test_market_state_after_claim`, and `test_integration_full_market_lifecycle_with_payouts`:
  - Removed the extra `distribute_payouts` call.
  - Assert resolution and payout by checking `market.state == Resolved` and `market.claimed` for winners/losers.

### Event archive and historical query (#271)

**Types**
- Added `EventHistoryEntry` in `types.rs`: public metadata only (no votes, stakes, or addresses) — `market_id`, `question`, `outcomes`, `end_time`, `created_at`, `state`, `winning_outcome`, `total_staked`, `archived_at`, `category`.

**New module: `event_archive.rs`**
- `archive_event(env, admin, market_id)` — Admin-only; archives a resolved or cancelled market. Uses `Error::InvalidState` / `Error::AlreadyClaimed` (no new error variants to stay within `#[contracterror]` limit).
- `is_archived(env, market_id)` — Returns whether a market is archived.
- `query_events_history(env, from_ts, to_ts, cursor, limit)` — Events by creation time range; paginated; limit capped at 30.
- `query_events_by_resolution_status(env, status, cursor, limit)` — Events by `MarketState` (e.g. Resolved, Cancelled).
- `query_events_by_category(env, category, cursor, limit)` — Events by oracle `feed_id` (category).

**Public API in `lib.rs`**
- `archive_event(env, admin, market_id) -> Result<(), Error>`
- `query_events_history(env, from_ts, to_ts, cursor, limit) -> (Vec<EventHistoryEntry>, u32)`
- `query_events_by_status(env, status, cursor, limit) -> (Vec<EventHistoryEntry>, u32)` (name kept ≤ 32 chars)
- `query_events_by_category(env, category, cursor, limit) -> (Vec<EventHistoryEntry>, u32)`

**Security / design**
- Archive and query expose only public metadata and outcome; no sensitive data (votes, stakes, addresses).
- Queries are gas-bounded via pagination and `MAX_QUERY_LIMIT = 30`.
- Existing event storage and resolution behavior is unchanged.

**Tests**
- Archive: resolved market archive, unauthorized, active market rejected, already archived (success then panic on second archive).
- Queries: time range, by resolution status, by category, pagination, and that `EventHistoryEntry` contains only public fields.

## Testing
- `cargo build` — success
- `cargo test -p predictify-hybrid` — **398 tests passed** (including 3 fixed payout tests and 10 new archive/query tests)

Closes #271