### PR TITLE
feat(contract): harden oracle timeout and dispute timing

### DIFF
--- a/contracts/predictify-hybrid/src/disputes.rs
+++ b/contracts/predictify-hybrid/src/disputes.rs
@@ -1913,20 +1913,38 @@ impl DisputeManager {
 pub struct DisputeValidator;
 
 impl DisputeValidator {
-    /// Validate market state for dispute
+    /// Validate market state for dispute.
+    ///
+    /// A dispute is only valid when:
+    /// 1. The market has ended (`current_time >= end_time`).
+    /// 2. The dispute window is still open (`current_time < end_time + dispute_window_seconds`).
+    ///    Allowing disputes after the window closes would create an ambiguous overlap with
+    ///    the payout phase and could re-open markets that users already consider settled.
+    /// 3. The market has not already been resolved.
+    /// 4. An oracle result is available to dispute.
     pub fn validate_market_for_dispute(env: &Env, market: &Market) -> Result<(), Error> {
-        // Check if market has ended
         let current_time = env.ledger().timestamp();
+
+        // Market must have ended before a dispute can be filed.
         if current_time < market.end_time {
             return Err(Error::MarketClosed);
         }
 
-        // Check if market is already resolved
+        // Disputes must be filed within the dispute window.
+        // After `end_time + dispute_window_seconds` the window is closed and payouts
+        // are unambiguously allowed, so late disputes are rejected.
+        if market.dispute_window_seconds > 0
+            && current_time >= market.end_time + market.dispute_window_seconds
+        {
+            return Err(Error::MarketResolved);
+        }
+
+        // Check if market is already resolved.
         if market.winning_outcomes.is_some() {
             return Err(Error::MarketResolved);
         }
 
-        // Check if oracle result is available
+        // Check if oracle result is available to dispute.
         if market.oracle_result.is_none() {
             return Err(Error::OracleUnavailable);
         }

--- a/contracts/predictify-hybrid/src/oracle_fallback_timeout_tests.rs
+++ b/contracts/predictify-hybrid/src/oracle_fallback_timeout_tests.rs
@@ -1,169 +1,285 @@
 #![cfg(test)]
 
-extern crate alloc;
-use alloc::string::String;
-use alloc::vec;
+//! Tests for oracle resolution timeout and its interaction with the dispute window.
+//!
+//! # Invariants under test
+//!
+//! 1. When `resolution_timeout` expires with **no active dispute**, the market is
+//!    cancelled so stakes can be refunded.
+//! 2. When `resolution_timeout` expires but a **dispute is active**, the market must
+//!    NOT be cancelled — `ResolutionTimeoutReached` is returned instead, leaving the
+//!    dispute process as the authoritative resolution path.
+//! 3. The dispute window (`dispute_window_seconds`) is enforced: disputes filed after
+//!    `end_time + dispute_window_seconds` are rejected.
+//! 4. A dispute filed within the window extends `end_time`, which in turn pushes the
+//!    effective resolution deadline forward.
 
-// Oracle Fallback and Resolution Timeout Tests
+use crate::config::ConfigManager;
+use crate::errors::Error;
+use crate::markets::MarketStateManager;
+use crate::resolution::OracleResolutionManager;
+use crate::types::{Market, MarketState, OracleConfig, OracleProvider};
+use crate::PredictifyHybrid;
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
 
-// ===== BASIC ORACLE TESTS =====
+// ===== TEST HELPERS =====
 
-#[test]
-fn test_oracle_basic_1() {
-    assert!(true);
+struct Setup {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
 }
 
-#[test]
-fn test_oracle_basic_2() {
-    assert_eq!(1, 1);
+impl Setup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, PredictifyHybrid);
+        env.as_contract(&contract_id, || {
+            let config = ConfigManager::get_development_config(&env);
+            ConfigManager::store_config(&env, &config).unwrap();
+        });
+        Self { env, contract_id, admin }
+    }
+
+    fn market(&self, end_time: u64, resolution_timeout: u64, dispute_window_seconds: u64) -> (Symbol, Market) {
+        let id = Symbol::new(&self.env, "mkt");
+        let mut outcomes = Vec::new(&self.env);
+        outcomes.push_back(String::from_str(&self.env, "yes"));
+        outcomes.push_back(String::from_str(&self.env, "no"));
+        let oracle = OracleConfig::new(
+            OracleProvider::reflector(),
+            Address::from_str(
+                &self.env,
+                "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            ),
+            String::from_str(&self.env, "BTC/USD"),
+            50_000_00,
+            String::from_str(&self.env, "gt"),
+        );
+        let mut m = Market::new(
+            &self.env,
+            self.admin.clone(),
+            String::from_str(&self.env, "Will BTC reach $50k?"),
+            outcomes,
+            end_time,
+            oracle,
+            None,
+            resolution_timeout,
+            MarketState::Active,
+        );
+        m.dispute_window_seconds = dispute_window_seconds;
+        (id, m)
+    }
+
+    fn tick(&self, secs: u64) {
+        let t = self.env.ledger().timestamp();
+        self.env.ledger().set(LedgerInfo {
+            timestamp: t + secs,
+            protocol_version: 22,
+            sequence_number: self.env.ledger().sequence() + 1,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 16,
+            min_persistent_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
 }
 
+// ===== ORACLE TIMEOUT — NO DISPUTE =====
+
+/// When the resolution timeout fires and there is no active dispute the market
+/// must be cancelled so participants can reclaim their stakes.
 #[test]
-fn test_oracle_basic_3() {
-    assert_ne!(1, 2);
+fn test_resolution_timeout_cancels_market_without_dispute() {
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let (id, mut market) = s.market(end_time, 86_400, 86_400);
+        market.state = MarketState::Active;
+        s.env.storage().persistent().set(&id, &market);
+
+        // Jump past end_time + resolution_timeout
+        s.tick(3_600 + 86_400 + 1);
+
+        let result = OracleResolutionManager::fetch_oracle_result(&s.env, &id);
+        // Expect InvalidState (market was cancelled)
+        assert_eq!(result, Err(Error::InvalidState));
+
+        let stored: Market = s.env.storage().persistent().get(&id).unwrap();
+        assert_eq!(stored.state, MarketState::Cancelled);
+    });
 }
 
+// ===== ORACLE TIMEOUT — ACTIVE DISPUTE (deadlock prevention) =====
+
+/// When the resolution timeout fires but a dispute is active, the market must
+/// NOT be cancelled.  Cancelling would permanently lock dispute stakes.
+/// The function must return `ResolutionTimeoutReached` instead.
 #[test]
-fn test_oracle_basic_4() {
-    let x = 42;
-    assert_eq!(x, 42);
+fn test_resolution_timeout_does_not_cancel_disputed_market() {
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let (id, mut market) = s.market(end_time, 86_400, 86_400);
+
+        // Simulate oracle result already set and a dispute filed
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        s.env.storage().persistent().set(&id, &market);
+
+        // File a dispute (transitions state to Disputed)
+        let disputer = Address::generate(&s.env);
+        MarketStateManager::add_dispute_stake(&mut market, disputer, 10_000_000, Some(&id));
+        assert_eq!(market.state, MarketState::Disputed);
+        s.env.storage().persistent().set(&id, &market);
+
+        // Jump past resolution_timeout
+        s.tick(3_600 + 86_400 + 1);
+
+        let result = OracleResolutionManager::fetch_oracle_result(&s.env, &id);
+        assert_eq!(result, Err(Error::ResolutionTimeoutReached));
+
+        // Market must still be Disputed — not Cancelled
+        let stored: Market = s.env.storage().persistent().get(&id).unwrap();
+        assert_eq!(stored.state, MarketState::Disputed);
+    });
 }
 
+/// Same as above but using `total_dispute_stakes > 0` as the signal (state not yet
+/// transitioned to Disputed but stakes are present).
 #[test]
-fn test_oracle_basic_5() {
-    let s = "test";
-    assert_eq!(s, "test");
+fn test_resolution_timeout_does_not_cancel_when_dispute_stakes_present() {
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let (id, mut market) = s.market(end_time, 86_400, 86_400);
+
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        // Manually inject dispute stake without state transition
+        let disputer = Address::generate(&s.env);
+        market.dispute_stakes.set(disputer, 5_000_000);
+        s.env.storage().persistent().set(&id, &market);
+
+        s.tick(3_600 + 86_400 + 1);
+
+        let result = OracleResolutionManager::fetch_oracle_result(&s.env, &id);
+        assert_eq!(result, Err(Error::ResolutionTimeoutReached));
+
+        let stored: Market = s.env.storage().persistent().get(&id).unwrap();
+        // State must not have been changed to Cancelled
+        assert_ne!(stored.state, MarketState::Cancelled);
+    });
 }
 
+// ===== DISPUTE WINDOW ENFORCEMENT =====
+
+/// Disputes filed after `end_time + dispute_window_seconds` must be rejected.
+/// Without this check a late dispute could re-open a market that users consider settled.
 #[test]
-fn test_oracle_basic_6() {
-    let v = vec![1, 2, 3];
-    assert_eq!(v.len(), 3);
+fn test_dispute_rejected_after_window_closes() {
+    use crate::disputes::DisputeValidator;
+
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        // dispute_window_seconds = 7_200 (2 hours)
+        let (id, mut market) = s.market(end_time, 86_400, 7_200);
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        s.env.storage().persistent().set(&id, &market);
+
+        // Jump past end_time + dispute_window_seconds
+        s.tick(3_600 + 7_200 + 1);
+
+        let result = DisputeValidator::validate_market_for_dispute(&s.env, &market);
+        assert_eq!(result, Err(Error::MarketResolved));
+    });
 }
 
+/// Disputes filed within the window must be accepted.
 #[test]
-fn test_oracle_basic_7() {
-    let result = 2 + 2;
-    assert_eq!(result, 4);
+fn test_dispute_accepted_within_window() {
+    use crate::disputes::DisputeValidator;
+
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let (id, mut market) = s.market(end_time, 86_400, 7_200);
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        s.env.storage().persistent().set(&id, &market);
+
+        // Jump past end_time but still inside the dispute window
+        s.tick(3_600 + 3_600); // end_time + 1 hour (window is 2 hours)
+
+        let result = DisputeValidator::validate_market_for_dispute(&s.env, &market);
+        assert!(result.is_ok());
+    });
 }
 
+/// A market with `dispute_window_seconds == 0` (no window configured) should
+/// not reject disputes based on the window check.
 #[test]
-fn test_oracle_basic_8() {
-    let flag = true;
-    assert!(flag);
+fn test_dispute_window_zero_means_no_window_restriction() {
+    use crate::disputes::DisputeValidator;
+
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let (id, mut market) = s.market(end_time, 86_400, 0); // 0 = no window
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        s.env.storage().persistent().set(&id, &market);
+
+        // Jump far past end_time
+        s.tick(3_600 + 999_999);
+
+        let result = DisputeValidator::validate_market_for_dispute(&s.env, &market);
+        // Should not fail on window check (may fail on other checks, but not window)
+        assert_ne!(result, Err(Error::MarketResolved));
+    });
 }
 
-#[test]
-fn test_oracle_basic_9() {
-    let option = Some(42);
-    assert!(option.is_some());
-}
+// ===== DISPUTE EXTENDS RESOLUTION DEADLINE =====
 
+/// Filing a dispute extends `market.end_time`.  The new end_time must be later
+/// than `end_time + resolution_timeout` so the oracle timeout cannot fire while
+/// the dispute is still open.
 #[test]
-fn test_oracle_basic_10() {
-    let result: Result<i32, &str> = Ok(42);
-    assert!(result.is_ok());
-}
+fn test_dispute_extension_pushes_past_resolution_timeout() {
+    let s = Setup::new();
+    s.env.as_contract(&s.contract_id, || {
+        let end_time = s.env.ledger().timestamp() + 3_600;
+        let resolution_timeout = 7_200_u64; // 2 hours
+        let (id, mut market) = s.market(end_time, resolution_timeout, 86_400);
+        market.oracle_result = Some(String::from_str(&s.env, "yes"));
+        market.state = MarketState::Ended;
+        s.env.storage().persistent().set(&id, &market);
 
-#[test]
-fn test_oracle_basic_11() {
-    let tuple = (1, 2);
-    assert_eq!(tuple.0, 1);
-}
+        // Advance to just before resolution_timeout fires
+        s.tick(3_600 + 7_100);
 
-#[test]
-fn test_oracle_basic_12() {
-    let array = [1, 2, 3];
-    assert_eq!(array[0], 1);
-}
+        // File dispute — this should extend end_time by 24 hours
+        let disputer = Address::generate(&s.env);
+        MarketStateManager::add_dispute_stake(&mut market, disputer, 10_000_000, Some(&id));
+        let cfg = ConfigManager::get_config(&s.env).unwrap();
+        MarketStateManager::extend_for_dispute(
+            &mut market,
+            &s.env,
+            cfg.voting.dispute_extension_hours.into(),
+        );
+        s.env.storage().persistent().set(&id, &market);
 
-#[test]
-fn test_oracle_basic_13() {
-    let string = String::from("test");
-    assert_eq!(string, "test");
-}
-
-#[test]
-fn test_oracle_basic_14() {
-    let number = 100i128;
-    assert_eq!(number, 100);
-}
-
-#[test]
-fn test_oracle_basic_15() {
-    let boolean = false;
-    assert!(!boolean);
-}
-
-#[test]
-fn test_oracle_basic_16() {
-    let mut counter = 0;
-    counter += 1;
-    assert_eq!(counter, 1);
-}
-
-#[test]
-fn test_oracle_basic_17() {
-    let slice = &[1, 2, 3][..];
-    assert_eq!(slice.len(), 3);
-}
-
-#[test]
-fn test_oracle_basic_18() {
-    let reference = &42;
-    assert_eq!(*reference, 42);
-}
-
-#[test]
-fn test_oracle_basic_19() {
-    let closure = || 42;
-    assert_eq!(closure(), 42);
-}
-
-#[test]
-fn test_oracle_basic_20() {
-    let range = 0..3;
-    assert_eq!(range.len(), 3);
-}
-
-#[test]
-fn test_oracle_basic_21() {
-    let option = None::<i32>;
-    assert!(option.is_none());
-}
-
-#[test]
-fn test_oracle_basic_22() {
-    let result: Result<i32, &str> = Err("error");
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_oracle_basic_23() {
-    let bytes = b"hello";
-    assert_eq!(bytes.len(), 5);
-}
-
-#[test]
-fn test_oracle_basic_24() {
-    let character = 'a';
-    assert_eq!(character, 'a');
-}
-
-#[test]
-fn test_oracle_basic_25() {
-    let float = 3.14f64;
-    assert!(float > 3.0);
-}
-
-#[test]
-fn test_oracle_basic_26() {
-    let hex = 0xFF;
-    assert_eq!(hex, 255);
-}
-
-#[test]
-fn test_oracle_basic_27() {
-    let binary = 0b1010;
-    assert_eq!(binary, 10);
+        let stored: Market = s.env.storage().persistent().get(&id).unwrap();
+        let current_time = s.env.ledger().timestamp();
+        // After extension, end_time must be in the future
+        assert!(stored.end_time > current_time);
+        // And the dispute state must be set
+        assert_eq!(stored.state, MarketState::Disputed);
+    });
 }

--- a/contracts/predictify-hybrid/src/resolution.rs
+++ b/contracts/predictify-hybrid/src/resolution.rs
@@ -975,10 +975,23 @@ impl OracleResolutionManager {
         // Get the market from storage
         let mut market = MarketStateManager::get_market(env, market_id)?;
 
-        // 1. Check if resolution timeout has been reached
+        // 1. Check if resolution timeout has been reached.
+        //
+        // Safety invariant: a market with an active dispute must NOT be cancelled by the
+        // oracle resolution timeout.  Cancelling while a dispute is open would permanently
+        // lock the dispute stakes and leave the market in an unresolvable state (deadlock).
+        // Instead we surface `ResolutionTimeoutReached` so the caller knows the oracle path
+        // is closed while the dispute process remains the authoritative resolution path.
         let current_time = env.ledger().timestamp();
         if current_time > market.end_time + market.resolution_timeout {
-            // Reached timeout without resolution, mark for refund
+            // If a dispute is active, refuse to cancel — the dispute window owns resolution.
+            if market.state == crate::types::MarketState::Disputed
+                || market.total_dispute_stakes() > 0
+            {
+                return Err(Error::ResolutionTimeoutReached);
+            }
+
+            // No active dispute: cancel the market so stakes can be refunded.
             let old_state = market.state.clone();
             market.state = crate::types::MarketState::Cancelled;
             MarketStateManager::update_market(env, market_id, &market);

--- a/docs/security/ATTACK-VECTORS.md
+++ b/docs/security/ATTACK-VECTORS.md
@@ -677,3 +677,47 @@ pub struct AuditEvent {
 ---
 
 This document serves as the authoritative reference for Predictify Hybrid security architecture and should be updated whenever new threats are identified or mitigations are implemented.
+
+---
+
+## ⏱ Oracle Timeout vs Dispute Window Interaction
+
+### Threat: Resolution Timeout Deadlocking a Disputed Market
+
+**Description**: If `fetch_oracle_result` is called after `end_time + resolution_timeout` and a dispute is active, the naive implementation would cancel the market. This permanently locks dispute stakes and leaves the market unresolvable — a deadlock.
+
+**Invariant**: `resolution_timeout` must never cancel a market that has an active dispute (`state == Disputed` or `total_dispute_stakes() > 0`). When a dispute is active, the dispute process is the authoritative resolution path.
+
+**Mitigation** (`resolution.rs` — `OracleResolutionManager::fetch_oracle_result`):
+```rust
+if current_time > market.end_time + market.resolution_timeout {
+    if market.state == MarketState::Disputed || market.total_dispute_stakes() > 0 {
+        return Err(Error::ResolutionTimeoutReached); // dispute owns resolution
+    }
+    // No dispute: safe to cancel for refunds
+    market.state = MarketState::Cancelled;
+    ...
+}
+```
+
+### Threat: Late Dispute Reopening a Settled Market
+
+**Description**: Without enforcing `dispute_window_seconds`, a dispute could be filed long after the market ended, re-opening a market that participants already consider settled and payouts already expected.
+
+**Invariant**: Disputes must be filed within `[end_time, end_time + dispute_window_seconds)`. After the window closes, payouts are unambiguously allowed.
+
+**Mitigation** (`disputes.rs` — `DisputeValidator::validate_market_for_dispute`):
+```rust
+if market.dispute_window_seconds > 0
+    && current_time >= market.end_time + market.dispute_window_seconds
+{
+    return Err(Error::MarketResolved);
+}
+```
+
+**Note**: `dispute_window_seconds == 0` disables the window check (no restriction), preserving backward compatibility for markets created before this field was introduced.
+
+### Non-Goals
+
+- This does not prevent an oracle from returning stale data within the timeout window; that is handled separately by `OracleStale` / `OracleConfidenceTooWide`.
+- Admin override (`finalize_market`) bypasses both checks by design — it is an emergency escape hatch requiring explicit admin authentication.


### PR DESCRIPTION
- resolution.rs: fetch_oracle_result no longer cancels a market when resolution_timeout fires if a dispute is active (state == Disputed or total_dispute_stakes() > 0).  Cancelling a disputed market would permanently lock dispute stakes with no recovery path (deadlock). Returns ResolutionTimeoutReached instead so the dispute process remains the authoritative resolution path.

- disputes.rs: DisputeValidator::validate_market_for_dispute now enforces dispute_window_seconds.  Disputes filed after end_time + dispute_window_seconds are rejected with MarketResolved, closing the ambiguous overlap where a late dispute could re-open a market that participants already consider settled. dispute_window_seconds == 0 skips the check (backward compatible).

- oracle_fallback_timeout_tests.rs: replaced 27 assert!(true) placeholders with 7 real tests covering both invariants and their edge cases (no-dispute cancel, disputed-market no-cancel, stake-only no-cancel, window rejection, window acceptance, zero-window bypass, dispute extension pushes past resolution deadline).

- docs/security/ATTACK-VECTORS.md: added section documenting both threat vectors, invariants, mitigations with code snippets, and explicit non-goals.

# Pull Request Description



closes #396 