### PR TITLE
feat: add refund mechanism for oracle resolution failures

### DIFF
--- a/contracts/predictify-hybrid/src/config.rs
+++ b/contracts/predictify-hybrid/src/config.rs
@@ -112,6 +112,10 @@ pub const COMMUNITY_WEIGHT_PERCENTAGE: u32 = 30;
 /// Minimum votes for community consensus
 pub const MIN_VOTES_FOR_CONSENSUS: u32 = 5;
 
+/// Default resolution timeout in seconds (7 days). After market end_time + this period
+/// with no oracle result, anyone may trigger refund on oracle failure.
+pub const DEFAULT_RESOLUTION_TIMEOUT_SECONDS: u64 = 604_800;
+
 // ===== ORACLE CONSTANTS =====
 
 /// Maximum oracle price age (1 hour)

--- a/contracts/predictify-hybrid/src/events.rs
+++ b/contracts/predictify-hybrid/src/events.rs
@@ -835,6 +835,21 @@ pub struct MarketClosedEvent {
     pub timestamp: u64,
 }
 
+/// Event emitted when a market is refunded due to oracle resolution failure or timeout.
+///
+/// Emitted after all bets are refunded in full (no fee deduction). The market is marked
+/// as cancelled and no further resolution is possible.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundOnOracleFailureEvent {
+    /// Market ID
+    pub market_id: Symbol,
+    /// Total amount refunded to all participants
+    pub total_refunded: i128,
+    /// Event timestamp
+    pub timestamp: u64,
+}
+
 /// Market finalized event
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1817,6 +1832,20 @@ impl EventEmitter {
         };
 
         Self::store_event(env, &symbol_short!("mkt_close"), &event);
+    }
+
+    /// Emit refund on oracle failure event (market cancelled, all bets refunded in full).
+    pub fn emit_refund_on_oracle_failure(
+        env: &Env,
+        market_id: &Symbol,
+        total_refunded: i128,
+    ) {
+        let event = RefundOnOracleFailureEvent {
+            market_id: market_id.clone(),
+            total_refunded,
+            timestamp: env.ledger().timestamp(),
+        };
+        Self::store_event(env, &symbol_short!("ref_oracl"), &event);
     }
 
     /// Emit market finalized event


### PR DESCRIPTION
- Introduced a new constant for default resolution timeout.
- Implemented refund_on_oracle_failure function to handle automatic refunds when oracle resolution fails or times out.
- Added RefundOnOracleFailureEvent to emit refund details.
- Created comprehensive tests to validate refund functionality for various scenarios, including admin-triggered refunds and timeout conditions.

Closes #253 #254 #257 #258