### PR TITLE
feat(contract): audit admin authorization paths

### DIFF
--- a/contracts/predictify-hybrid/src/admin.rs
+++ b/contracts/predictify-hybrid/src/admin.rs
@@ -616,15 +616,7 @@ impl ContractPauseManager {
 
     /// Pause contract operations. Caller must be the current primary admin.
     pub fn pause(env: &Env, admin: &Address) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(env, "Admin"))
-            .ok_or(Error::AdminNotSet)?;
-        if admin != &stored {
-            return Err(Error::Unauthorized);
-        }
+        AdminAccessControl::require_admin_auth(env, admin)?;
         env.storage()
             .persistent()
             .set(&Symbol::new(env, CONTRACT_PAUSED_KEY), &true);
@@ -640,15 +632,7 @@ impl ContractPauseManager {
 
     /// Unpause contract operations. Caller must be the current primary admin.
     pub fn unpause(env: &Env, admin: &Address) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(env, "Admin"))
-            .ok_or(Error::AdminNotSet)?;
-        if admin != &stored {
-            return Err(Error::Unauthorized);
-        }
+        AdminAccessControl::require_admin_auth(env, admin)?;
         env.storage()
             .persistent()
             .set(&Symbol::new(env, CONTRACT_PAUSED_KEY), &false);
@@ -677,15 +661,7 @@ impl ContractPauseManager {
         current_admin: &Address,
         new_admin: &Address,
     ) -> Result<(), Error> {
-        current_admin.require_auth();
-        let stored: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(env, "Admin"))
-            .ok_or(Error::AdminNotSet)?;
-        if current_admin != &stored {
-            return Err(Error::Unauthorized);
-        }
+        AdminAccessControl::require_admin_auth(env, current_admin)?;
         if new_admin == current_admin {
             return Err(Error::InvalidInput);
         }
@@ -1566,11 +1542,9 @@ impl AdminManager {
 
     // ===== Helper Methods =====
 
-    /// Generate a proper admin storage key using the correct environment
-    fn get_admin_key(env: &Env, admin: &Address) -> Symbol {
-        // Create a unique key based on admin address
-        let key_str = alloc::format!("MultiAdmin_{:?}", admin.to_string());
-        Symbol::new(env, &key_str)
+    /// Generate a deterministic multi-admin storage key for an address.
+    fn get_admin_key(env: &Env, admin: &Address) -> String {
+        String::from_str(env, &alloc::format!("MultiAdmin_{:?}", admin.to_string()))
     }
 
     /// Check if an address is the original admin from single-admin system

--- a/contracts/predictify-hybrid/src/admin_auth_audit_tests.rs
+++ b/contracts/predictify-hybrid/src/admin_auth_audit_tests.rs
@@ -1,0 +1,126 @@
+use crate::admin::{AdminManager, AdminPermission, AdminRole, ContractPauseManager};
+use crate::errors::Error;
+use crate::{PredictifyHybrid, PredictifyHybridClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Symbol};
+
+struct TestSetup {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+}
+
+impl TestSetup {
+    fn uninitialized() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(PredictifyHybrid, ());
+        let admin = Address::generate(&env);
+
+        Self {
+            env,
+            contract_id,
+            admin,
+        }
+    }
+
+    fn initialized() -> Self {
+        let setup = Self::uninitialized();
+        setup.client().initialize(&setup.admin, &None);
+        setup
+    }
+
+    fn client(&self) -> PredictifyHybridClient<'_> {
+        PredictifyHybridClient::new(&self.env, &self.contract_id)
+    }
+}
+
+#[test]
+fn test_upgrade_contract_requires_persistent_primary_admin() {
+    let setup = TestSetup::uninitialized();
+    let wasm_hash = BytesN::from_array(&setup.env, &[7; 32]);
+
+    let result = setup.client().try_upgrade_contract(&setup.admin, &wasm_hash);
+
+    assert_eq!(result, Err(Ok(Error::AdminNotSet)));
+}
+
+#[test]
+fn test_upgrade_contract_rejects_legacy_instance_admin_bypass() {
+    let setup = TestSetup::initialized();
+    let attacker = Address::generate(&setup.env);
+    let wasm_hash = BytesN::from_array(&setup.env, &[9; 32]);
+
+    setup.env.as_contract(&setup.contract_id, || {
+        setup
+            .env
+            .storage()
+            .instance()
+            .set(&Symbol::new(&setup.env, "admin"), &attacker);
+    });
+
+    let result = setup.client().try_upgrade_contract(&attacker, &wasm_hash);
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_validate_admin_permission_requires_initialized_admin_root() {
+    let setup = TestSetup::uninitialized();
+
+    let result = setup
+        .client()
+        .try_validate_admin_permission(&setup.admin, &AdminPermission::Emergency);
+
+    assert_eq!(result, Err(Ok(Error::AdminNotSet)));
+}
+
+#[test]
+fn test_migrate_to_multi_admin_requires_primary_admin() {
+    let setup = TestSetup::initialized();
+    let outsider = Address::generate(&setup.env);
+
+    let result = setup.client().try_migrate_to_multi_admin(&outsider);
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_delegated_super_admin_can_manage_admins_after_migration() {
+    let setup = TestSetup::initialized();
+    let delegated_admin = Address::generate(&setup.env);
+    let target_admin = Address::generate(&setup.env);
+
+    setup.client().migrate_to_multi_admin(&setup.admin);
+    setup
+        .client()
+        .add_admin(&setup.admin, &delegated_admin, &AdminRole::SuperAdmin);
+
+    let result = setup
+        .client()
+        .try_add_admin(&delegated_admin, &target_admin, &AdminRole::MarketAdmin);
+
+    assert_eq!(result, Ok(Ok(())));
+
+    let assignment = setup.env.as_contract(&setup.contract_id, || {
+        AdminManager::get_admin_assignment(&setup.env, &target_admin)
+    });
+    assert_eq!(assignment.map(|value| value.role), Some(AdminRole::MarketAdmin));
+}
+
+#[test]
+fn test_primary_admin_transfer_rotates_entrypoint_access() {
+    let setup = TestSetup::initialized();
+    let new_admin = Address::generate(&setup.env);
+
+    setup.env.as_contract(&setup.contract_id, || {
+        ContractPauseManager::transfer_admin(&setup.env, &setup.admin, &new_admin).unwrap();
+    });
+
+    let old_admin_result = setup.client().try_set_platform_fee(&setup.admin, &250i128);
+    assert_eq!(old_admin_result, Err(Ok(Error::Unauthorized)));
+
+    let new_admin_result = setup.client().try_set_platform_fee(&new_admin, &250i128);
+    assert_eq!(new_admin_result, Ok(Ok(())));
+}

--- a/contracts/predictify-hybrid/src/event_management_tests.rs
+++ b/contracts/predictify-hybrid/src/event_management_tests.rs
@@ -38,6 +38,9 @@ impl TestSetup {
         // Initialize the contract
         let client = PredictifyHybridClient::new(&env, &contract_id);
         client.initialize(&admin, &None);
+        env.as_contract(&contract_id, || {
+            crate::circuit_breaker::CircuitBreaker::initialize(&env).unwrap();
+        });
 
         Self {
             env,

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -114,6 +114,9 @@ mod balance_tests;
 #[cfg(test)]
 mod event_management_tests;
 
+#[cfg(test)]
+mod admin_auth_audit_tests;
+
 #[cfg(any())]
 mod category_tags_tests;
 #[cfg(any())]
@@ -129,7 +132,10 @@ mod tests;
 mod event_creation_tests;
 
 // Re-export commonly used items
-use admin::{AdminAnalyticsResult, AdminInitializer, AdminManager, AdminPermission, AdminRole};
+use admin::{
+    AdminAnalyticsResult, AdminInitializer, AdminManager, AdminPermission, AdminRole,
+    AdminSystemIntegration,
+};
 pub use err::Error;
 // Backwards-compatible re-export for existing module paths.
 pub mod errors {
@@ -248,6 +254,50 @@ impl PredictifyHybrid {
 
         // Emit platform fee set event
         EventEmitter::emit_platform_fee_set(&env, fee_percentage, &admin);
+    }
+
+    fn stored_primary_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .persistent()
+            .get(&Symbol::new(env, "Admin"))
+            .ok_or(Error::AdminNotSet)
+    }
+
+    fn require_primary_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        if &Self::stored_primary_admin(env)? != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(())
+    }
+
+    fn require_primary_admin_or_panic(env: &Env, admin: &Address) {
+        if let Err(error) = Self::require_primary_admin(env, admin) {
+            panic_with_error!(env, error);
+        }
+    }
+
+    fn require_initialized_admin_root(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+        let _ = Self::stored_primary_admin(env)?;
+        Ok(())
+    }
+
+    fn require_admin_permission(
+        env: &Env,
+        admin: &Address,
+        permission: AdminPermission,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin = Self::stored_primary_admin(env)?;
+        if &stored_admin == admin {
+            return Ok(());
+        }
+
+        AdminSystemIntegration::validate_admin_unified(env, admin, permission)
     }
 
     /// Deposits funds into the user's balance.
@@ -461,19 +511,7 @@ impl PredictifyHybrid {
             panic_with_error!(env, e);
         }
         let gas_marker = GasTracker::start_tracking(&env);
-        // Authenticate that the caller is the admin
-        admin.require_auth();
-
-        // Verify the caller is an admin
-        let stored_admin: Address =
-            match env.storage().persistent().get(&Symbol::new(&env, "Admin")) {
-                Some(admin_addr) => admin_addr,
-                None => panic_with_error!(env, Error::AdminNotSet),
-            };
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
 
         // Validate inputs
         if outcomes.len() < 2 {
@@ -590,19 +628,7 @@ impl PredictifyHybrid {
         if let Err(e) = crate::circuit_breaker::CircuitBreaker::require_write_allowed(&env, "create_event") {
             panic_with_error!(env, e);
         }
-        // Authenticate that the caller is the admin
-        admin.require_auth();
-
-        // Verify the caller is an admin
-        let stored_admin: Address =
-            match env.storage().persistent().get(&Symbol::new(&env, "Admin")) {
-                Some(admin_addr) => admin_addr,
-                None => panic_with_error!(env, Error::AdminNotSet),
-            };
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
 
         // Skip validation for now since validation module is disabled
         // TODO: Re-enable when validation module is fixed
@@ -1658,20 +1684,7 @@ impl PredictifyHybrid {
         winning_outcome: String,
     ) {
         let gas_marker = GasTracker::start_tracking(&env);
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
 
         let mut market: Market = env
             .storage()
@@ -1806,20 +1819,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         winning_outcomes: Vec<String>,
     ) {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
 
         // Validate outcomes vector is not empty
         if winning_outcomes.len() == 0 {
@@ -2281,7 +2281,7 @@ impl PredictifyHybrid {
         outcome: String,
         reason: String,
     ) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_primary_admin(&env, &admin)?;
         // Temporarily disabled due to oracles module being disabled
         // oracles::OracleIntegrationManager::admin_override_result(
         //     &env,
@@ -2623,20 +2623,7 @@ impl PredictifyHybrid {
         admin: Address,
         market_id: Symbol,
     ) -> Result<disputes::DisputeResolution, Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         disputes::DisputeManager::resolve_dispute(&env, market_id, admin)
     }
@@ -2651,20 +2638,7 @@ impl PredictifyHybrid {
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
     pub fn collect_fees(env: Env, admin: Address, market_id: Symbol) -> Result<i128, Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         fees::FeeManager::collect_fees(&env, admin, market_id)
     }
@@ -3081,19 +3055,7 @@ impl PredictifyHybrid {
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
     pub fn set_platform_fee(env: Env, admin: Address, fee_percentage: i128) -> Result<(), Error> {
-        // Require authentication
-        admin.require_auth();
-
-        // Verify admin - get from storage with defensive check
-        let admin_key = Symbol::new(&env, "Admin");
-        if !env.storage().persistent().has(&admin_key) {
-            return Err(Error::Unauthorized);
-        }
-
-        let stored_admin: Address = env.storage().persistent().get(&admin_key).unwrap();
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Validate fee percentage (0-10%)
         if fee_percentage < 0 || fee_percentage > 1000 {
@@ -3131,15 +3093,7 @@ impl PredictifyHybrid {
         min_bet: i128,
         max_bet: i128,
     ) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
         let limits = crate::types::BetLimits { min_bet, max_bet };
         crate::bets::set_global_bet_limits(&env, &limits)?;
         let scope = Symbol::new(&env, "global");
@@ -3172,15 +3126,7 @@ impl PredictifyHybrid {
         min_bet: i128,
         max_bet: i128,
     ) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
         let limits = BetLimits { min_bet, max_bet };
         crate::bets::set_event_bet_limits(&env, &market_id, &limits)?;
         EventEmitter::emit_bet_limits_updated(&env, &admin, &market_id, min_bet, max_bet);
@@ -3219,15 +3165,7 @@ impl PredictifyHybrid {
         max_staleness_secs: u64,
         max_confidence_bps: u32,
     ) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         let config = GlobalOracleValidationConfig {
             max_staleness_secs,
@@ -3264,15 +3202,7 @@ impl PredictifyHybrid {
         max_staleness_secs: u64,
         max_confidence_bps: u32,
     ) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         let config = EventOracleValidationConfig {
             max_staleness_secs,
@@ -3370,20 +3300,7 @@ impl PredictifyHybrid {
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
     pub fn withdraw_collected_fees(env: Env, admin: Address, amount: i128) -> Result<i128, Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Get collected fees from storage (using the same key as FeeTracker)
         let fees_key = Symbol::new(&env, "tot_fees");
@@ -3495,18 +3412,7 @@ impl PredictifyHybrid {
         additional_days: u32,
         reason: String,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::Unauthorized));
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Get market
         let mut market: Market = env
@@ -3642,18 +3548,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         new_description: String,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::Unauthorized));
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Validate new description
         if new_description.is_empty() {
@@ -3795,18 +3690,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         new_outcomes: Vec<String>,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::Unauthorized));
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Validate new outcomes
         if new_outcomes.len() < 2 {
@@ -3933,18 +3817,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         category: Option<String>,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::Unauthorized));
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Get market
         let mut market: Market = env
@@ -4061,18 +3934,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         tags: Vec<String>,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| panic_with_error!(env, Error::Unauthorized));
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Validate tags - none should be empty
         for tag in tags.iter() {
@@ -4328,20 +4190,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         reason: Option<String>,
     ) -> Result<i128, Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         // Get and validate market
         let mut market: Market = env
@@ -4494,20 +4343,7 @@ impl PredictifyHybrid {
         reason: String,
         _fee_amount: i128,
     ) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Verify admin
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&Symbol::new(&env, "Admin"))
-            .unwrap_or_else(|| {
-                panic_with_error!(env, Error::Unauthorized);
-            });
-
-        if admin != stored_admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
+        Self::require_primary_admin(&env, &admin)?;
 
         extensions::ExtensionManager::extend_market_duration(
             &env,
@@ -4920,10 +4756,7 @@ impl PredictifyHybrid {
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
     pub fn recover_market_state(env: Env, admin: Address, market_id: Symbol) -> bool {
-        admin.require_auth();
-        if let Err(e) = crate::recovery::RecoveryManager::assert_is_admin(&env, &admin) {
-            panic_with_error!(env, e);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
         let result = match crate::recovery::RecoveryManager::recover_market_state(&env, &market_id)
         {
             Ok(res) => res,
@@ -4955,10 +4788,7 @@ impl PredictifyHybrid {
         market_id: Symbol,
         users: Vec<Address>,
     ) -> i128 {
-        admin.require_auth();
-        if let Err(e) = crate::recovery::RecoveryManager::assert_is_admin(&env, &admin) {
-            panic_with_error!(env, e);
-        }
+        Self::require_primary_admin_or_panic(&env, &admin);
         let result = match crate::recovery::RecoveryManager::partial_refund_mechanism(
             &env, &market_id, &users,
         ) {
@@ -5328,6 +5158,10 @@ impl PredictifyHybrid {
 
     /// Add a new admin with specified role (SuperAdmin only)
     ///
+    /// The caller must satisfy Soroban `require_auth()`. Access is granted to the
+    /// stored primary admin and, after multi-admin migration, any delegated admin
+    /// with `AdminPermission::Emergency`.
+    ///
     /// # Errors
     ///
     /// Returns [`Error`] when validation, authorization, storage, or subsystem checks fail.
@@ -5341,11 +5175,15 @@ impl PredictifyHybrid {
         new_admin: Address,
         role: AdminRole,
     ) -> Result<(), Error> {
-        current_admin.require_auth();
+        Self::require_admin_permission(&env, &current_admin, AdminPermission::Emergency)?;
         AdminManager::add_admin(&env, &current_admin, &new_admin, role)
     }
 
     /// Remove an admin from the system (SuperAdmin only)
+    ///
+    /// The caller must satisfy Soroban `require_auth()`. Access is granted to the
+    /// stored primary admin and, after multi-admin migration, any delegated admin
+    /// with `AdminPermission::Emergency`.
     ///
     /// # Errors
     ///
@@ -5359,11 +5197,15 @@ impl PredictifyHybrid {
         current_admin: Address,
         admin_to_remove: Address,
     ) -> Result<(), Error> {
-        current_admin.require_auth();
+        Self::require_admin_permission(&env, &current_admin, AdminPermission::Emergency)?;
         AdminManager::remove_admin(&env, &current_admin, &admin_to_remove)
     }
 
     /// Update an admin's role (SuperAdmin only)
+    ///
+    /// The caller must satisfy Soroban `require_auth()`. Access is granted to the
+    /// stored primary admin and, after multi-admin migration, any delegated admin
+    /// with `AdminPermission::Emergency`.
     ///
     /// # Errors
     ///
@@ -5378,11 +5220,14 @@ impl PredictifyHybrid {
         target_admin: Address,
         new_role: AdminRole,
     ) -> Result<(), Error> {
-        current_admin.require_auth();
+        Self::require_admin_permission(&env, &current_admin, AdminPermission::Emergency)?;
         AdminManager::update_admin_role(&env, &current_admin, &target_admin, new_role)
     }
 
     /// Validate admin permission for specific action
+    ///
+    /// The caller must satisfy Soroban `require_auth()`, and the contract must
+    /// already have an initialized primary admin in persistent storage.
     ///
     /// # Errors
     ///
@@ -5396,6 +5241,7 @@ impl PredictifyHybrid {
         admin: Address,
         permission: AdminPermission,
     ) -> Result<(), Error> {
+        Self::require_initialized_admin_root(&env, &admin)?;
         AdminManager::validate_admin_permission(&env, &admin, permission)
     }
 
@@ -5427,6 +5273,9 @@ impl PredictifyHybrid {
 
     /// Migrate from single-admin to multi-admin system
     ///
+    /// Only the stored primary admin can trigger the one-way migration into the
+    /// delegated multi-admin storage layout.
+    ///
     /// # Errors
     ///
     /// Returns [`Error`] when validation, authorization, storage, or subsystem checks fail.
@@ -5435,7 +5284,7 @@ impl PredictifyHybrid {
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
     pub fn migrate_to_multi_admin(env: Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_primary_admin(&env, &admin)?;
         admin::AdminSystemIntegration::migrate_to_multi_admin(&env)
     }
 
@@ -5486,7 +5335,8 @@ impl PredictifyHybrid {
     ///
     /// # Security
     ///
-    /// - Requires admin authentication via `require_auth()`
+    /// - Requires Soroban `require_auth()` from the caller
+    /// - Requires the caller to match the stored primary admin in persistent storage
     /// - Validates version compatibility
     /// - Performs safety checks before upgrade
     /// - Logs all upgrade attempts for audit trail
@@ -5517,7 +5367,7 @@ impl PredictifyHybrid {
         admin: Address,
         new_wasm_hash: soroban_sdk::BytesN<32>,
     ) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_primary_admin(&env, &admin)?;
         let result = upgrade_manager::UpgradeManager::upgrade_contract(&env, &admin, new_wasm_hash);
 
         crate::audit_trail::AuditTrailManager::append_record(
@@ -5558,7 +5408,7 @@ impl PredictifyHybrid {
         admin: Address,
         rollback_wasm_hash: soroban_sdk::BytesN<32>,
     ) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_primary_admin(&env, &admin)?;
         let result =
             upgrade_manager::UpgradeManager::rollback_upgrade(&env, &admin, rollback_wasm_hash);
 

--- a/contracts/predictify-hybrid/src/upgrade_manager.rs
+++ b/contracts/predictify-hybrid/src/upgrade_manager.rs
@@ -3,6 +3,7 @@
 use alloc::format;
 use soroban_sdk::{contracttype, Address, BytesN, Env, String, Symbol, Vec};
 
+use crate::admin::AdminAccessControl;
 use crate::errors::Error;
 use crate::events::EventEmitter;
 use crate::versioning::{Version, VersionManager};
@@ -341,9 +342,6 @@ impl UpgradeManager {
         admin: &Address,
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), Error> {
-        // Verify admin authorization
-        admin.require_auth();
-
         // Validate admin permissions
         Self::validate_admin_permissions(env, admin)?;
 
@@ -505,9 +503,6 @@ impl UpgradeManager {
         admin: &Address,
         rollback_wasm_hash: BytesN<32>,
     ) -> Result<(), Error> {
-        // Verify admin authorization
-        admin.require_auth();
-
         // Validate admin permissions
         Self::validate_admin_permissions(env, admin)?;
 
@@ -673,20 +668,7 @@ impl UpgradeManager {
 
     /// Validate admin has upgrade permissions
     fn validate_admin_permissions(env: &Env, admin: &Address) -> Result<(), Error> {
-        // Check if admin exists in storage
-        let admin_key = Symbol::new(env, "admin");
-        let stored_admin: Address = env
-            .storage()
-            .instance()
-            .get(&admin_key)
-            .ok_or(Error::Unauthorized)?;
-
-        // Verify admin matches
-        if stored_admin != *admin {
-            return Err(Error::Unauthorized);
-        }
-
-        Ok(())
+        AdminAccessControl::require_admin_auth(env, admin)
     }
 
     /// Get current Wasm hash

--- a/docs/security/SECURITY_CONSIDERATIONS.md
+++ b/docs/security/SECURITY_CONSIDERATIONS.md
@@ -190,6 +190,35 @@ Critical operations require multiple admin approvals:
 - **Configuration Updates**: Require 2+ admin approvals
 - **Emergency Pauses**: Require superadmin + 1 other admin
 
+### Primary Admin Storage and Entrypoint Authentication
+
+Predictify Hybrid treats persistent storage key `Admin` as the contract's root of trust for administrative authority.
+
+- `initialize()` stores the primary admin once in persistent storage.
+- Primary-admin-only contract entrypoints now require both Soroban `require_auth()` and an exact match against the stored `Admin` address.
+- If the `Admin` key is missing, admin-gated entrypoints fail with `AdminNotSet` rather than silently falling back to another storage source.
+- Upgrade and rollback flows use the same persistent `Admin` check as the rest of the contract; they do not trust legacy instance-storage admin keys.
+
+### Delegated Multi-Admin Flows
+
+The contract also supports delegated admin roles after migration to the multi-admin storage layout.
+
+- `migrate_to_multi_admin()` may only be triggered by the stored primary admin.
+- Delegated admin entrypoints still require Soroban `require_auth()`.
+- Delegated authorization is only evaluated after confirming the contract has an initialized primary admin root in persistent storage.
+- The stored `Admin` address remains the primary authority record even after migration; delegated admins do not replace it.
+
+### Admin Rotation and Transfer
+
+Primary-admin rotation is implemented by `ContractPauseManager::transfer_admin()`.
+
+- The current primary admin must satisfy Soroban `require_auth()`.
+- The caller must match the stored `Admin` address.
+- On success, the contract atomically rewrites the persistent `Admin` key to the new address.
+- After rotation, the old primary admin immediately loses access to primary-admin-only entrypoints, and the new primary admin gains it.
+
+Current public contract entrypoints do not expose a standalone `transfer_admin()` method. Integrators should treat the stored `Admin` value as the canonical authority source and wire any rotation workflow through an audited governance or admin-management wrapper if they need on-chain rotation at the application level.
+
 ---
 
 ## 🔄 Input Validation and Data Integrity


### PR DESCRIPTION
Closes: #386 

## Summary

This PR audits and hardens admin-gated authorization paths in `predictify-hybrid` so they consistently anchor on the stored primary admin and Soroban `require_auth()` semantics.

It also documents the current authority model, including primary admin rotation and delegated multi-admin behavior after migration.

## What changed

- introduced shared admin authorization helpers in `predictify-hybrid` public entrypoints
- standardized primary-admin-only entrypoints to require:
  - Soroban `require_auth()`
  - a match against the persistent `Admin` storage key
- fixed inconsistent missing-admin handling so these paths now fail with `AdminNotSet` instead of silently treating it as generic unauthorized access
- tightened admin-gated recovery and upgrade entrypoints to use the same stored-admin root of trust
- updated pause, unpause, and admin transfer logic to reuse the shared admin auth helper
- fixed upgrade authorization to stop reading the legacy instance-storage `"admin"` key and instead trust the persistent `"Admin"` key
- preserved delegated multi-admin flows by requiring:
  - initialized primary admin storage
  - Soroban `require_auth()`
  - delegated permission validation only where the design supports it
- fixed multi-admin storage key generation so migrated/delegated admin assignments use a deterministic Soroban-safe storage key type
- documented primary admin storage, admin rotation, and delegated multi-admin semantics in security docs

## Files changed

- `contracts/predictify-hybrid/src/lib.rs`
- `contracts/predictify-hybrid/src/admin.rs`
- `contracts/predictify-hybrid/src/upgrade_manager.rs`
- `contracts/predictify-hybrid/src/admin_auth_audit_tests.rs`
- `contracts/predictify-hybrid/src/event_management_tests.rs`
- `docs/security/SECURITY_CONSIDERATIONS.md`

## Behavior clarified

### Primary-admin-only entrypoints

These entrypoints now consistently require:
1. caller `require_auth()`
2. persistent `Admin` key to exist
3. caller address to equal the stored primary admin

This applies to creation, resolution, fee/config updates, cancellation/extension, recovery, and upgrade/rollback paths audited in this PR.

### Delegated multi-admin entrypoints

For delegated admin management flows such as:
- `add_admin`
- `remove_admin`
- `update_admin_role`

the wrapper entrypoints now require:
- caller `require_auth()`
- initialized primary admin root in storage
- either:
  - caller is the stored primary admin, or
  - caller passes delegated permission checks after migration

### Upgrade authorization

- `upgrade_contract` and `rollback_upgrade` no longer trust instance-storage `"admin"`
- both now validate against the same persistent `Admin` root used elsewhere in the contract

### Admin rotation

- primary admin rotation remains supported via `ContractPauseManager::transfer_admin()`
- after rotation:
  - the old primary admin loses primary-admin-only access immediately
  - the new primary admin gains it immediately

## Tests

### Focused regression tests

- `cargo test -p predictify-hybrid admin_auth_audit_tests -- --nocapture`

Covered cases:
- upgrade fails with `AdminNotSet` when primary admin storage is missing
- upgrade rejects a legacy instance-storage `"admin"` bypass
- `validate_admin_permission` requires initialized primary admin storage
- multi-admin migration requires the stored primary admin
- delegated super admin can manage admins after migration
- primary admin transfer rotates access correctly

### Compatibility regression tests

- `cargo test -p predictify-hybrid event_management_tests -- --nocapture`

This also confirmed the updated test setup matches current circuit-breaker initialization requirements.

### Full package tests

- `cargo test -p predictify-hybrid`

Result:
- `406 passed; 0 failed`

### Wasm build verification

- `cargo rustc --manifest-path=contracts/predictify-hybrid/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release`

Result:
- release wasm build passed

## Security notes

### Threat model

This change reduces the risk of authorization drift across admin-gated entrypoints, especially where different wrappers previously used different storage checks or inconsistent error behavior. It also closes a concrete upgrade-path risk where authorization logic referenced a different storage location than the live primary admin root.

### Invariants

- primary-admin-only entrypoints require both `require_auth()` and equality with persistent `Admin`
- missing primary admin storage fails closed with `AdminNotSet`
- upgrade and rollback authorization use the same persistent primary admin root as the rest of the contract
- delegated multi-admin entrypoints still require `require_auth()` and an initialized primary admin root
- primary admin rotation immediately changes who can call primary-admin-only entrypoints
- migrated multi-admin assignments use Soroban-safe deterministic storage keys

### Explicit non-goals

- this PR does not redesign the full admin role model
- this PR does not add a new public `transfer_admin` contract entrypoint
- this PR does not change frontend or backend authorization behavior outside `predictify-contracts`
- this PR does not introduce external coverage tooling in this environment

## Notes for reviewers

- the diff intentionally centralizes admin auth checks to make the audited surface easier to review
- `event_management_tests` now initializes the circuit breaker so the suite matches current contract preconditions
- two unrelated local unstaged changes were left out of this PR:
  - `contracts/predictify-hybrid/src/balance_tests.rs`
  - `contracts/predictify-hybrid/src/types.rs`
