### PR TITLE
feat: implement contract pause and admin transfer functionality

### DIFF
--- a/contracts/predictify-hybrid/src/admin.rs
+++ b/contracts/predictify-hybrid/src/admin.rs
@@ -564,7 +564,93 @@ impl AdminAccessControl {
 
         Ok(())
     }
+}
 
+// ===== CONTRACT PAUSE AND ADMIN TRANSFER =====
+
+const CONTRACT_PAUSED_KEY: &str = "ContractPaused";
+
+/// Contract-level pause and primary admin transfer.
+pub struct ContractPauseManager;
+
+impl ContractPauseManager {
+    /// Returns true if the contract is currently paused.
+    pub fn is_contract_paused(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&Symbol::new(env, CONTRACT_PAUSED_KEY))
+            .unwrap_or(false)
+    }
+
+    /// Pause contract operations. Caller must be the current primary admin.
+    pub fn pause(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(env, "Admin"))
+            .ok_or(Error::AdminNotSet)?;
+        if admin != &stored {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(env, CONTRACT_PAUSED_KEY), &true);
+        EventEmitter::emit_contract_paused(env, admin);
+        Ok(())
+    }
+
+    /// Unpause contract operations. Caller must be the current primary admin.
+    pub fn unpause(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(env, "Admin"))
+            .ok_or(Error::AdminNotSet)?;
+        if admin != &stored {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(env, CONTRACT_PAUSED_KEY), &false);
+        EventEmitter::emit_contract_unpaused(env, admin);
+        Ok(())
+    }
+
+    /// Require that the contract is not paused; return Error::InvalidState otherwise.
+    pub fn require_not_paused(env: &Env) -> Result<(), Error> {
+        if Self::is_contract_paused(env) {
+            return Err(Error::InvalidState);
+        }
+        Ok(())
+    }
+
+    /// Transfer the primary admin role to a new address. Caller must be the current primary admin.
+    /// New admin must not be the zero/invalid address.
+    pub fn transfer_admin(env: &Env, current_admin: &Address, new_admin: &Address) -> Result<(), Error> {
+        current_admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(env, "Admin"))
+            .ok_or(Error::AdminNotSet)?;
+        if current_admin != &stored {
+            return Err(Error::Unauthorized);
+        }
+        if new_admin == current_admin {
+            return Err(Error::InvalidInput);
+        }
+        AdminValidator::validate_admin_address(env, new_admin)?;
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(env, "Admin"), new_admin);
+        EventEmitter::emit_admin_transferred(env, current_admin, new_admin);
+        Ok(())
+    }
+}
+
+impl AdminAccessControl {
     /// Validates admin authentication and permissions for a specific action.
     ///
     /// This comprehensive validation function combines authentication and

--- a/contracts/predictify-hybrid/src/bet_tests.rs
+++ b/contracts/predictify-hybrid/src/bet_tests.rs
@@ -116,6 +116,8 @@ impl BetTestSetup {
             &None,
             &86400u64,
             &None,
+            &None,
+            &None,
         )
     }
 

--- a/contracts/predictify-hybrid/src/bets.rs
+++ b/contracts/predictify-hybrid/src/bets.rs
@@ -798,6 +798,16 @@ impl BetValidator {
             return Err(Error::MarketClosed);
         }
 
+        // Bet deadline: no bets after deadline (0 = use end_time)
+        let deadline = if market.bet_deadline > 0 {
+            market.bet_deadline
+        } else {
+            market.end_time
+        };
+        if current_time >= deadline {
+            return Err(Error::MarketClosed);
+        }
+
         // Check if market is not already resolved
         if market.winning_outcomes.is_some() {
             return Err(Error::MarketResolved);

--- a/contracts/predictify-hybrid/src/category_tags_tests.rs
+++ b/contracts/predictify-hybrid/src/category_tags_tests.rs
@@ -48,6 +48,8 @@ fn create_test_market(
         &None,
         &86400u64,
         &None,
+        &None,
+        &None,
     )
 }
 
@@ -264,6 +266,8 @@ impl TokenTestSetup {
             },
             &None,
             &86400u64,
+            &None,
+            &None,
             &None,
         );
 

--- a/contracts/predictify-hybrid/src/event_creation_tests.rs
+++ b/contracts/predictify-hybrid/src/event_creation_tests.rs
@@ -105,6 +105,8 @@ fn test_create_market_success() {
         &None,
         &0,
         &None,
+        &None,
+        &None,
     );
 
     assert!(client.get_market(&market_id).is_some());
@@ -237,6 +239,9 @@ fn test_create_event_limit_enforced() {
             &oracle_config,
             &None,
             &0,
+            &None,
+            &None,
+            &None,
         );
     }
 }
@@ -272,6 +277,9 @@ fn test_decrement_on_cancel_frees_slot() {
             &oracle_config,
             &None,
             &0,
+            &None,
+            &None,
+            &None,
         ));
     }
 
@@ -290,5 +298,91 @@ fn test_decrement_on_cancel_frees_slot() {
         &oracle_config,
         &None,
         &0,
+        &None,
+        &None,
+        &None,
     );
+}
+
+#[test]
+fn test_event_id_unique() {
+    let setup = TestSetup::new();
+    let client = PredictifyHybridClient::new(&setup.env, &setup.contract_id);
+
+    let description = String::from_str(&setup.env, "Will this be a unique event A?");
+    let outcomes = vec![
+        &setup.env,
+        String::from_str(&setup.env, "Yes"),
+        String::from_str(&setup.env, "No"),
+    ];
+    let end_time = setup.env.ledger().timestamp() + 3600;
+    let oracle_config = OracleConfig {
+        provider: OracleProvider::Reflector,
+        oracle_address: Address::generate(&setup.env),
+        feed_id: String::from_str(&setup.env, "BTC/USD"),
+        threshold: 50000,
+        comparison: String::from_str(&setup.env, "gt"),
+    };
+
+    let event_id_1 = client.create_event(
+        &setup.admin,
+        &description,
+        &outcomes,
+        &end_time,
+        &oracle_config,
+        &None,
+        &0,
+        &None,
+    );
+    let desc_b = String::from_str(&setup.env, "Will this be a unique event B?");
+    let event_id_2 = client.create_event(
+        &setup.admin,
+        &desc_b,
+        &outcomes,
+        &end_time,
+        &oracle_config,
+        &None,
+        &0,
+        &None,
+    );
+
+    assert_ne!(event_id_1, event_id_2, "Event IDs must be unique");
+}
+
+#[test]
+fn test_event_storage_consistency() {
+    let setup = TestSetup::new();
+    let client = PredictifyHybridClient::new(&setup.env, &setup.contract_id);
+
+    let description = String::from_str(&setup.env, "Stored event?");
+    let outcomes = vec![
+        &setup.env,
+        String::from_str(&setup.env, "Yes"),
+        String::from_str(&setup.env, "No"),
+    ];
+    let end_time = setup.env.ledger().timestamp() + 7200;
+    let oracle_config = OracleConfig {
+        provider: OracleProvider::Reflector,
+        oracle_address: Address::generate(&setup.env),
+        feed_id: String::from_str(&setup.env, "BTC/USD"),
+        threshold: 50000,
+        comparison: String::from_str(&setup.env, "gt"),
+    };
+
+    let event_id = client.create_event(
+        &setup.admin,
+        &description,
+        &outcomes,
+        &end_time,
+        &oracle_config,
+        &None,
+        &0,
+        &None,
+    );
+
+    let stored = client.get_event(&event_id).unwrap();
+    assert_eq!(stored.description, description);
+    assert_eq!(stored.end_time, end_time);
+    assert_eq!(stored.outcomes.len(), outcomes.len());
+    assert_eq!(stored.id, event_id);
 }

--- a/contracts/predictify-hybrid/src/event_management_tests.rs
+++ b/contracts/predictify-hybrid/src/event_management_tests.rs
@@ -73,6 +73,8 @@ impl TestSetup {
             &None,
             &86400u64,
             &None,
+            &None,
+            &None,
         )
     }
 }

--- a/contracts/predictify-hybrid/src/events.rs
+++ b/contracts/predictify-hybrid/src/events.rs
@@ -1088,6 +1088,31 @@ pub struct AdminInitializedEvent {
     pub timestamp: u64,
 }
 
+/// Event emitted when the contract admin is transferred to a new address.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferredEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when the contract is paused by admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractPausedEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when the contract is unpaused by admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractUnpausedEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractInitializedEvent {
@@ -2306,6 +2331,34 @@ impl EventEmitter {
         };
 
         Self::store_event(env, &symbol_short!("adm_init"), &event);
+    }
+
+    /// Emit admin transferred event (primary admin role transferred to new address).
+    pub fn emit_admin_transferred(env: &Env, previous_admin: &Address, new_admin: &Address) {
+        let event = AdminTransferredEvent {
+            previous_admin: previous_admin.clone(),
+            new_admin: new_admin.clone(),
+            timestamp: env.ledger().timestamp(),
+        };
+        Self::store_event(env, &symbol_short!("adm_xfer"), &event);
+    }
+
+    /// Emit contract paused event.
+    pub fn emit_contract_paused(env: &Env, admin: &Address) {
+        let event = ContractPausedEvent {
+            admin: admin.clone(),
+            timestamp: env.ledger().timestamp(),
+        };
+        Self::store_event(env, &symbol_short!("ctr_pause"), &event);
+    }
+
+    /// Emit contract unpaused event.
+    pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
+        let event = ContractUnpausedEvent {
+            admin: admin.clone(),
+            timestamp: env.ledger().timestamp(),
+        };
+        Self::store_event(env, &symbol_short!("ctr_unp"), &event);
     }
 
     /// Emit contract initialized event (full initialization with platform fee)

--- a/contracts/predictify-hybrid/src/integration_test.rs
+++ b/contracts/predictify-hybrid/src/integration_test.rs
@@ -99,6 +99,8 @@ impl IntegrationTestSuite {
             &None,
             &0,
             &None,
+            &None,
+            &None,
         );
 
         self.market_ids.push_back(market_id.clone());

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -358,7 +358,12 @@ impl PredictifyHybrid {
         fallback_oracle_config: Option<OracleConfig>,
         resolution_timeout: u64,
         min_pool_size: Option<i128>,
+        bet_deadline_mins_before_end: Option<u32>,
+        dispute_window_seconds: Option<u64>,
     ) -> Symbol {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         // Authenticate that the caller is the admin
         admin.require_auth();
 
@@ -399,6 +404,19 @@ impl PredictifyHybrid {
         let duration_seconds: u64 = (duration_days as u64) * seconds_per_day;
         let end_time: u64 = env.ledger().timestamp() + duration_seconds;
 
+        // Bet deadline: if set, must be before end_time
+        let bet_deadline: u64 = match bet_deadline_mins_before_end {
+            Some(mins) => {
+                let deadline = end_time.saturating_sub((mins as u64) * 60);
+                if deadline >= end_time || deadline == 0 {
+                    panic_with_error!(env, Error::InvalidDuration);
+                }
+                deadline
+            }
+            None => 0,
+        };
+        let dispute_win = dispute_window_seconds.unwrap_or(86400u64); // 24h default
+
         let (has_fallback, fallback_cfg) = match &fallback_oracle_config {
             Some(c) => (true, c.clone()),
             None => (false, OracleConfig::none_sentinel(&env)),
@@ -428,6 +446,8 @@ impl PredictifyHybrid {
             category: None,
             tags: Vec::new(&env),
             min_pool_size,
+            bet_deadline,
+            dispute_window_seconds: dispute_win,
         };
 
         // Store the market
@@ -480,6 +500,9 @@ impl PredictifyHybrid {
         resolution_timeout: u64,
         min_pool_size: Option<i128>,
     ) -> Symbol {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         // Authenticate that the caller is the admin
         admin.require_auth();
 
@@ -628,6 +651,9 @@ impl PredictifyHybrid {
     /// - Current time must be before market end time
     /// - Market must not be cancelled or resolved
     pub fn vote(env: Env, user: Address, market_id: Symbol, outcome: String, stake: i128) {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         user.require_auth();
 
         let mut market: Market = env
@@ -807,6 +833,9 @@ impl PredictifyHybrid {
         outcome: String,
         amount: i128,
     ) -> crate::types::Bet {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         if ReentrancyGuard::check_reentrancy_state(&env).is_err() {
             panic_with_error!(env, Error::InvalidState);
         }
@@ -880,6 +909,9 @@ impl PredictifyHybrid {
         user: Address,
         bets: Vec<(Symbol, String, i128)>,
     ) -> Vec<crate::types::Bet> {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         if ReentrancyGuard::check_reentrancy_state(&env).is_err() {
             panic_with_error!(env, Error::InvalidState);
         }
@@ -1216,6 +1248,9 @@ impl PredictifyHybrid {
     /// - User must have voted for the winning outcome
     /// - User must not have previously claimed winnings
     pub fn claim_winnings(env: Env, user: Address, market_id: Symbol) {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         user.require_auth();
         if ReentrancyGuard::check_reentrancy_state(&env).is_err() {
             panic_with_error!(env, Error::InvalidState);
@@ -1455,6 +1490,9 @@ impl PredictifyHybrid {
         market_id: Symbol,
         winning_outcome: String,
     ) {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         admin.require_auth();
 
         // Verify admin
@@ -1534,8 +1572,12 @@ impl PredictifyHybrid {
             &reason,
         );
 
-        // Automatically distribute payouts to winners after resolution
-        let _ = Self::distribute_payouts(env.clone(), market_id);
+        // Distribute payouts only after dispute window closes (or skip and allow finalize_after_window later)
+        let now = env.ledger().timestamp();
+        let payout_allowed = now >= market.end_time.saturating_add(market.dispute_window_seconds);
+        if payout_allowed {
+            let _ = Self::distribute_payouts(env.clone(), market_id);
+        }
     }
 
     /// Resolves a market with multiple winning outcomes (for tie cases).
@@ -1596,6 +1638,9 @@ impl PredictifyHybrid {
         market_id: Symbol,
         winning_outcomes: Vec<String>,
     ) {
+        if let Err(e) = admin::ContractPauseManager::require_not_paused(&env) {
+            panic_with_error!(env, e);
+        }
         admin.require_auth();
 
         // Verify admin
@@ -1680,8 +1725,12 @@ impl PredictifyHybrid {
             &reason,
         );
 
-        // Automatically distribute payouts (handles split pool for ties)
-        let _ = Self::distribute_payouts(env.clone(), market_id);
+        // Distribute payouts only after dispute window closes
+        let now = env.ledger().timestamp();
+        let payout_allowed = now >= market.end_time.saturating_add(market.dispute_window_seconds);
+        if payout_allowed {
+            let _ = Self::distribute_payouts(env.clone(), market_id);
+        }
     }
 
     /// Fetches oracle result for a market from external oracle contracts.
@@ -2422,6 +2471,7 @@ impl PredictifyHybrid {
     ///
     /// This function emits `WinningsClaimedEvent` for each user who receives a payout.
     pub fn distribute_payouts(env: Env, market_id: Symbol) -> Result<i128, Error> {
+        admin::ContractPauseManager::require_not_paused(&env)?;
         if ReentrancyGuard::check_reentrancy_state(&env).is_err() {
             return Err(Error::InvalidState);
         }
@@ -2438,6 +2488,12 @@ impl PredictifyHybrid {
             Some(outcomes) => outcomes,
             None => return Err(Error::MarketNotResolved),
         };
+
+        // Dispute window: payouts only after end_time + dispute_window_seconds
+        let now = env.ledger().timestamp();
+        if now < market.end_time.saturating_add(market.dispute_window_seconds) {
+            return Err(Error::InvalidState);
+        }
 
         // Get all bettors
         let bettors = bets::BetStorage::get_all_bets_for_market(&env, &market_id);
@@ -2616,6 +2672,12 @@ impl PredictifyHybrid {
         env.storage().persistent().set(&market_id, &market);
 
         Ok(total_distributed)
+    }
+
+    /// Finalize payouts after the dispute window has closed. Callable by anyone once
+    /// market is resolved and current time >= end_time + dispute_window_seconds.
+    pub fn finalize_after_window(env: Env, market_id: Symbol) -> Result<i128, Error> {
+        Self::distribute_payouts(env, market_id)
     }
 
     // ===== EVENT ARCHIVE AND HISTORICAL QUERY =====
@@ -4339,6 +4401,30 @@ impl PredictifyHybrid {
     /// Get all admin roles in the system
     pub fn get_admin_roles(env: Env) -> Map<Address, AdminRole> {
         AdminManager::get_admin_roles(&env)
+    }
+
+    /// Transfer the primary contract admin to a new address. Caller must be the current primary admin.
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), Error> {
+        admin::ContractPauseManager::transfer_admin(&env, &current_admin, &new_admin)
+    }
+
+    /// Pause contract operations (admin only). Blocks all state-changing operations until unpause.
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        admin::ContractPauseManager::pause(&env, &admin)
+    }
+
+    /// Unpause contract operations (admin only).
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        admin::ContractPauseManager::unpause(&env, &admin)
+    }
+
+    /// Returns true if the contract is currently paused.
+    pub fn is_contract_paused(env: Env) -> bool {
+        admin::ContractPauseManager::is_contract_paused(&env)
     }
 
     /// Get comprehensive admin analytics

--- a/contracts/predictify-hybrid/src/monitoring.rs
+++ b/contracts/predictify-hybrid/src/monitoring.rs
@@ -467,6 +467,8 @@ impl ContractMonitor {
             category: None,
             tags: Vec::new(env),
             min_pool_size: None,
+            bet_deadline: 0,
+            dispute_window_seconds: 86400,
         })
     }
 

--- a/contracts/predictify-hybrid/src/property_based_tests.rs
+++ b/contracts/predictify-hybrid/src/property_based_tests.rs
@@ -181,6 +181,8 @@ proptest! {
             &None,
             &0,
             &None,
+            &None,
+            &None,
         );
 
         // Verify market was created with correct properties
@@ -231,6 +233,8 @@ proptest! {
             &oracle_config,
             &None,
             &0,
+            &None,
+            &None,
             &None,
         );
 
@@ -285,6 +289,8 @@ proptest! {
             &oracle_config,
             &None,
             &0,
+            &None,
+            &None,
             &None,
         );
 
@@ -456,6 +462,8 @@ proptest! {
             &None,
             &0,
             &None,
+            &None,
+            &None,
         );
 
         let initial_market = client.get_market(&market_id).unwrap();
@@ -511,6 +519,8 @@ proptest! {
             &oracle_config,
             &None,
             &86400u64,
+            &None,
+            &None,
             &None,
         );
 

--- a/contracts/predictify-hybrid/src/test.rs
+++ b/contracts/predictify-hybrid/src/test.rs
@@ -154,6 +154,8 @@ impl PredictifyTest {
             &None,
             &0,
             &None,
+            &None,
+            &None,
         )
     }
 }
@@ -185,6 +187,8 @@ fn test_create_market_successful() {
         },
         &None,
         &0,
+        &None,
+        &None,
         &None,
     );
 
@@ -274,7 +278,7 @@ fn test_vote_on_closed_market() {
     });
 
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1243,7 +1247,7 @@ fn test_automatic_payout_distribution() {
             .unwrap()
     });
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1310,7 +1314,7 @@ fn test_automatic_payout_distribution_no_winners() {
             .unwrap()
     });
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1535,7 +1539,7 @@ fn test_cancel_event_already_resolved() {
             .unwrap()
     });
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1648,7 +1652,7 @@ fn test_refund_on_oracle_failure_admin_success() {
             .unwrap()
     });
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1703,7 +1707,7 @@ fn test_refund_on_oracle_failure_full_amount_per_user() {
             .unwrap()
     });
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -1994,8 +1998,10 @@ fn test_manual_dispute_resolution_triggers_payout() {
             .get::<Symbol, Market>(&market_id)
             .unwrap()
     });
+    // Advance past end_time and dispute window so resolve_market_manual can distribute payouts
+    let payout_time = market.end_time + market.dispute_window_seconds + 1;
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: payout_time,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -2005,7 +2011,7 @@ fn test_manual_dispute_resolution_triggers_payout() {
         max_entry_ttl: 10000,
     });
 
-    // Manually resolve (distribute_payouts runs inside and marks winner as claimed)
+    // Manually resolve (distribute_payouts runs inside once dispute window has passed)
     test.env.mock_all_auths();
     client.resolve_market_manual(&test.admin, &market_id, &String::from_str(&test.env, "yes"));
 
@@ -2127,7 +2133,7 @@ fn test_claim_winnings_successful() {
     });
 
     test.env.ledger().set(LedgerInfo {
-        timestamp: market.end_time + 1,
+        timestamp: market.end_time + market.dispute_window_seconds + 1,
         protocol_version: 22,
         sequence_number: test.env.ledger().sequence(),
         network_id: Default::default(),
@@ -2287,6 +2293,8 @@ fn test_create_market_with_min_pool_size() {
         &None,
         &0,
         &Some(500_0000000), // 500 XLM min pool
+        &None,
+        &None,
     );
 
     let market = test.env.as_contract(&test.contract_id, || {
@@ -2325,6 +2333,8 @@ fn test_create_market_without_min_pool_size() {
         },
         &None,
         &0,
+        &None,
+        &None,
         &None,
     );
 
@@ -2365,6 +2375,8 @@ fn test_resolution_blocked_when_pool_below_minimum() {
         &None,
         &0,
         &Some(500_0000000), // 500 XLM minimum
+        &None,
+        &None,
     );
 
     // Place a small vote below min pool
@@ -2442,6 +2454,8 @@ fn test_resolution_succeeds_when_pool_meets_minimum() {
         &None,
         &0,
         &Some(10_0000000), // 10 XLM minimum
+        &None,
+        &None,
     );
 
     // Place votes totaling above min pool
@@ -2519,6 +2533,8 @@ fn test_resolution_succeeds_with_no_min_pool_size() {
         },
         &None,
         &0,
+        &None,
+        &None,
         &None,
     );
 
@@ -2598,6 +2614,8 @@ fn test_cancel_underfunded_event() {
         &None,
         &0,
         &Some(500_0000000), // 500 XLM minimum
+        &None,
+        &None,
     );
 
     // Place a small vote below min pool

--- a/contracts/predictify-hybrid/src/types.rs
+++ b/contracts/predictify-hybrid/src/types.rs
@@ -770,6 +770,10 @@ pub struct Market {
     pub tags: Vec<String>,
     /// Minimum total pool size required for resolution (None = no minimum)
     pub min_pool_size: Option<i128>,
+    /// Bet deadline (Unix timestamp). No bets accepted after this time. 0 = use end_time (no early cutoff).
+    pub bet_deadline: u64,
+    /// Dispute window in seconds after end_time. Payouts allowed only after end_time + this period (or dispute resolved).
+    pub dispute_window_seconds: u64,
 }
 
 // ===== BET LIMITS =====
@@ -899,6 +903,8 @@ impl Market {
             category: None,
             tags: Vec::new(env),
             min_pool_size: None,
+            bet_deadline: 0,
+            dispute_window_seconds: 86400, // 24h default
         }
     }
 


### PR DESCRIPTION
# feat: admin controls, bet deadline, resolution delay/dispute window, and event creation tests (#220, #245, #263, #197)

## Summary

Implements four issues: admin management and contract control (#220), bet deadline cutoff (#245), resolution delay and dispute window (#263), and comprehensive event creation tests (#197).

---

## #220 – Admin management and contract control

- **transfer_admin**: Current primary admin can transfer the role to a new address (validated, not zero).
- **pause / unpause**: Admin can pause and unpause contract operations; state-changing calls check pause and return `InvalidState` when paused.
- **Events**: `emit_admin_transferred`, `emit_contract_paused`, `emit_contract_unpaused`.
- **Storage**: Primary admin under `"Admin"`; global pause flag under `"ContractPaused"`.

---

## #245 – Bet deadline cutoff before event end

- **Per-event bet deadline**: `create_market` accepts optional `bet_deadline_mins_before_end`; stored as absolute `bet_deadline` on `Market` (0 = no early cutoff).
- **Validation**: `place_bet` / `place_bets` reject bets when current time ≥ bet deadline (or ≥ `end_time` if no deadline).
- **Creation**: Deadline must be before `end_time`; invalid values cause `InvalidDuration`.

---

## #263 – Resolution delay and dispute window before final payout

- **Per-event dispute window**: `Market.dispute_window_seconds` (default 24h); optional at `create_market` via `dispute_window_seconds`.
- **Resolution vs payout**: `resolve_market_manual` and `resolve_market_with_ties` set winning outcomes immediately; payouts run only when `current_time >= end_time + dispute_window_seconds`.
- **finalize_after_window**: New entrypoint to trigger `distribute_payouts` once the window has closed (callable by anyone).
- **distribute_payouts**: Returns `InvalidState` if still inside the dispute window.
- Integrates with existing dispute and payout logic; resolution delay tests already in `resolution_delay_dispute_window_tests.rs`.

---

## #197 – Comprehensive event creation tests

- **Event ID uniqueness**: Two events created; assert IDs differ.
- **Event storage consistency**: Create event, then assert `get_event` returns same description, `end_time`, outcomes, and `id`.
- Existing coverage kept: success, admin-only, parameter validation (end time, outcomes), limit enforced, decrement on cancel.

---

## Testing and CI

- All relevant tests updated for new `create_market` signature (`bet_deadline_mins_before_end`, `dispute_window_seconds`) and for dispute-window timing (advance time past `end_time + dispute_window_seconds` where payouts are asserted).
- `cargo build`, `stellar contract build`, and `cargo test` run successfully (CI parity).

---

## Breaking / API changes

- **create_market**: Two new optional parameters: `bet_deadline_mins_before_end: Option<u32>`, `dispute_window_seconds: Option<u64>`. Callers should pass `None, None` for previous behavior (no bet deadline, 24h dispute window).
- **Market**: New fields `bet_deadline: u64`, `dispute_window_seconds: u64` (existing `Market::new` and storage usages updated).