### PR TITLE
  feat: implement per-market cumulative extension cap (#672)

### DIFF
--- a/contracts/predictify-hybrid/src/err.rs
+++ b/contracts/predictify-hybrid/src/err.rs
@@ -189,6 +189,8 @@ pub enum Error {
     CBError = 504,
     /// Rate limit exceeded. Too many requests in the time window.
     RateLimitExceeded = 505,
+    /// Cumulative extension cap reached; no further extensions allowed for this market.
+    CumulativeExtensionCapHit = 506,
 }
 
 // ===== ERROR CATEGORIZATION AND RECOVERY SYSTEM =====
@@ -1428,6 +1430,7 @@ impl Error {
             Error::CBOpen => "Circuit breaker is open (operations blocked)",
             Error::CBError => "Generic circuit breaker subsystem error",
             Error::RateLimitExceeded => "Rate limit exceeded; too many requests in the time window",
+            Error::CumulativeExtensionCapHit => "Cumulative extension cap reached; no further extensions allowed for this market",
         }
     }
 
@@ -1522,6 +1525,7 @@ impl Error {
             Error::CBOpen => "CIRCUIT_BREAKER_OPEN",
             Error::CBError => "CIRCUIT_BREAKER_ERROR",
             Error::RateLimitExceeded => "RATE_LIMIT_EXCEEDED",
+            Error::CumulativeExtensionCapHit => "CUMULATIVE_EXTENSION_CAP_HIT",
         }
     }
 }
@@ -1623,6 +1627,8 @@ mod tests {
             Error::CBNotOpen,
             Error::CBOpen,
             Error::CBError,
+            Error::RateLimitExceeded,
+            Error::CumulativeExtensionCapHit,
         ]
     }
 

--- a/contracts/predictify-hybrid/src/extensions.rs
+++ b/contracts/predictify-hybrid/src/extensions.rs
@@ -11,6 +11,7 @@ use crate::types::*;
 /// - Extension events and logging
 /// - Extension history tracking
 /// - Extension analytics and reporting
+/// - Per-market cumulative extension cap with audit event on cap hit
 
 // ===== EXTENSION CONSTANTS =====
 // Note: These constants are now managed by the config module
@@ -20,6 +21,11 @@ const MAX_EXTENSION_DAYS: u32 = crate::config::MAX_EXTENSION_DAYS;
 const MIN_EXTENSION_DAYS: u32 = crate::config::MIN_EXTENSION_DAYS;
 const EXTENSION_FEE_PER_DAY: i128 = crate::config::EXTENSION_FEE_PER_DAY; // 1 XLM per day in stroops
 const MAX_TOTAL_EXTENSIONS: u32 = crate::config::MAX_TOTAL_EXTENSIONS;
+
+/// Storage key for the admin-configurable cumulative extension cap (in days).
+/// Stored under `Symbol::new(env, "cum_ext_cap")` in persistent storage.
+/// Defaults to 0 (no cap) when absent.
+const CUMULATIVE_CAP_KEY: &str = "cum_ext_cap";
 
 // ===== EXTENSION MANAGEMENT =====
 
@@ -192,8 +198,11 @@ impl ExtensionManager {
         // Validate extension conditions
         ExtensionValidator::validate_extension_conditions(env, &market_id, additional_days)?;
 
-        // Check extension limits
+        // Check per-call extension limits
         ExtensionValidator::check_extension_limits(env, &market_id, additional_days)?;
+
+        // Check cumulative extension cap for this market
+        ExtensionValidator::check_cumulative_cap(env, &market_id, additional_days)?;
 
         // Verify admin permissions
         ExtensionValidator::can_extend_market(env, &market_id, &admin)?;
@@ -215,6 +224,9 @@ impl ExtensionManager {
 
         // Store updated market
         MarketStateManager::update_market(env, &market_id, &market);
+
+        // Update the cumulative extension total for this market
+        ExtensionUtils::increment_extension_total(env, &market_id, additional_days);
 
         // Emit extension event
         ExtensionUtils::emit_extension_event(env, &market_id, additional_days, &admin);
@@ -653,6 +665,53 @@ impl ExtensionValidator {
 
         Ok(())
     }
+
+    /// Check cumulative extension cap.
+    ///
+    /// Reads the admin-configured cap (days) stored under `CUMULATIVE_CAP_KEY`.
+    /// A cap value of `0` means no cumulative cap is enforced.
+    /// When the cap is set, the proposed extension is checked against the
+    /// running total stored under `DataKey::MarketExtensionTotal(market_id)`.
+    /// On rejection an audit event is emitted before returning the error.
+    pub fn check_cumulative_cap(
+        env: &Env,
+        market_id: &Symbol,
+        additional_days: u32,
+    ) -> Result<(), Error> {
+        let cap_key = Symbol::new(env, CUMULATIVE_CAP_KEY);
+        let cap: u32 = env
+            .storage()
+            .persistent()
+            .get(&cap_key)
+            .unwrap_or(0u32);
+
+        // 0 means no cap configured — skip check
+        if cap == 0 {
+            return Ok(());
+        }
+
+        let total_key = crate::storage::DataKey::MarketExtensionTotal(market_id.clone());
+        let current_total: u32 = env
+            .storage()
+            .persistent()
+            .get(&total_key)
+            .unwrap_or(0u32);
+
+        let new_total = current_total
+            .checked_add(additional_days)
+            .ok_or(Error::CumulativeExtensionCapHit)?;
+
+        if new_total > cap {
+            // Emit audit event before returning the error
+            env.events().publish(
+                (symbol_short!("cum_cap"), market_id.clone()),
+                (current_total, cap),
+            );
+            return Err(Error::CumulativeExtensionCapHit);
+        }
+
+        Ok(())
+    }
 }
 
 // ===== EXTENSION UTILITIES =====
@@ -661,6 +720,15 @@ impl ExtensionValidator {
 pub struct ExtensionUtils;
 
 impl ExtensionUtils {
+    /// Increment the persistent cumulative extension total for a market.
+    /// Called after a successful extension so the counter is monotone-increasing.
+    pub fn increment_extension_total(env: &Env, market_id: &Symbol, additional_days: u32) {
+        let key = crate::storage::DataKey::MarketExtensionTotal(market_id.clone());
+        let current: u32 = env.storage().persistent().get(&key).unwrap_or(0u32);
+        let new_total = current.saturating_add(additional_days);
+        env.storage().persistent().set(&key, &new_total);
+    }
+
     /// Handle extension fees
     pub fn handle_extension_fees(
         env: &Env,

--- a/contracts/predictify-hybrid/src/extensions_cumulative_cap_tests.rs
+++ b/contracts/predictify-hybrid/src/extensions_cumulative_cap_tests.rs
@@ -1,0 +1,243 @@
+//! Tests for the per-market cumulative extension cap (issue #672).
+//!
+//! Coverage:
+//! - No cap set → extensions are unrestricted by cumulative logic
+//! - Cap set → first extension within cap succeeds
+//! - Cap set → extension that would exceed cap is rejected with CumulativeExtensionCapHit
+//! - Audit event is emitted when the cap rejects an extension
+//! - Cumulative total is monotone-increasing across successive extensions
+//! - Unauthorized caller cannot change the cap
+//! - get_cumulative_extension_total returns correct running total
+//! - Exact cap boundary is allowed; one-over is rejected
+
+#![cfg(test)]
+
+use crate::errors::Error;
+use crate::{PredictifyHybrid, PredictifyHybridClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, String, Symbol, TryFromVal, Val,
+};
+
+// ===== TEST SETUP =====
+
+struct Setup {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+}
+
+impl Setup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let contract_id = env.register(PredictifyHybrid, ());
+
+        let token_admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_id = token_contract.address();
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&Symbol::new(&env, "TokenID"), &token_id);
+            crate::circuit_breaker::CircuitBreaker::initialize(&env).unwrap();
+        });
+
+        let client = PredictifyHybridClient::new(&env, &contract_id);
+        client.initialize(&admin, &None, &None);
+
+        env.as_contract(&contract_id, || {
+            crate::circuit_breaker::CircuitBreaker::initialize(&env).unwrap();
+        });
+
+        Self { env, contract_id, admin }
+    }
+
+    fn create_market(&self, duration_days: u32) -> Symbol {
+        use crate::types::{OracleConfig, OracleProvider};
+        let client = PredictifyHybridClient::new(&self.env, &self.contract_id);
+        let oracle_config = OracleConfig::new(
+            OracleProvider::reflector(),
+            Address::from_str(
+                &self.env,
+                "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            ),
+            String::from_str(&self.env, "BTC/USD"),
+            5_000_000,
+            String::from_str(&self.env, "gt"),
+        );
+        client.create_market(
+            &self.admin,
+            &String::from_str(&self.env, "Will BTC hit 100k?"),
+            &vec![
+                &self.env,
+                String::from_str(&self.env, "Yes"),
+                String::from_str(&self.env, "No"),
+            ],
+            &duration_days,
+            &oracle_config,
+            &None,
+            &86400u64,
+            &None,
+            &None,
+            &None,
+        )
+    }
+
+    fn extend(
+        &self,
+        market_id: &Symbol,
+        days: u32,
+    ) -> Result<Result<(), soroban_sdk::ConversionError>, Result<Error, soroban_sdk::InvokeError>> {
+        let client = PredictifyHybridClient::new(&self.env, &self.contract_id);
+        client.try_extend_deadline(
+            &self.admin,
+            market_id,
+            &days,
+            &String::from_str(&self.env, "test extension"),
+        )
+    }
+}
+
+// ===== TESTS =====
+
+/// When no cumulative cap is configured (default 0), extensions are unrestricted.
+#[test]
+fn test_no_cap_allows_multiple_extensions() {
+    let s = Setup::new();
+    let market_id = s.create_market(90);
+
+    assert!(s.extend(&market_id, 5).is_ok());
+    assert!(s.extend(&market_id, 5).is_ok());
+}
+
+/// After setting a cap, an extension within the cap succeeds.
+#[test]
+fn test_cap_set_extension_within_cap_succeeds() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(60);
+
+    client.set_cumulative_extension_cap(&s.admin, &20u32);
+
+    assert!(s.extend(&market_id, 10).is_ok());
+}
+
+/// Extending beyond the configured cap is rejected with CumulativeExtensionCapHit.
+#[test]
+fn test_cap_exceeded_returns_error() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(60);
+
+    client.set_cumulative_extension_cap(&s.admin, &15u32);
+
+    // First extension: 10 days — within cap
+    assert!(s.extend(&market_id, 10).is_ok());
+
+    // Second extension: 6 days — would push total to 16, exceeding 15-day cap
+    let result = s.extend(&market_id, 6);
+    assert_eq!(result, Err(Ok(Error::CumulativeExtensionCapHit)));
+}
+
+/// An audit event is emitted with topic `cum_cap` when the cap rejects an extension.
+#[test]
+fn test_audit_event_emitted_on_cap_hit() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(60);
+
+    client.set_cumulative_extension_cap(&s.admin, &10u32);
+    assert!(s.extend(&market_id, 7).is_ok());
+
+    // This call hits the cap and should emit the audit event
+    let _ = s.extend(&market_id, 5);
+
+    let cap_topic = soroban_sdk::symbol_short!("cum_cap");
+    let all = s.env.events().all();
+    let found = all.events().iter().any(|e| {
+        let body = match &e.body {
+            soroban_sdk::xdr::ContractEventBody::V0(v0) => v0,
+        };
+        body.topics.iter().any(|t| {
+            let sym: Option<Symbol> = Symbol::try_from_val(&s.env, t).ok();
+            sym.map(|s| s == cap_topic).unwrap_or(false)
+        })
+    });
+    assert!(found, "expected cum_cap audit event to be emitted on cap hit");
+}
+
+/// Cumulative total is monotone-increasing: each successful extension increments it.
+#[test]
+fn test_cumulative_total_is_monotone_increasing() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(90);
+
+    client.set_cumulative_extension_cap(&s.admin, &30u32);
+
+    let before = client.get_cumulative_extension_total(&market_id);
+
+    assert!(s.extend(&market_id, 5).is_ok());
+    let after_first = client.get_cumulative_extension_total(&market_id);
+
+    assert!(s.extend(&market_id, 3).is_ok());
+    let after_second = client.get_cumulative_extension_total(&market_id);
+
+    assert!(after_first > before, "total must increase after first extension");
+    assert!(after_second > after_first, "total must increase after second extension");
+    assert_eq!(after_second - before, 8, "total must equal sum of extended days");
+}
+
+/// Non-admin cannot set the cumulative extension cap.
+#[test]
+fn test_unauthorized_cannot_set_cap() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let rando = Address::generate(&s.env);
+
+    let result = client.try_set_cumulative_extension_cap(&rando, &20u32);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+/// get_cumulative_extension_total returns 0 before any extensions.
+#[test]
+fn test_cumulative_total_starts_at_zero() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(30);
+
+    let total = client.get_cumulative_extension_total(&market_id);
+    assert_eq!(total, 0);
+}
+
+/// Exactly hitting the cap (new_total == cap) is allowed.
+#[test]
+fn test_extension_exactly_at_cap_succeeds() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(60);
+
+    client.set_cumulative_extension_cap(&s.admin, &10u32);
+
+    // Exactly 10 days == cap → must succeed
+    assert!(s.extend(&market_id, 10).is_ok());
+}
+
+/// Once the cap is hit exactly, any further extension is rejected.
+#[test]
+fn test_extension_beyond_cap_after_exact_hit_rejected() {
+    let s = Setup::new();
+    let client = PredictifyHybridClient::new(&s.env, &s.contract_id);
+    let market_id = s.create_market(90);
+
+    client.set_cumulative_extension_cap(&s.admin, &10u32);
+    assert!(s.extend(&market_id, 10).is_ok());
+
+    // Now at cap; 1 more day must be rejected
+    let result = s.extend(&market_id, 1);
+    assert_eq!(result, Err(Ok(Error::CumulativeExtensionCapHit)));
+}

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -127,6 +127,9 @@ mod upgrade_manager_tests;
 // #[cfg(test)]
 // mod governance_tests;
 
+#[cfg(test)]
+mod extensions_cumulative_cap_tests;
+
 #[cfg(any())]
 mod category_tags_tests;
 #[cfg(test)]
@@ -4955,6 +4958,42 @@ impl PredictifyHybrid {
             additional_days,
             reason,
         )
+    }
+
+    /// Sets the admin-configurable cumulative extension cap (in days) that applies
+    /// globally to all markets. A value of `0` disables the cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] when the caller is not the primary admin.
+    ///
+    /// # Events
+    ///
+    /// Emits no events; purely a configuration write.
+    pub fn set_cumulative_extension_cap(
+        env: Env,
+        admin: Address,
+        cap_days: u32,
+    ) -> Result<(), Error> {
+        Self::require_primary_admin(&env, &admin)?;
+        let key = Symbol::new(&env, "cum_ext_cap");
+        env.storage().persistent().set(&key, &cap_days);
+        Ok(())
+    }
+
+    /// Returns the running cumulative extension total (in days) for a given market.
+    /// Returns `0` when no extensions have been recorded yet.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] when validation, authorization, storage, or subsystem checks fail.
+    ///
+    /// # Events
+    ///
+    /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
+    pub fn get_cumulative_extension_total(env: Env, market_id: Symbol) -> Result<u32, Error> {
+        let key = crate::storage::DataKey::MarketExtensionTotal(market_id);
+        Ok(env.storage().persistent().get(&key).unwrap_or(0u32))
     }
 
     // ===== STORAGE OPTIMIZATION FUNCTIONS =====

--- a/contracts/predictify-hybrid/src/storage.rs
+++ b/contracts/predictify-hybrid/src/storage.rs
@@ -29,6 +29,8 @@ pub enum DataKey {
     Whitelisted(Address),
     Blacklisted(Address),
     ArchivedMarket(Symbol, u64),
+    /// Cumulative days extended for a given market (u32).
+    MarketExtensionTotal(Symbol),
 }
 
 /// Storage format version for migration tracking


### PR DESCRIPTION
Summary
  
  closes #672
 Adds a configurable cumulative extension cap per market, preventing a single
  market from being extended beyond an admin-set total day limit across all extension calls.
  
  Changes
  
  storage.rs
  
  - Added DataKey::MarketExtensionTotal(Symbol) — persistent counter tracking total days
  extended per market.
  
  extensions.rs
  
  - Added ExtensionValidator::check_cumulative_cap — reads the admin-configured cap
  (cum_ext_cap) from persistent storage; a value of 0 disables the cap. Emits an audit event
  before rejecting a cap-exceeding request.
  - Added ExtensionUtils::increment_extension_total — increments the per-market counter after
  each successful extension.
  - Wired both into ExtensionManager::extend_market_deadline, after the existing per-call
  limit check.
  
  err.rs
  
  - Added CumulativeExtensionCapHit = 506 with message and code string.
  
  extensions_cumulative_cap_tests.rs
  
  - Full test coverage: no cap set (unrestricted), cap enforced on overflow, running total
  correctness, audit event emitted on rejection.
  
  Testing
  
  cargo test -p predictify-hybrid
  
  All existing and new tests pass.
