### PR TITLE
fix: guard market extension against invalid states and caps

### DIFF
--- a/contracts/predictify-hybrid/src/event_management_tests.rs
+++ b/contracts/predictify-hybrid/src/event_management_tests.rs
@@ -319,7 +319,7 @@ fn test_extend_deadline_resolved_market() {
         &String::from_str(&setup.env, "Yes"),
     );
 
-    // Try to extend resolved market
+    // Try to extend resolved market — must be rejected
     let result = client.try_extend_deadline(
         &setup.admin,
         &market_id,
@@ -327,7 +327,7 @@ fn test_extend_deadline_resolved_market() {
         &String::from_str(&setup.env, "Extension after resolution"),
     );
 
-    assert_eq!(result, Err(Ok(Error::MarketResolved)));
+    assert_eq!(result, Err(Ok(Error::ExtensionDenied)));
 }
 
 #[test]
@@ -353,6 +353,105 @@ fn test_extend_deadline_unauthorized() {
     );
 
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_extend_deadline_after_end_time_rejected() {
+    // A market whose end_time has already passed must be rejected even if
+    // adding days would produce a future timestamp.
+    let setup = TestSetup::new();
+    let client = PredictifyHybridClient::new(&setup.env, &setup.contract_id);
+
+    let outcomes = vec![
+        &setup.env,
+        String::from_str(&setup.env, "Yes"),
+        String::from_str(&setup.env, "No"),
+    ];
+
+    let market_id = setup.create_market("Test question?", outcomes, 30);
+
+    // Advance time past the market end without resolving it.
+    setup.env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + (31 * 24 * 60 * 60);
+    });
+
+    let result = client.try_extend_deadline(
+        &setup.admin,
+        &market_id,
+        &7u32,
+        &String::from_str(&setup.env, "Extend after end"),
+    );
+
+    assert_eq!(result, Err(Ok(Error::ExtensionDenied)));
+}
+
+#[test]
+fn test_extend_deadline_cap_exceeded() {
+    // Cumulative extensions must not exceed max_extension_days (default 30).
+    let setup = TestSetup::new();
+    let client = PredictifyHybridClient::new(&setup.env, &setup.contract_id);
+
+    let outcomes = vec![
+        &setup.env,
+        String::from_str(&setup.env, "Yes"),
+        String::from_str(&setup.env, "No"),
+    ];
+
+    let market_id = setup.create_market("Test question?", outcomes, 30);
+
+    // First extension: 20 days — should succeed.
+    let first = client.try_extend_deadline(
+        &setup.admin,
+        &market_id,
+        &20u32,
+        &String::from_str(&setup.env, "First extension"),
+    );
+    assert!(first.is_ok());
+
+    // Second extension: 11 days — would push total to 31, exceeding the 30-day cap.
+    let second = client.try_extend_deadline(
+        &setup.admin,
+        &market_id,
+        &11u32,
+        &String::from_str(&setup.env, "Cap exceeded"),
+    );
+    assert_eq!(second, Err(Ok(Error::InvalidDuration)));
+}
+
+#[test]
+fn test_extend_market_closed_state_rejected() {
+    // extend_market must also reject a closed market.
+    let setup = TestSetup::new();
+    let client = PredictifyHybridClient::new(&setup.env, &setup.contract_id);
+
+    let outcomes = vec![
+        &setup.env,
+        String::from_str(&setup.env, "Yes"),
+        String::from_str(&setup.env, "No"),
+    ];
+
+    let market_id = setup.create_market("Test question?", outcomes, 30);
+
+    // Advance time and resolve, then close.
+    setup.env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + (31 * 24 * 60 * 60);
+    });
+    let _ = client.try_resolve_market_manual(
+        &setup.admin,
+        &market_id,
+        &String::from_str(&setup.env, "Yes"),
+    );
+    let _ = client.try_close_market(&setup.admin, &market_id);
+
+    let result = client.try_extend_market(
+        &setup.admin,
+        &market_id,
+        &7u32,
+        &String::from_str(&setup.env, "Extend closed market"),
+        &0i128,
+    );
+
+    assert_eq!(result, Err(Ok(Error::ExtensionDenied)));
 }
 
 // ===== UPDATE EVENT DESCRIPTION TESTS =====

--- a/contracts/predictify-hybrid/src/extensions.rs
+++ b/contracts/predictify-hybrid/src/extensions.rs
@@ -574,23 +574,42 @@ impl ExtensionValidator {
             return Err(Error::InvalidDuration);
         }
 
-        // Get market and validate state
+        // Get market and validate state.
+        // Extension is only permitted while the market is Active. Any terminal
+        // or post-resolution state (Resolved, Closed, Cancelled, Ended) must be
+        // rejected to prevent lifecycle corruption.
         let market = MarketStateManager::get_market(env, market_id)?;
 
-        if market.state == MarketState::Resolved {
-            return Err(Error::MarketResolved);
-        }
-
-        if market.state != MarketState::Active {
-            return Err(Error::MarketClosed);
+        match market.state {
+            MarketState::Resolved | MarketState::Closed | MarketState::Cancelled => {
+                return Err(Error::ExtensionDenied);
+            }
+            MarketState::Ended => {
+                return Err(Error::ExtensionDenied);
+            }
+            MarketState::Active => {}
+            MarketState::Disputed => {
+                return Err(Error::ExtensionDenied);
+            }
         }
 
         let current_time = env.ledger().timestamp();
+
+        // Reject if the market has already passed its end time.
         if current_time >= market.end_time {
-            return Err(Error::MarketClosed);
+            return Err(Error::ExtensionDenied);
         }
 
-        // Check if market is already resolved
+        // Reject if the resulting deadline would still be in the past or present.
+        // This guards against edge cases where end_time is very close to now.
+        let new_end_time = market
+            .end_time
+            .saturating_add((additional_days as u64) * 24 * 60 * 60);
+        if new_end_time <= current_time {
+            return Err(Error::ExtensionDenied);
+        }
+
+        // Reject if oracle has already produced a result (market is effectively resolved).
         if market.oracle_result.is_some() {
             return Err(Error::MarketResolved);
         }


### PR DESCRIPTION
Closes #559

---

## Problem

`ExtensionValidator::validate_extension_conditions` used ad-hoc state checks that were incomplete and returned misleading errors:

- `Resolved` → `MarketResolved` (correct error, wrong signal for callers)
- `!= Active` → `MarketClosed` (catches `Ended`, `Closed`, `Cancelled`, `Disputed` but with a wrong error code)
- No check that the resulting `new_end_time` is strictly in the future — an extension on a market whose `end_time` is 1 second away could produce a new deadline that is still in the past

## Changes

**`extensions.rs` — `ExtensionValidator::validate_extension_conditions`**

- Replace the two `if` state checks with an exhaustive `match` that explicitly rejects every non-`Active` state (`Resolved`, `Closed`, `Cancelled`, `Ended`, `Disputed`) with `ExtensionDenied` (416)
- Add post-extension deadline guard: compute `new_end_time = end_time + days` and reject if `new_end_time <= current_time`
- Existing `current_time >= end_time` check now returns `ExtensionDenied` instead of `MarketClosed`

**`event_management_tests.rs`**

- `test_extend_deadline_resolved_market`: updated expected error from `MarketResolved` to `ExtensionDenied`
- `test_extend_deadline_after_end_time_rejected`: extend after `end_time` without resolving
- `test_extend_deadline_cap_exceeded`: two extensions whose cumulative days exceed `max_extension_days`
- `test_extend_market_closed_state_rejected`: `extend_market` on a closed market

## Acceptance criteria

- [x] Extension after `Resolved`/`Closed`/`Cancelled`/`Ended`/`Disputed` returns `ExtensionDenied`
- [x] Extension when `current_time >= end_time` returns `ExtensionDenied`
- [x] Extension where resulting deadline is not strictly future returns `ExtensionDenied`
- [x] Cumulative extension cap enforced via existing `check_extension_limits`
- [x] All new edge cases covered by tests