### PR TITLE
fix: enforce unclaimed winnings timeout from resolution anchor

### DIFF
--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -1424,6 +1424,14 @@ impl PredictifyHybrid {
             None => panic_with_error!(env, Error::MarketNotResolved),
         };
 
+        if recovery::UnclaimedWinningsPolicy::is_claim_window_expired(
+            &env,
+            &market_id,
+            market.end_time,
+        ) {
+            panic_with_error!(env, Error::ResolutionTimeoutReached);
+        }
+
         // Get user's vote
         let user_outcome = market
             .votes
@@ -1518,6 +1526,281 @@ impl PredictifyHybrid {
         // If no winnings (user didn't win or zero payout), still mark as claimed to prevent re-attempts
         market.claimed.set(user.clone(), ClaimInfo::new(&env, 0));
         env.storage().persistent().set(&market_id, &market);
+    }
+
+    /// Set the global claim period for resolved markets (admin only).
+    ///
+    /// Claims are allowed until `market.end_time + claim_period_seconds` unless overridden
+    /// per market. After expiry, claims revert with `Error::ResolutionTimeoutReached`.
+    pub fn set_global_claim_period(env: Env, admin: Address, claim_period_seconds: u64) {
+        admin.require_auth();
+
+        if claim_period_seconds == 0 {
+            panic_with_error!(env, Error::InvalidInput);
+        }
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, "Admin"))
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
+
+        if admin != stored_admin {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        recovery::UnclaimedWinningsPolicy::set_global_claim_period(&env, claim_period_seconds);
+        EventEmitter::emit_claim_period_updated(&env, &admin, claim_period_seconds);
+    }
+
+    /// Set a market-specific claim period override (admin only).
+    ///
+    /// The market-specific value overrides the global claim period for the given market.
+    pub fn set_market_claim_period(
+        env: Env,
+        admin: Address,
+        market_id: Symbol,
+        claim_period_seconds: u64,
+    ) {
+        admin.require_auth();
+
+        if claim_period_seconds == 0 {
+            panic_with_error!(env, Error::InvalidInput);
+        }
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, "Admin"))
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
+
+        if admin != stored_admin {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        if markets::MarketStateManager::get_market(&env, &market_id).is_err() {
+            panic_with_error!(env, Error::MarketNotFound);
+        }
+
+        recovery::UnclaimedWinningsPolicy::set_market_claim_period(
+            &env,
+            &market_id,
+            claim_period_seconds,
+        );
+        EventEmitter::emit_market_claim_period_updated(&env, &admin, &market_id, claim_period_seconds);
+    }
+
+    /// Set treasury recipient for unclaimed winnings sweeps (admin only).
+    pub fn set_treasury(env: Env, admin: Address, treasury: Address) {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, "Admin"))
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotSet));
+
+        if admin != stored_admin {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        recovery::UnclaimedWinningsPolicy::set_treasury(&env, &treasury);
+        EventEmitter::emit_treasury_updated(&env, &admin, &treasury);
+    }
+
+    /// Sweep unclaimed winning payouts after claim period expiry (admin only).
+    ///
+    /// If `burn` is true, swept funds are burned (no recipient balance credited).
+    /// If `burn` is false, swept funds are credited to the configured treasury.
+    pub fn sweep_unclaimed_winnings(
+        env: Env,
+        admin: Address,
+        market_id: Symbol,
+        burn: bool,
+    ) -> Result<i128, Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, "Admin"))
+            .ok_or(Error::AdminNotSet)?;
+
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut market: Market = env
+            .storage()
+            .persistent()
+            .get(&market_id)
+            .ok_or(Error::MarketNotFound)?;
+
+        let winning_outcomes = market
+            .winning_outcomes
+            .clone()
+            .ok_or(Error::MarketNotResolved)?;
+
+        if !recovery::UnclaimedWinningsPolicy::is_claim_window_expired(
+            &env,
+            &market_id,
+            market.end_time,
+        ) {
+            return Err(Error::InvalidState);
+        }
+
+        let fee_percent = crate::config::ConfigManager::get_config(&env)
+            .map(|cfg| cfg.fees.platform_fee_percentage)
+            .unwrap_or_else(|_| {
+                env.storage()
+                    .persistent()
+                    .get(&Symbol::new(&env, "platform_fee"))
+                    .unwrap_or(2)
+            });
+
+        if fee_percent < 0 || fee_percent > PERCENTAGE_DENOMINATOR {
+            return Err(Error::InvalidFeeConfig);
+        }
+
+        let bettors = bets::BetStorage::get_all_bets_for_market(&env, &market_id);
+
+        let mut winning_total = 0i128;
+        for (voter, outcome) in market.votes.iter() {
+            if winning_outcomes.contains(&outcome) {
+                winning_total = winning_total
+                    .checked_add(market.stakes.get(voter.clone()).unwrap_or(0))
+                    .ok_or(Error::InvalidInput)?;
+            }
+        }
+
+        for user in bettors.iter() {
+            if market.votes.contains_key(user.clone()) {
+                continue;
+            }
+
+            if let Some(bet) = bets::BetStorage::get_bet(&env, &market_id, &user) {
+                if winning_outcomes.contains(&bet.outcome) {
+                    winning_total = winning_total
+                        .checked_add(bet.amount)
+                        .ok_or(Error::InvalidInput)?;
+                }
+            }
+        }
+
+        if winning_total <= 0 {
+            return Ok(0);
+        }
+
+        let mut swept_total = 0i128;
+        let total_pool = market.total_staked;
+
+        for (user, outcome) in market.votes.iter() {
+            if !winning_outcomes.contains(&outcome) {
+                continue;
+            }
+
+            if market
+                .claimed
+                .get(user.clone())
+                .map(|info| info.is_claimed())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let user_stake = market.stakes.get(user.clone()).unwrap_or(0);
+            if user_stake <= 0 {
+                continue;
+            }
+
+            let user_share = user_stake
+                .checked_mul(PERCENTAGE_DENOMINATOR - fee_percent)
+                .ok_or(Error::InvalidInput)?
+                / PERCENTAGE_DENOMINATOR;
+            let payout = user_share
+                .checked_mul(total_pool)
+                .ok_or(Error::InvalidInput)?
+                / winning_total;
+
+            if payout < 0 {
+                return Err(Error::InvalidInput);
+            }
+
+            market.claimed.set(user.clone(), ClaimInfo::new(&env, payout));
+            swept_total = swept_total.checked_add(payout).ok_or(Error::InvalidInput)?;
+        }
+
+        for user in bettors.iter() {
+            if market.votes.contains_key(user.clone()) {
+                continue;
+            }
+
+            let Some(bet) = bets::BetStorage::get_bet(&env, &market_id, &user) else {
+                continue;
+            };
+
+            if !winning_outcomes.contains(&bet.outcome) {
+                continue;
+            }
+
+            if market
+                .claimed
+                .get(user.clone())
+                .map(|info| info.is_claimed())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            if bet.amount <= 0 {
+                continue;
+            }
+
+            let user_share = bet
+                .amount
+                .checked_mul(PERCENTAGE_DENOMINATOR - fee_percent)
+                .ok_or(Error::InvalidInput)?
+                / PERCENTAGE_DENOMINATOR;
+            let payout = user_share
+                .checked_mul(total_pool)
+                .ok_or(Error::InvalidInput)?
+                / winning_total;
+
+            if payout < 0 {
+                return Err(Error::InvalidInput);
+            }
+
+            market.claimed.set(user.clone(), ClaimInfo::new(&env, payout));
+            swept_total = swept_total.checked_add(payout).ok_or(Error::InvalidInput)?;
+        }
+
+        let recipient = if burn {
+            None
+        } else {
+            let treasury = recovery::UnclaimedWinningsPolicy::get_treasury(&env)
+                .ok_or(Error::ConfigNotFound)?;
+            if swept_total > 0 {
+                storage::BalanceStorage::add_balance(
+                    &env,
+                    &treasury,
+                    &types::ReflectorAsset::Stellar,
+                    swept_total,
+                )?;
+            }
+            Some(treasury)
+        };
+
+        env.storage().persistent().set(&market_id, &market);
+        EventEmitter::emit_unclaimed_winnings_swept(
+            &env,
+            &market_id,
+            &admin,
+            &recipient,
+            swept_total,
+            burn,
+        );
+
+        Ok(swept_total)
     }
 
     /// Retrieves complete market information by market identifier.
@@ -1700,6 +1983,11 @@ impl PredictifyHybrid {
         winning_outcomes_vec.push_back(winning_outcome.clone());
         market.winning_outcomes = Some(winning_outcomes_vec.clone());
         market.state = MarketState::Resolved;
+        recovery::UnclaimedWinningsPolicy::set_claim_window_start_if_missing(
+            &env,
+            &market_id,
+            env.ledger().timestamp(),
+        );
         env.storage().persistent().set(&market_id, &market);
 
         // Resolve bets to mark them as won/lost
@@ -1853,6 +2141,11 @@ impl PredictifyHybrid {
         // Set winning outcome(s) - supports multiple winners for ties
         market.winning_outcomes = Some(winning_outcomes.clone());
         market.state = MarketState::Resolved;
+        recovery::UnclaimedWinningsPolicy::set_claim_window_start_if_missing(
+            &env,
+            &market_id,
+            env.ledger().timestamp(),
+        );
         env.storage().persistent().set(&market_id, &market);
 
         // Resolve bets to mark them as won/lost
@@ -6599,3 +6892,6 @@ impl PredictifyHybrid {
 
 #[cfg(any())]
 mod test;
+
+#[cfg(test)]
+mod unclaimed_winnings_timeout_tests;

--- a/contracts/predictify-hybrid/src/recovery.rs
+++ b/contracts/predictify-hybrid/src/recovery.rs
@@ -6,6 +6,8 @@ use crate::markets::MarketStateManager;
 use crate::types::{ClaimInfo, MarketState};
 use crate::Error;
 
+const DEFAULT_UNCLAIMED_CLAIM_PERIOD_SECONDS: u64 = 90 * 24 * 60 * 60;
+
 // ===== RECOVERY TYPES =====
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -89,6 +91,109 @@ impl RecoveryStorage {
             .get(&Self::status_key(env))
             .unwrap_or(Map::new(env));
         status_map.get(market_id.clone())
+    }
+}
+
+pub struct UnclaimedWinningsPolicy;
+impl UnclaimedWinningsPolicy {
+    #[inline(always)]
+    fn global_claim_period_key(env: &Env) -> Symbol {
+        Symbol::new(env, "claim_period_global")
+    }
+
+    #[inline(always)]
+    fn market_claim_periods_key(env: &Env) -> Symbol {
+        Symbol::new(env, "claim_period_market")
+    }
+
+    #[inline(always)]
+    fn treasury_key(env: &Env) -> Symbol {
+        Symbol::new(env, "treasury_addr")
+    }
+
+    #[inline(always)]
+    fn claim_window_start_key(env: &Env) -> Symbol {
+        Symbol::new(env, "claim_window_start")
+    }
+
+    pub fn set_global_claim_period(env: &Env, claim_period_seconds: u64) {
+        env.storage()
+            .persistent()
+            .set(&Self::global_claim_period_key(env), &claim_period_seconds);
+    }
+
+    pub fn get_global_claim_period(env: &Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&Self::global_claim_period_key(env))
+            .unwrap_or(DEFAULT_UNCLAIMED_CLAIM_PERIOD_SECONDS)
+    }
+
+    pub fn set_market_claim_period(env: &Env, market_id: &Symbol, claim_period_seconds: u64) {
+        let mut periods: Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&Self::market_claim_periods_key(env))
+            .unwrap_or(Map::new(env));
+        periods.set(market_id.clone(), claim_period_seconds);
+        env.storage()
+            .persistent()
+            .set(&Self::market_claim_periods_key(env), &periods);
+    }
+
+    pub fn get_market_claim_period(env: &Env, market_id: &Symbol) -> Option<u64> {
+        let periods: Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&Self::market_claim_periods_key(env))
+            .unwrap_or(Map::new(env));
+        periods.get(market_id.clone())
+    }
+
+    pub fn get_effective_claim_period(env: &Env, market_id: &Symbol) -> u64 {
+        Self::get_market_claim_period(env, market_id).unwrap_or(Self::get_global_claim_period(env))
+    }
+
+    pub fn claim_deadline(env: &Env, market_id: &Symbol, market_end_time: u64) -> u64 {
+        Self::get_claim_window_start(env, market_id, market_end_time)
+            .saturating_add(Self::get_effective_claim_period(env, market_id))
+    }
+
+    pub fn is_claim_window_expired(env: &Env, market_id: &Symbol, market_end_time: u64) -> bool {
+        env.ledger().timestamp() >= Self::claim_deadline(env, market_id, market_end_time)
+    }
+
+    pub fn set_claim_window_start_if_missing(env: &Env, market_id: &Symbol, start_timestamp: u64) {
+        let mut starts: Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&Self::claim_window_start_key(env))
+            .unwrap_or(Map::new(env));
+
+        if starts.get(market_id.clone()).is_none() {
+            starts.set(market_id.clone(), start_timestamp);
+            env.storage()
+                .persistent()
+                .set(&Self::claim_window_start_key(env), &starts);
+        }
+    }
+
+    pub fn get_claim_window_start(env: &Env, market_id: &Symbol, market_end_time: u64) -> u64 {
+        let starts: Map<Symbol, u64> = env
+            .storage()
+            .persistent()
+            .get(&Self::claim_window_start_key(env))
+            .unwrap_or(Map::new(env));
+
+        starts.get(market_id.clone()).unwrap_or(market_end_time)
+    }
+
+    pub fn set_treasury(env: &Env, treasury: &Address) {
+        env.storage().persistent().set(&Self::treasury_key(env), treasury);
+    }
+
+    pub fn get_treasury(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&Self::treasury_key(env))
     }
 }
 

--- a/contracts/predictify-hybrid/src/unclaimed_winnings_timeout_tests.rs
+++ b/contracts/predictify-hybrid/src/unclaimed_winnings_timeout_tests.rs
@@ -231,3 +231,66 @@ fn test_market_specific_claim_period_override_used() {
         .amount;
     assert_eq!(treasury_balance, 0);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #400)")]
+fn test_delayed_resolution_has_fresh_claim_window() {
+    let setup = TimeoutSweepSetup::new();
+
+    setup
+        .client()
+        .set_global_claim_period(&setup.admin, &100u64);
+
+    setup.set_time(setup.end_time + 10_000);
+
+    setup.env.as_contract(&setup.contract_id, || {
+        let outcomes = vec![
+            &setup.env,
+            String::from_str(&setup.env, "yes"),
+            String::from_str(&setup.env, "no"),
+        ];
+
+        let mut market = Market::new(
+            &setup.env,
+            setup.admin.clone(),
+            String::from_str(&setup.env, "Will outcome be yes?"),
+            outcomes,
+            setup.end_time,
+            OracleConfig {
+                provider: OracleProvider::reflector(),
+                oracle_address: Address::from_str(
+                    &setup.env,
+                    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                ),
+                feed_id: String::from_str(&setup.env, "TEST/YES"),
+                threshold: 1,
+                comparison: String::from_str(&setup.env, "gt"),
+            },
+            None,
+            86_400,
+            MarketState::Active,
+        );
+
+        market
+            .votes
+            .set(setup.winner_1.clone(), String::from_str(&setup.env, "yes"));
+        market.stakes.set(setup.winner_1.clone(), 1_000_000);
+        market.total_staked = 1_000_000;
+
+        setup
+            .env
+            .storage()
+            .persistent()
+            .set(&setup.market_id, &market);
+    });
+
+    setup.client().resolve_market_manual(
+        &setup.admin,
+        &setup.market_id,
+        &String::from_str(&setup.env, "yes"),
+    );
+
+    setup
+        .client()
+        .sweep_unclaimed_winnings(&setup.admin, &setup.market_id, &true);
+}

--- a/docs/operations/INCIDENT_RESPONSE.md
+++ b/docs/operations/INCIDENT_RESPONSE.md
@@ -18,6 +18,36 @@ This documentation helps in detecting incident response procedures, provides ins
 - Documentation of incident and prevention
 - Notfication to regulatory bodies during a security breach
 
+## 6. Unclaimed Winnings Timeout Policy
+- Claiming window is enforced per resolved market.
+- Default claim window: 90 days from recorded resolution time (legacy fallback uses `market.end_time`).
+- Admin can set:
+	- Global claim window: `set_global_claim_period(admin, claim_period_seconds)`
+	- Market override: `set_market_claim_period(admin, market_id, claim_period_seconds)`
+- Claims attempted after deadline revert with `ResolutionTimeoutReached`.
+
+### Sweep Policy
+- Sweep entrypoint: `sweep_unclaimed_winnings(admin, market_id, burn)`.
+- Authorization: admin only.
+- Preconditions:
+	- Market must be resolved.
+	- Claim window must be expired.
+- Sweep scope:
+	- Only unclaimed winning payouts are swept.
+	- Already claimed payouts are excluded.
+
+### Destination Modes
+- `burn = false`: transfer swept amount to configured treasury address.
+	- Treasury must be configured first via `set_treasury(admin, treasury)`.
+- `burn = true`: burn mode (no treasury credit).
+
+### Operational Runbook
+1. Verify market is resolved and claim window has expired.
+2. Decide destination mode (`burn` or treasury).
+3. If treasury mode, verify treasury address is configured.
+4. Execute sweep.
+5. Verify emitted `UnclaimedWinningsSweptEvent` and resulting balances.
+
 # Guidelines for Security Monitoring
 
 ## Metrices to watch


### PR DESCRIPTION
closes #405

### Summary

Claim timeout checks were anchored to `end_time` only, causing misaligned
timeout enforcement when market resolution occurs significantly after market
close. This PR introduces a per-market claim-window anchor to correctly
derive the timeout deadline from the moment of resolution.

---

### Root Cause

Timeout deadlines were computed solely from `market.end_time`. In delayed-
resolution markets, this means the claim window can expire before — or
immediately after — resolution, giving users no meaningful time to claim
winnings.

---

### What Changed

**1. Per-market claim-window anchor**
Introduced a claim-window anchor field in recovery policy storage, scoped
per-market.

**2. Deadline computation**
Switched timeout deadline computation to use the persisted claim-window anchor,
with a legacy fallback to `end_time` for markets resolved before this change.

**3. Anchor set on resolution**
The anchor is written once at all manual resolution entrypoints, establishing
the post-resolution claim window from the moment of resolution.

**4. Regression tests**
Added coverage in `unclaimed_winnings_timeout_tests.rs` for delayed-resolution
behaviour, verifying that claim windows are preserved correctly when resolution
lags market close.

**5. Operations documentation**
Updated operations docs to reflect the new deadline derivation logic and anchor
lifecycle.

---

### Testing

#### Automated

| Check | Result |
|---|---|
| `cargo fmt --check` | ⚠️ Not executed — `cargo` unavailable in this environment |
| `cargo test` | ⚠️ Not executed — `cargo` unavailable in this environment |
| Static diagnostics | ✅ Clean |


---

### Security Notes

| Item | Detail |
|---|---|
| **Threat model** | Delayed-resolution markets must not silently forfeit their intended post-resolution claim window |
| **Invariant** | Timeout deadline derives from the persisted claim-window anchor when present; anchor is written once on the manual resolution path |
| **Non-goals** | No payout formula refactor · No fee-model refactor · No unrelated module changes |