### PR TITLE
feat(contract): clarify primary and fallback oracle resolution

### DIFF
--- a/contracts/predictify-hybrid/src/event_management_tests.rs
+++ b/contracts/predictify-hybrid/src/event_management_tests.rs
@@ -38,6 +38,10 @@ impl TestSetup {
         // Initialize the contract
         let client = PredictifyHybridClient::new(&env, &contract_id);
         client.initialize(&admin, &None);
+        env.as_contract(&contract_id, || {
+            crate::circuit_breaker::CircuitBreaker::initialize(&env)
+                .expect("circuit breaker should initialize in tests");
+        });
 
         Self {
             env,

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -73,7 +73,7 @@ mod bandprotocol {
 
 #[cfg(any())]
 mod circuit_breaker_tests;
-#[cfg(any())]
+#[cfg(test)]
 mod oracle_fallback_timeout_tests;
 
 #[cfg(any())]
@@ -155,6 +155,34 @@ use soroban_sdk::{
 pub struct PredictifyHybrid;
 
 const PERCENTAGE_DENOMINATOR: i128 = 100;
+const MIN_RESOLUTION_TIMEOUT_SECONDS: u64 = 3_600;
+const MAX_RESOLUTION_TIMEOUT_SECONDS: u64 = 31_536_000;
+const ORACLE_FAILURE_PRIMARY_ONLY_REASON: &str = "oracle_resolution_failed_primary_only";
+const ORACLE_FAILURE_PRIMARY_THEN_FALLBACK_REASON: &str =
+    "oracle_resolution_failed_primary_then_fallback";
+
+fn validate_resolution_timeout(timeout: u64) -> Result<(), Error> {
+    if !(MIN_RESOLUTION_TIMEOUT_SECONDS..=MAX_RESOLUTION_TIMEOUT_SECONDS).contains(&timeout) {
+        return Err(Error::InvalidInput);
+    }
+
+    Ok(())
+}
+
+fn resolution_deadline(market: &Market) -> u64 {
+    market.end_time.saturating_add(market.resolution_timeout)
+}
+
+fn resolution_timeout_reached(env: &Env, market: &Market) -> bool {
+    env.ledger().timestamp() >= resolution_deadline(market)
+}
+
+fn automatic_oracle_result_unavailable(
+    _env: &Env,
+    _config: &OracleConfig,
+) -> Result<String, Error> {
+    Err(Error::OracleUnavailable)
+}
 
 #[contractimpl]
 impl PredictifyHybrid {
@@ -440,6 +468,13 @@ impl PredictifyHybrid {
     /// New markets are created in `MarketState::Active` state, allowing immediate voting.
     /// The market will automatically transition to `MarketState::Ended` when the duration expires.
     ///
+    /// # Oracle Resolution Policy
+    ///
+    /// - `oracle_config` is always the first automatic oracle consulted after market end.
+    /// - `fallback_oracle_config`, when present, is consulted only after one failed primary attempt.
+    /// - `resolution_timeout` is enforced per market from `end_time`; automatic oracle resolution stops at
+    ///   `end_time + resolution_timeout`.
+    ///
     /// # Errors
     ///
     /// This entrypoint surfaces contract errors via panic in internal calls.
@@ -457,7 +492,9 @@ impl PredictifyHybrid {
         fallback_oracle_config: Option<OracleConfig>,
         resolution_timeout: u64,
     ) -> Symbol {
-        if let Err(e) = crate::circuit_breaker::CircuitBreaker::require_write_allowed(&env, "create_market") {
+        if let Err(e) =
+            crate::circuit_breaker::CircuitBreaker::require_write_allowed(&env, "create_market")
+        {
             panic_with_error!(env, e);
         }
         let gas_marker = GasTracker::start_tracking(&env);
@@ -482,6 +519,20 @@ impl PredictifyHybrid {
 
         if question.len() == 0 {
             panic_with_error!(env, Error::InvalidQuestion);
+        }
+
+        if let Err(e) = oracle_config.validate(&env) {
+            panic_with_error!(env, e);
+        }
+
+        if let Some(fallback) = &fallback_oracle_config {
+            if let Err(e) = fallback.validate(&env) {
+                panic_with_error!(env, e);
+            }
+        }
+
+        if let Err(e) = validate_resolution_timeout(resolution_timeout) {
+            panic_with_error!(env, e);
         }
 
         // Generate a unique collision-resistant market ID
@@ -558,7 +609,9 @@ impl PredictifyHybrid {
     /// * `description` - The event description or question
     /// * `outcomes` - Vector of possible outcomes
     /// * `end_time` - Absolute Unix timestamp for when the event ends
-    /// * `oracle_config` - Configuration for oracle integration
+    /// * `oracle_config` - Primary oracle configuration for automatic resolution
+    /// * `fallback_oracle_config` - Optional backup oracle attempted only after one failed primary attempt
+    /// * `resolution_timeout` - Per-event oracle deadline in seconds, measured from `end_time`
     ///
     /// # Returns
     ///
@@ -569,6 +622,7 @@ impl PredictifyHybrid {
     /// Panics if:
     /// - Caller is not the contract admin
     /// - validation fails (invalid description, outcomes, or end time)
+    /// - `resolution_timeout` falls outside the supported bounds
     ///
     /// # Errors
     ///
@@ -587,7 +641,9 @@ impl PredictifyHybrid {
         fallback_oracle_config: Option<OracleConfig>,
         resolution_timeout: u64,
     ) -> Symbol {
-        if let Err(e) = crate::circuit_breaker::CircuitBreaker::require_write_allowed(&env, "create_event") {
+        if let Err(e) =
+            crate::circuit_breaker::CircuitBreaker::require_write_allowed(&env, "create_event")
+        {
             panic_with_error!(env, e);
         }
         // Authenticate that the caller is the admin
@@ -604,8 +660,19 @@ impl PredictifyHybrid {
             panic_with_error!(env, Error::Unauthorized);
         }
 
-        // Skip validation for now since validation module is disabled
-        // TODO: Re-enable when validation module is fixed
+        if let Err(e) = oracle_config.validate(&env) {
+            panic_with_error!(env, e);
+        }
+
+        if let Some(fallback) = &fallback_oracle_config {
+            if let Err(e) = fallback.validate(&env) {
+                panic_with_error!(env, e);
+            }
+        }
+
+        if let Err(e) = validate_resolution_timeout(resolution_timeout) {
+            panic_with_error!(env, e);
+        }
 
         // Generate a unique collision-resistant event ID (reusing market ID generator)
         let event_id = MarketIdGenerator::generate_market_id(&env, &admin);
@@ -1953,7 +2020,9 @@ impl PredictifyHybrid {
     ///
     /// - Market must exist and be past its end time
     /// - Market must not already have an oracle result
-    /// - Oracle contract must be accessible and responsive
+    /// - Automatic oracle resolution stops once `ledger.timestamp() >= end_time + resolution_timeout`
+    /// - When `has_fallback` is `true`, the contract attempts the primary oracle once and then the fallback once
+    /// - The market-stored oracle configuration controls ordering; the external `oracle_contract` argument is ignored
     ///
     /// # Events
     ///
@@ -1963,8 +2032,10 @@ impl PredictifyHybrid {
         market_id: Symbol,
         oracle_contract: Address,
     ) -> Result<String, Error> {
+        let _ = oracle_contract;
+
         // Get the market from storage
-        let market = env
+        let mut market = env
             .storage()
             .persistent()
             .get::<Symbol, Market>(&market_id)
@@ -1981,15 +2052,49 @@ impl PredictifyHybrid {
             return Err(Error::MarketClosed);
         }
 
-        // Get oracle result using the resolution module (oracle_contract from market config is used internally)
-        // Temporarily disabled due to resolution module being disabled
-        // let oracle_resolution = resolution::OracleResolutionManager::fetch_oracle_result(
-        //     &env,
-        //     &market_id,
-        // )?;
+        if resolution_timeout_reached(&env, &market) {
+            EventEmitter::emit_resolution_timeout(&env, &market_id, current_time);
+            return Err(Error::ResolutionTimeoutReached);
+        }
 
-        // Return a dummy result for now
-        Err(Error::OracleUnavailable)
+        match automatic_oracle_result_unavailable(&env, &market.oracle_config) {
+            Ok(outcome) => {
+                market.oracle_result = Some(outcome.clone());
+                env.storage().persistent().set(&market_id, &market);
+                Ok(outcome)
+            }
+            Err(_) if market.has_fallback => {
+                match automatic_oracle_result_unavailable(&env, &market.fallback_oracle_config) {
+                    Ok(outcome) => {
+                        market.oracle_result = Some(outcome.clone());
+                        env.storage().persistent().set(&market_id, &market);
+                        EventEmitter::emit_fallback_used(
+                            &env,
+                            &market_id,
+                            &market.oracle_config.oracle_address,
+                            &market.fallback_oracle_config.oracle_address,
+                        );
+                        Ok(outcome)
+                    }
+                    Err(_) => {
+                        EventEmitter::emit_manual_resolution_required(
+                            &env,
+                            &market_id,
+                            &String::from_str(&env, ORACLE_FAILURE_PRIMARY_THEN_FALLBACK_REASON),
+                        );
+                        Err(Error::FallbackOracleUnavailable)
+                    }
+                }
+            }
+            Err(err) => {
+                EventEmitter::emit_manual_resolution_required(
+                    &env,
+                    &market_id,
+                    &String::from_str(&env, ORACLE_FAILURE_PRIMARY_ONLY_REASON),
+                );
+                Err(err)
+            }
+        }
     }
 
     /// Verifies and fetches event outcome from external oracle sources automatically.
@@ -4414,6 +4519,9 @@ impl PredictifyHybrid {
     /// Refunds full bet amount per user (no fee deduction). Marks market as cancelled and
     /// prevents further resolution. Emits refund events. Idempotent when already cancelled.
     ///
+    /// The timeout gate is evaluated per market from `end_time + resolution_timeout`.
+    /// Non-admin callers cannot trigger this path before that market-specific deadline.
+    ///
     /// # Errors
     ///
     /// Returns [`Error`] when validation, authorization, storage, or subsystem checks fail.
@@ -4451,8 +4559,7 @@ impl PredictifyHybrid {
         let stored_admin: Option<Address> =
             env.storage().persistent().get(&Symbol::new(&env, "Admin"));
         let is_admin = stored_admin.as_ref().map_or(false, |a| a == &caller);
-        let timeout_passed = current_time.saturating_sub(market.end_time)
-            >= config::DEFAULT_RESOLUTION_TIMEOUT_SECONDS;
+        let timeout_passed = resolution_timeout_reached(&env, &market);
         if !is_admin && !timeout_passed {
             return Err(Error::Unauthorized);
         }
@@ -5235,7 +5342,11 @@ impl PredictifyHybrid {
 
     // ===== ORACLE FALLBACK FUNCTIONS =====
 
-    /// Get oracle data with backup if primary fails
+    /// Get oracle data with backup if primary fails.
+    ///
+    /// The helper always attempts `primary_oracle` first. It attempts `backup_oracle`
+    /// only after a failed primary call, and it aborts before any oracle call once
+    /// `ledger.timestamp() >= end_time + resolution_timeout`.
     ///
     /// # Errors
     ///
@@ -5262,6 +5373,10 @@ impl PredictifyHybrid {
         let current_time = env.ledger().timestamp();
         if current_time < market.end_time {
             return Err(Error::MarketClosed);
+        }
+        if resolution_timeout_reached(&env, &market) {
+            EventEmitter::emit_resolution_timeout(&env, &market_id, current_time);
+            return Err(Error::ResolutionTimeoutReached);
         }
 
         // Try to get price with backup
@@ -5296,9 +5411,9 @@ impl PredictifyHybrid {
             }
             Err(_) => {
                 // Both oracles failed
-                let reason = String::from_str(&env, "All oracles failed");
+                let reason = String::from_str(&env, ORACLE_FAILURE_PRIMARY_THEN_FALLBACK_REASON);
                 events::EventEmitter::emit_manual_resolution_required(&env, &market_id, &reason);
-                Err(Error::OracleUnavailable)
+                Err(Error::FallbackOracleUnavailable)
             }
         }
     }

--- a/contracts/predictify-hybrid/src/oracle_fallback_timeout_tests.rs
+++ b/contracts/predictify-hybrid/src/oracle_fallback_timeout_tests.rs
@@ -1,169 +1,265 @@
-#![cfg(test)]
+use crate::errors::Error;
+use crate::events::{
+    FallbackUsedEvent, ManualResolutionRequiredEvent, RefundOnOracleFailureEvent,
+    ResolutionTimeoutEvent,
+};
+use crate::types::{Market, MarketState, OracleConfig, OracleProvider};
+use crate::{PredictifyHybrid, PredictifyHybridClient};
+use soroban_sdk::testutils::{Address as _, Events, Ledger};
+use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol, TryFromVal, TryIntoVal};
 
-extern crate alloc;
-use alloc::string::String;
-use alloc::vec;
+struct TestSetup {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+    token_id: Address,
+}
 
-// Oracle Fallback and Resolution Timeout Tests
+impl TestSetup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
 
-// ===== BASIC ORACLE TESTS =====
+        let admin = Address::generate(&env);
+        let contract_id = env.register(PredictifyHybrid, ());
 
-#[test]
-fn test_oracle_basic_1() {
-    assert!(true);
+        let token_admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_id = token_contract.address();
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&Symbol::new(&env, "TokenID"), &token_id);
+        });
+
+        let client = PredictifyHybridClient::new(&env, &contract_id);
+        client.initialize(&admin, &None);
+        env.as_contract(&contract_id, || {
+            crate::circuit_breaker::CircuitBreaker::initialize(&env)
+                .expect("circuit breaker should initialize in tests");
+        });
+
+        Self {
+            env,
+            contract_id,
+            admin,
+            token_id,
+        }
+    }
+
+    fn client(&self) -> PredictifyHybridClient<'_> {
+        PredictifyHybridClient::new(&self.env, &self.contract_id)
+    }
+
+    fn create_user(&self) -> Address {
+        let user = Address::generate(&self.env);
+        let stellar_client = soroban_sdk::token::StellarAssetClient::new(&self.env, &self.token_id);
+        self.env.mock_all_auths();
+        stellar_client.mint(&user, &10_000_000_000);
+        user
+    }
+
+    fn create_market(&self, has_fallback: bool, resolution_timeout: u64) -> Symbol {
+        let outcomes = vec![
+            &self.env,
+            String::from_str(&self.env, "yes"),
+            String::from_str(&self.env, "no"),
+        ];
+        let primary = OracleConfig::new(
+            OracleProvider::reflector(),
+            Address::generate(&self.env),
+            String::from_str(&self.env, "BTC/USD"),
+            50_000_00,
+            String::from_str(&self.env, "gt"),
+        );
+        let fallback = has_fallback.then(|| {
+            OracleConfig::new(
+                OracleProvider::reflector(),
+                Address::generate(&self.env),
+                String::from_str(&self.env, "ETH/USD"),
+                50_000_00,
+                String::from_str(&self.env, "gt"),
+            )
+        });
+
+        self.env.mock_all_auths();
+        self.client().create_market(
+            &self.admin,
+            &String::from_str(&self.env, "Will BTC close above $50k?"),
+            &outcomes,
+            &1u32,
+            &primary,
+            &fallback,
+            &resolution_timeout,
+        )
+    }
+
+    fn get_market(&self, market_id: &Symbol) -> Market {
+        self.client().get_market(market_id).unwrap()
+    }
+
+    fn advance_to(&self, timestamp: u64) {
+        self.env.ledger().with_mut(|li| {
+            li.timestamp = timestamp;
+        });
+    }
+}
+
+fn find_published_event<T>(env: &Env, topic: Symbol) -> Option<T>
+where
+    T: Clone + TryFromVal<Env, soroban_sdk::xdr::ScVal>,
+{
+    let events = env.events().all();
+    events.events().iter().rev().find_map(|event| {
+        let body = match &event.body {
+            soroban_sdk::xdr::ContractEventBody::V0(v0) => v0,
+        };
+        let first_topic_scval = body.topics.get(0)?;
+        let first_topic: Symbol = first_topic_scval.clone().try_into_val(env).ok()?;
+        if first_topic != topic {
+            return None;
+        }
+        T::try_from_val(env, &body.data).ok()
+    })
 }
 
 #[test]
-fn test_oracle_basic_2() {
-    assert_eq!(1, 1);
+fn fetch_oracle_result_without_fallback_reports_primary_only_failure() {
+    let setup = TestSetup::new();
+    let market_id = setup.create_market(false, 3_600);
+    let market = setup.get_market(&market_id);
+
+    setup.advance_to(market.end_time + 1);
+
+    let result = setup.env.as_contract(&setup.contract_id, || {
+        PredictifyHybrid::fetch_oracle_result(
+            setup.env.clone(),
+            market_id.clone(),
+            market.oracle_config.oracle_address.clone(),
+        )
+    });
+    assert_eq!(result, Err(Error::OracleUnavailable));
+
+    let manual =
+        find_published_event::<ManualResolutionRequiredEvent>(&setup.env, symbol_short!("man_res"))
+            .expect("manual resolution event should be published");
+    assert_eq!(manual.market_id, market_id);
+    assert_eq!(
+        manual.reason,
+        String::from_str(&setup.env, "oracle_resolution_failed_primary_only")
+    );
 }
 
 #[test]
-fn test_oracle_basic_3() {
-    assert_ne!(1, 2);
+fn fetch_oracle_result_with_fallback_reports_primary_then_fallback_failure() {
+    let setup = TestSetup::new();
+    let market_id = setup.create_market(true, 3_600);
+    let market = setup.get_market(&market_id);
+
+    setup.advance_to(market.end_time + 1);
+
+    let result = setup.env.as_contract(&setup.contract_id, || {
+        PredictifyHybrid::fetch_oracle_result(
+            setup.env.clone(),
+            market_id.clone(),
+            market.oracle_config.oracle_address.clone(),
+        )
+    });
+    assert_eq!(result, Err(Error::FallbackOracleUnavailable));
+
+    let manual =
+        find_published_event::<ManualResolutionRequiredEvent>(&setup.env, symbol_short!("man_res"))
+            .expect("manual resolution event should be published");
+    assert_eq!(manual.market_id, market_id);
+    assert_eq!(
+        manual.reason,
+        String::from_str(&setup.env, "oracle_resolution_failed_primary_then_fallback",)
+    );
+
+    assert!(
+        find_published_event::<FallbackUsedEvent>(&setup.env, symbol_short!("fbk_used")).is_none(),
+        "fallback-used event should only be emitted after a successful fallback result"
+    );
 }
 
 #[test]
-fn test_oracle_basic_4() {
-    let x = 42;
-    assert_eq!(x, 42);
+fn fetch_oracle_result_stops_at_market_resolution_deadline() {
+    let setup = TestSetup::new();
+    let market_id = setup.create_market(true, 3_600);
+    let market = setup.get_market(&market_id);
+    let deadline = market.end_time + market.resolution_timeout;
+
+    setup.advance_to(deadline);
+
+    let result = setup.env.as_contract(&setup.contract_id, || {
+        PredictifyHybrid::fetch_oracle_result(
+            setup.env.clone(),
+            market_id.clone(),
+            market.oracle_config.oracle_address.clone(),
+        )
+    });
+    assert_eq!(result, Err(Error::ResolutionTimeoutReached));
+
+    let timeout_event =
+        find_published_event::<ResolutionTimeoutEvent>(&setup.env, symbol_short!("res_tmo"))
+            .expect("resolution-timeout event should be published");
+    assert_eq!(timeout_event.market_id, market_id);
+    assert_eq!(timeout_event.timeout_timestamp, deadline);
 }
 
 #[test]
-fn test_oracle_basic_5() {
-    let s = "test";
-    assert_eq!(s, "test");
-}
+fn refund_on_oracle_failure_uses_market_specific_timeout_for_non_admins() {
+    let setup = TestSetup::new();
+    let resolution_timeout = 3_600u64;
+    let market_id = setup.create_market(false, resolution_timeout);
+    let user = setup.create_user();
+    let caller = setup.create_user();
 
-#[test]
-fn test_oracle_basic_6() {
-    let v = vec![1, 2, 3];
-    assert_eq!(v.len(), 3);
-}
+    setup.env.mock_all_auths();
+    setup.client().place_bet(
+        &user,
+        &market_id,
+        &String::from_str(&setup.env, "yes"),
+        &10_000_000i128,
+    );
 
-#[test]
-fn test_oracle_basic_7() {
-    let result = 2 + 2;
-    assert_eq!(result, 4);
-}
+    let market = setup.get_market(&market_id);
+    setup.advance_to(market.end_time + resolution_timeout - 1);
 
-#[test]
-fn test_oracle_basic_8() {
-    let flag = true;
-    assert!(flag);
-}
+    let early = setup.env.as_contract(&setup.contract_id, || {
+        PredictifyHybrid::refund_on_oracle_failure(
+            setup.env.clone(),
+            caller.clone(),
+            market_id.clone(),
+        )
+    });
+    assert_eq!(early, Err(Error::Unauthorized));
 
-#[test]
-fn test_oracle_basic_9() {
-    let option = Some(42);
-    assert!(option.is_some());
-}
+    let deadline = market.end_time + resolution_timeout;
+    setup.advance_to(deadline);
+    setup.env.mock_all_auths();
+    let refunded = setup.env.as_contract(&setup.contract_id, || {
+        PredictifyHybrid::refund_on_oracle_failure(
+            setup.env.clone(),
+            caller.clone(),
+            market_id.clone(),
+        )
+    });
+    assert_eq!(refunded, Ok(10_000_000i128));
 
-#[test]
-fn test_oracle_basic_10() {
-    let result: Result<i32, &str> = Ok(42);
-    assert!(result.is_ok());
-}
+    let cancelled_market = setup.get_market(&market_id);
+    assert_eq!(cancelled_market.state, MarketState::Cancelled);
 
-#[test]
-fn test_oracle_basic_11() {
-    let tuple = (1, 2);
-    assert_eq!(tuple.0, 1);
-}
-
-#[test]
-fn test_oracle_basic_12() {
-    let array = [1, 2, 3];
-    assert_eq!(array[0], 1);
-}
-
-#[test]
-fn test_oracle_basic_13() {
-    let string = String::from("test");
-    assert_eq!(string, "test");
-}
-
-#[test]
-fn test_oracle_basic_14() {
-    let number = 100i128;
-    assert_eq!(number, 100);
-}
-
-#[test]
-fn test_oracle_basic_15() {
-    let boolean = false;
-    assert!(!boolean);
-}
-
-#[test]
-fn test_oracle_basic_16() {
-    let mut counter = 0;
-    counter += 1;
-    assert_eq!(counter, 1);
-}
-
-#[test]
-fn test_oracle_basic_17() {
-    let slice = &[1, 2, 3][..];
-    assert_eq!(slice.len(), 3);
-}
-
-#[test]
-fn test_oracle_basic_18() {
-    let reference = &42;
-    assert_eq!(*reference, 42);
-}
-
-#[test]
-fn test_oracle_basic_19() {
-    let closure = || 42;
-    assert_eq!(closure(), 42);
-}
-
-#[test]
-fn test_oracle_basic_20() {
-    let range = 0..3;
-    assert_eq!(range.len(), 3);
-}
-
-#[test]
-fn test_oracle_basic_21() {
-    let option = None::<i32>;
-    assert!(option.is_none());
-}
-
-#[test]
-fn test_oracle_basic_22() {
-    let result: Result<i32, &str> = Err("error");
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_oracle_basic_23() {
-    let bytes = b"hello";
-    assert_eq!(bytes.len(), 5);
-}
-
-#[test]
-fn test_oracle_basic_24() {
-    let character = 'a';
-    assert_eq!(character, 'a');
-}
-
-#[test]
-fn test_oracle_basic_25() {
-    let float = 3.14f64;
-    assert!(float > 3.0);
-}
-
-#[test]
-fn test_oracle_basic_26() {
-    let hex = 0xFF;
-    assert_eq!(hex, 255);
-}
-
-#[test]
-fn test_oracle_basic_27() {
-    let binary = 0b1010;
-    assert_eq!(binary, 10);
+    let refund_event: RefundOnOracleFailureEvent =
+        setup.env.as_contract(&setup.contract_id, || {
+            setup
+                .env
+                .storage()
+                .persistent()
+                .get(&symbol_short!("ref_oracl"))
+                .expect("refund event should be stored")
+        });
+    assert_eq!(refund_event.market_id, market_id);
+    assert_eq!(refund_event.total_refunded, 10_000_000i128);
 }

--- a/contracts/predictify-hybrid/src/resolution.rs
+++ b/contracts/predictify-hybrid/src/resolution.rs
@@ -970,36 +970,20 @@ impl OracleResolutionManager {
         Ok((price_data.price, outcome))
     }
 
-    /// Fetch oracle result for a market with fallback support and timeout
+    /// Fetch oracle result for a market with deterministic fallback ordering and timeout handling.
+    ///
+    /// The resolver attempts the primary oracle once. When `has_fallback` is `true`, it attempts the
+    /// fallback oracle once only after that primary failure. No oracle calls are made once
+    /// `ledger.timestamp() >= end_time + resolution_timeout`.
     pub fn fetch_oracle_result(env: &Env, market_id: &Symbol) -> Result<OracleResolution, Error> {
         // Get the market from storage
         let mut market = MarketStateManager::get_market(env, market_id)?;
 
         // 1. Check if resolution timeout has been reached
         let current_time = env.ledger().timestamp();
-        if current_time > market.end_time + market.resolution_timeout {
-            // Reached timeout without resolution, mark for refund
-            let old_state = market.state.clone();
-            market.state = crate::types::MarketState::Cancelled;
-            MarketStateManager::update_market(env, market_id, &market);
-
+        if current_time >= market.end_time.saturating_add(market.resolution_timeout) {
             crate::events::EventEmitter::emit_resolution_timeout(env, market_id, current_time);
-            crate::events::EventEmitter::emit_state_change_event(
-                env,
-                market_id,
-                &old_state,
-                &crate::types::MarketState::Cancelled,
-                &soroban_sdk::String::from_str(env, "Resolution timeout reached, market cancelled"),
-            );
-            crate::monitoring::ContractMonitor::emit_resolution_transition_hook(
-                env,
-                market_id,
-                &old_state,
-                &crate::types::MarketState::Cancelled,
-                &soroban_sdk::String::from_str(env, "timeout_cancelled"),
-            );
-
-            return Err(Error::InvalidState);
+            return Err(Error::ResolutionTimeoutReached);
         }
 
         // Validate market for oracle resolution
@@ -1026,9 +1010,27 @@ impl OracleResolutionManager {
                             used_config = fallback_config.clone();
                             res
                         }
-                        Err(_) => return Err(Error::OracleUnavailable),
+                        Err(_) => {
+                            crate::events::EventEmitter::emit_manual_resolution_required(
+                                env,
+                                market_id,
+                                &soroban_sdk::String::from_str(
+                                    env,
+                                    "oracle_resolution_failed_primary_then_fallback",
+                                ),
+                            );
+                            return Err(Error::FallbackOracleUnavailable);
+                        }
                     }
                 } else {
+                    crate::events::EventEmitter::emit_manual_resolution_required(
+                        env,
+                        market_id,
+                        &soroban_sdk::String::from_str(
+                            env,
+                            "oracle_resolution_failed_primary_only",
+                        ),
+                    );
                     return Err(Error::OracleUnavailable);
                 }
             }

--- a/contracts/predictify-hybrid/src/types.rs
+++ b/contracts/predictify-hybrid/src/types.rs
@@ -1004,14 +1004,20 @@ pub struct Market {
     pub end_time: u64,
     /// Oracle configuration for this market (primary)
     pub oracle_config: OracleConfig,
-    /// Whether a fallback oracle is configured (avoids Option in contract type for SDK compatibility)
+    /// Whether a fallback oracle is configured.
+    ///
+    /// When `true`, automatic resolution attempts the primary oracle once and then this market's
+    /// fallback oracle once if the primary attempt fails.
     pub has_fallback: bool,
     /// Fallback oracle configuration.
     ///
     /// When `has_fallback` is `false`, this field is populated with `OracleConfig::none_sentinel()`
     /// so the stored representation stays collision-free without using `Option<OracleConfig>`.
+    /// When `has_fallback` is `true`, this config is consulted only after one failed primary attempt.
     pub fallback_oracle_config: OracleConfig,
-    /// Resolution timeout in seconds after end_time
+    /// Resolution timeout in seconds after `end_time`.
+    ///
+    /// Automatic oracle resolution stops once `ledger.timestamp() >= end_time + resolution_timeout`.
     pub resolution_timeout: u64,
     /// Oracle result (set after market ends)
     pub oracle_result: Option<String>,
@@ -3739,14 +3745,20 @@ pub struct Event {
     pub end_time: u64,
     /// Oracle configuration for result verification (primary)
     pub oracle_config: OracleConfig,
-    /// Whether a fallback oracle is configured
+    /// Whether a fallback oracle is configured.
+    ///
+    /// When `true`, automatic resolution attempts the primary oracle once and then this event's
+    /// fallback oracle once if the primary attempt fails.
     pub has_fallback: bool,
     /// Fallback oracle configuration.
     ///
     /// When `has_fallback` is `false`, this field is populated with `OracleConfig::none_sentinel()`
     /// so the stored representation stays collision-free without using `Option<OracleConfig>`.
+    /// When `has_fallback` is `true`, this config is consulted only after one failed primary attempt.
     pub fallback_oracle_config: OracleConfig,
-    /// Resolution timeout in seconds after end_time
+    /// Resolution timeout in seconds after `end_time`.
+    ///
+    /// Automatic oracle resolution stops once `ledger.timestamp() >= end_time + resolution_timeout`.
     pub resolution_timeout: u64,
     /// Administrative address that created/manages the event
     pub admin: Address,
@@ -3832,7 +3844,7 @@ impl ReflectorAsset {
             ReflectorAsset::Other(symbol) => String::from_str(
                 &env,
                 &alloc::format!("{}/USD", Self::custom_symbol_to_host_string(symbol)),
-            )
+            ),
         }
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Implementation-specific documentation for the Predictify Hybrid contract:
 - **[Types System](./contracts/TYPES_SYSTEM.md)** - Comprehensive type system and data structures
 - **[Voting System](./contracts/VOTING_SYSTEM.md)** - Voting mechanism and dispute resolution
 - **[Balance Management](./contracts/BALANCES.md)** - Security invariants and token safety semantics for deposits and withdrawals
+- **[Oracle Resolution](./contracts/ORACLE_RESOLUTION.md)** - Deterministic primary/fallback ordering, timeout rules, and failure semantics for hybrid market resolution
 
 
 ### 💰 [Claims Documentation](./claims/)

--- a/docs/contracts/ORACLE_RESOLUTION.md
+++ b/docs/contracts/ORACLE_RESOLUTION.md
@@ -1,0 +1,92 @@
+# Oracle Resolution
+
+This document defines the deterministic oracle-resolution policy for `predictify-hybrid` markets and events.
+
+## Scope
+
+The policy applies to:
+
+- `PredictifyHybrid::create_market`
+- `PredictifyHybrid::create_event`
+- `PredictifyHybrid::fetch_oracle_result`
+- `PredictifyHybrid::refund_on_oracle_failure`
+
+It also mirrors the intended behavior of the internal `contracts/predictify-hybrid/src/resolution.rs` flow.
+
+## Stored Configuration
+
+Each market and event stores:
+
+- `oracle_config`: the primary oracle configuration
+- `has_fallback`: whether a fallback oracle is enabled
+- `fallback_oracle_config`: the backup oracle configuration when enabled
+- `resolution_timeout`: the per-market/per-event deadline, in seconds, measured from `end_time`
+
+`has_fallback = false` means `fallback_oracle_config` is the reserved `OracleConfig::none_sentinel()` value and must never be used for live resolution.
+
+## Deterministic Attempt Order
+
+Automatic resolution uses a fixed order:
+
+1. Attempt the primary oracle once.
+2. If and only if `has_fallback` is `true`, attempt the fallback oracle once after the primary attempt fails.
+3. If both attempts fail, stop and require manual resolution.
+
+There is no dynamic reordering, no provider scoring, and no implicit retry loop in this path. Auditors and integrators can therefore reason about a single, stable resolution sequence.
+
+## Timeout Policy
+
+The automatic resolution deadline is:
+
+`resolution_deadline = end_time + resolution_timeout`
+
+Behavior is:
+
+- Before `end_time`, oracle resolution is rejected because the market is still open.
+- From `end_time` up to but not including `resolution_deadline`, automatic oracle resolution may be attempted.
+- At or after `resolution_deadline`, automatic oracle resolution stops immediately with `RESOLUTION_TIMEOUT_REACHED`.
+
+Timeout handling is deliberately fail-closed:
+
+- the contract does not continue trying alternate providers after the deadline
+- the contract does not silently extend deadlines
+- non-admin refund callers become authorized only once the same per-market timeout has elapsed
+
+## Error Mapping
+
+The active contract path uses the following deterministic outcomes:
+
+- Primary failure with no fallback configured: `ORACLE_UNAVAILABLE`
+- Primary failure followed by fallback failure: `FALLBACK_ORACLE_UNAVAILABLE`
+- Any automatic resolution attempt at or after the deadline: `RESOLUTION_TIMEOUT_REACHED`
+
+## Events and Auditability
+
+The contract emits events to make the resolution path observable:
+
+- `man_res`: manual resolution required after automatic attempts are exhausted
+- `fbk_used`: emitted only when a fallback oracle succeeds
+- `res_tmo`: emitted when the market/event reaches the automatic resolution deadline
+- `ref_oracl`: emitted when the refund path is used after oracle failure/timeout
+
+For failure cases, the manual-resolution reason string is stable:
+
+- `oracle_resolution_failed_primary_only`
+- `oracle_resolution_failed_primary_then_fallback`
+
+These reason codes are intended for off-chain monitors, audit tooling, and incident playbooks.
+
+## Security Notes
+
+Threat model and enforced invariants:
+
+- Fixed ordering prevents an attacker from influencing provider selection at runtime.
+- A per-market timeout prevents indefinite oracle polling and makes the refund path predictable.
+- The fallback sentinel stays outside the valid oracle-config domain, so `has_fallback = false` cannot collide with a live backup configuration.
+- Non-admin callers cannot force early cancellation before the stored market timeout expires.
+
+Explicit non-goals:
+
+- This policy does not define provider-specific trust assumptions.
+- This policy does not add weighted consensus across multiple oracle providers.
+- This policy does not auto-resolve subjective markets without an oracle result.


### PR DESCRIPTION
Closes: #395 

## Summary

This PR makes hybrid oracle resolution ordering and timeout behavior deterministic, documented, and regression-tested for `predictify-hybrid`.

### What changed

- enforce deterministic automatic oracle resolution order:
  - try the primary oracle once
  - if `has_fallback == true`, try the fallback oracle once only after primary failure
- stop automatic oracle resolution once `ledger.timestamp() >= end_time + resolution_timeout`
- return explicit failure outcomes for:
  - primary-only failure
  - primary-then-fallback failure
  - resolution timeout reached
- align `refund_on_oracle_failure` with the market-specific `resolution_timeout` instead of the global default timeout
- add/expand Rust doc comments on public contract API and related types
- add integrator-facing documentation for oracle resolution semantics

## Files changed

- `contracts/predictify-hybrid/src/lib.rs`
- `contracts/predictify-hybrid/src/resolution.rs`
- `contracts/predictify-hybrid/src/types.rs`
- `contracts/predictify-hybrid/src/oracle_fallback_timeout_tests.rs`
- `contracts/predictify-hybrid/src/event_management_tests.rs`
- `docs/contracts/ORACLE_RESOLUTION.md`
- `docs/README.md`

## Behavior clarified

### Automatic resolution ordering

1. primary oracle is attempted first
2. fallback oracle is attempted second only if configured and only after primary failure
3. no further automatic oracle attempts occur after the resolution deadline

### Timeout semantics

- the deadline is `end_time + resolution_timeout`
- once the current ledger timestamp reaches that deadline, automatic oracle resolution stops
- timeout emits a resolution-timeout event and returns `ResolutionTimeoutReached`

### Refund semantics

- non-admin callers can trigger `refund_on_oracle_failure` only after the market-specific resolution timeout has elapsed
- admin behavior is unchanged

## Tests

### Focused regression tests

- `cargo test -p predictify-hybrid oracle_fallback_timeout_tests -- --nocapture`

Covered cases:
- primary failure without fallback emits manual-resolution-required and returns `OracleUnavailable`
- primary failure with fallback failure emits manual-resolution-required and returns `FallbackOracleUnavailable`
- automatic oracle resolution stops exactly at the market deadline
- oracle failure refunds use the market-specific timeout for non-admin callers

### Full package tests

- `cargo test -p predictify-hybrid`

Result:
- `404 passed; 0 failed`

## Security notes

### Threat model

This change is intended to reduce ambiguity and inconsistent behavior around hybrid oracle resolution, especially where fallback oracles and deadlines are involved.

### Invariants

- primary oracle is always attempted before fallback
- fallback is attempted at most once and only after primary failure
- automatic resolution does not continue past `end_time + resolution_timeout`
- non-admin refund-on-oracle-failure cannot happen before the market-specific deadline

### Explicit non-goals

- this PR does not add a real successful oracle-fetch integration path to the active public `fetch_oracle_result` entrypoint
- this PR does not change frontend or backend behavior outside `predictify-contracts`
- this PR does not redesign oracle provider interfaces or market payout logic

## Notes for reviewers

- `ORACLE_RESOLUTION.md` is intended to be sufficient for integrators and auditors without requiring a deep read of all Rust internals
- test setup in `event_management_tests` now initializes the circuit breaker so the suite reflects current contract preconditions
