### PR TITLE
feat: governance vote salt + quorum decay (#712)

### DIFF
--- a/contracts/predictify-hybrid/README.md
+++ b/contracts/predictify-hybrid/README.md
@@ -708,13 +708,40 @@ soroban contract invoke --id <contract_id> -- set_token_contract --token_contrac
 - **Fallback**: TWAP used as fallback if latest price unavailable
 - **Caching**: Consider caching oracle results for efficiency
 
+## Governance
+
+The contract includes a full on-chain governance module (`src/governance.rs`) supporting:
+
+- **Proposals**: Any address can create a proposal with an optional contract execution target.
+- **Direct voting**: Cast a FOR/AGAINST vote within the open voting window.
+- **Commit-reveal voting (vote salt)**: Submit a salted commitment hash first, reveal later — prevents front-running and precomputation of results before the window closes.
+- **Quorum decay**: The required quorum decreases linearly from the base quorum toward a configurable floor over the proposal lifetime, preventing stale proposals from lingering forever.
+- **Delegation**: Delegate vote weight (up to 50 incoming delegations per address).
+
+See [`docs/contracts/GOVERNANCE.md`](../../docs/contracts/GOVERNANCE.md) for the full API reference.
+
+### Vote Salt Quick Reference
+
+```text
+commit_vote(voter, proposal_id, sha256(salt ++ support_byte))  // hide preference
+reveal_vote(voter, proposal_id, salt, support)                  // tally vote
+```
+
+`support_byte = 0x01` (FOR) · `0x00` (AGAINST)
+
+### Quorum Decay Quick Reference
+
+```rust
+QuorumDecay { floor_bps: 2000, halving_seconds: 86400 }
+// floor = 20 % of base quorum; full decay after 2 days
+```
+
 ## Future Enhancements
 
 1. **Multiple Oracle Support**: Add more oracle providers
 2. **Oracle Aggregation**: Combine multiple oracle results
 3. **Dynamic Asset Support**: Parse feed_id for different asset pairs
 4. **Price Validation**: Add confidence intervals and staleness checks
-5. **Governance**: Add DAO-style governance for parameter updates
 
 ## Troubleshooting
 

--- a/contracts/predictify-hybrid/src/events.rs
+++ b/contracts/predictify-hybrid/src/events.rs
@@ -1370,6 +1370,16 @@ pub struct GovernanceVoteCastEvent {
     pub timestamp: u64,
 }
 
+/// Governance vote committed event — emitted when a voter submits a salted commitment
+/// during the commit phase of commit-reveal voting.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceVoteCommittedEvent {
+    pub proposal_id: Symbol,
+    pub voter: Address,
+    pub timestamp: u64,
+}
+
 /// Event emitted when a fallback oracle is used for market resolution.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3772,6 +3782,18 @@ impl EventEmitter {
         Self::store_event(env, &symbol_short!("gov_vote"), &event);
         env.events()
             .publish((symbol_short!("gov_vote"), proposal_id.clone()), event);
+    }
+
+    /// Emit governance vote committed event (commit phase of commit-reveal)
+    pub fn emit_governance_vote_committed(env: &Env, proposal_id: &Symbol, voter: &Address) {
+        let event = GovernanceVoteCommittedEvent {
+            proposal_id: proposal_id.clone(),
+            voter: voter.clone(),
+            timestamp: env.ledger().timestamp(),
+        };
+        Self::store_event(env, &symbol_short!("gov_cmit"), &event);
+        env.events()
+            .publish((symbol_short!("gov_cmit"), proposal_id.clone()), event);
     }
 
     /// Emit governance proposal executed event

--- a/contracts/predictify-hybrid/src/governance.rs
+++ b/contracts/predictify-hybrid/src/governance.rs
@@ -1,5 +1,5 @@
 use crate::events::EventEmitter;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 
 /// ---------- CONTRACT TYPES ----------
 
@@ -49,6 +49,8 @@ enum StorageKey {
     /// Tracks how many delegators are currently delegating to a given address.
     /// Capped at MAX_INCOMING_DELEGATIONS to bound storage.
     DelegateCount(Address),
+    /// Commit-reveal: stores sha256(salt ++ [0|1]) per (proposal, voter).
+    VoteCommitment(Symbol, Address),
 }
 
 /// Maximum number of delegators that may point to a single delegate address.
@@ -81,6 +83,12 @@ pub enum GovernanceError {
     NoDelegationSet,
     /// Delegation would create a cycle (A→B→A).
     DelegationCycle,
+    /// Caller has not committed a vote for this proposal yet.
+    NoCommitment,
+    /// The revealed (salt, support) pair does not match the stored commitment.
+    InvalidReveal,
+    /// A commitment already exists for this (proposal, voter) pair.
+    CommitmentExists,
 }
 
 /// ---------- CONTRACT ----------
@@ -300,6 +308,160 @@ impl GovernanceContract {
             .set(&StorageKey::Proposal(proposal_id.clone()), &p);
 
         // Emit governance vote event
+        EventEmitter::emit_governance_vote_cast(&env, &proposal_id, &voter, support);
+
+        Ok(())
+    }
+
+    /// Commit a salted vote for a proposal (commit phase of commit-reveal).
+    ///
+    /// The caller supplies a 32-byte commitment = `sha256(salt ++ support_byte)` where
+    /// `support_byte` is `0x01` for FOR and `0x00` for AGAINST.  The commitment is
+    /// stored on-chain but the actual vote preference stays hidden until `reveal_vote`.
+    ///
+    /// Constraints
+    /// - Voting window must be open (`start_time <= now < end_time`).
+    /// - Each (proposal, voter) pair may only commit once.
+    /// - The voter must not have already voted via the direct `vote()` path.
+    pub fn commit_vote(
+        env: Env,
+        voter: Address,
+        proposal_id: Symbol,
+        commitment: BytesN<32>,
+    ) -> Result<(), GovernanceError> {
+        voter.require_auth();
+
+        let p: GovernanceProposal = env
+            .storage()
+            .persistent()
+            .get::<StorageKey, GovernanceProposal>(&StorageKey::Proposal(proposal_id.clone()))
+            .ok_or(GovernanceError::ProposalNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if now < p.start_time {
+            return Err(GovernanceError::VotingNotStarted);
+        }
+        if now >= p.end_time {
+            return Err(GovernanceError::VotingEnded);
+        }
+
+        // Guard: direct vote already cast
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::Vote(proposal_id.clone(), voter.clone()))
+        {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+
+        // Guard: commitment already stored
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::VoteCommitment(proposal_id.clone(), voter.clone()))
+        {
+            return Err(GovernanceError::CommitmentExists);
+        }
+
+        env.storage().persistent().set(
+            &StorageKey::VoteCommitment(proposal_id.clone(), voter.clone()),
+            &commitment,
+        );
+
+        EventEmitter::emit_governance_vote_committed(&env, &proposal_id, &voter);
+
+        Ok(())
+    }
+
+    /// Reveal a previously committed vote (reveal phase of commit-reveal).
+    ///
+    /// The contract recomputes `sha256(salt ++ support_byte)` and verifies it matches
+    /// the stored commitment.  On success the vote weight is tallied and the commitment
+    /// entry is replaced with the recorded vote, preventing double-reveals.
+    ///
+    /// Constraints
+    /// - A commitment for this (proposal, voter) must exist.
+    /// - Voting window must still be open when revealing.
+    /// - The voter must not have already been counted (guards against re-reveal).
+    pub fn reveal_vote(
+        env: Env,
+        voter: Address,
+        proposal_id: Symbol,
+        salt: Bytes,
+        support: bool,
+    ) -> Result<(), GovernanceError> {
+        voter.require_auth();
+
+        let stored: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get::<StorageKey, BytesN<32>>(&StorageKey::VoteCommitment(
+                proposal_id.clone(),
+                voter.clone(),
+            ))
+            .ok_or(GovernanceError::NoCommitment)?;
+
+        // Verify commitment: sha256(salt ++ support_byte)
+        let mut preimage = Bytes::new(&env);
+        preimage.append(&salt);
+        preimage.push_back(if support { 1u8 } else { 0u8 });
+        let expected: BytesN<32> = env.crypto().sha256(&preimage).into();
+        if stored != expected {
+            return Err(GovernanceError::InvalidReveal);
+        }
+
+        let mut p: GovernanceProposal = env
+            .storage()
+            .persistent()
+            .get::<StorageKey, GovernanceProposal>(&StorageKey::Proposal(proposal_id.clone()))
+            .ok_or(GovernanceError::ProposalNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if now < p.start_time {
+            return Err(GovernanceError::VotingNotStarted);
+        }
+        if now >= p.end_time {
+            return Err(GovernanceError::VotingEnded);
+        }
+
+        // Guard: already counted via direct vote or prior reveal
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::Vote(proposal_id.clone(), voter.clone()))
+        {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+
+        // Tally with delegation weight
+        let delegated: u128 = env
+            .storage()
+            .persistent()
+            .get::<StorageKey, u32>(&StorageKey::DelegateCount(voter.clone()))
+            .unwrap_or(0) as u128;
+        let weight: u128 = 1 + delegated;
+
+        if support {
+            p.for_votes += weight;
+            env.storage()
+                .persistent()
+                .set(&StorageKey::Vote(proposal_id.clone(), voter.clone()), &1i32);
+        } else {
+            p.against_votes += weight;
+            env.storage()
+                .persistent()
+                .set(&StorageKey::Vote(proposal_id.clone(), voter.clone()), &2i32);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Proposal(proposal_id.clone()), &p);
+
+        // Remove commitment after reveal to free storage
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::VoteCommitment(proposal_id.clone(), voter.clone()));
+
         EventEmitter::emit_governance_vote_cast(&env, &proposal_id, &voter, support);
 
         Ok(())

--- a/contracts/predictify-hybrid/src/governance_tests.rs
+++ b/contracts/predictify-hybrid/src/governance_tests.rs
@@ -3,7 +3,7 @@
 use crate::governance::{GovernanceContract, GovernanceError, QuorumDecay};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, Env, String, Symbol,
+    Address, Bytes, BytesN, Env, String, Symbol,
 };
 
 struct GovernanceFixture {
@@ -132,6 +132,43 @@ impl GovernanceFixture {
     fn get_quorum_decay(&self) -> Option<QuorumDecay> {
         self.env.as_contract(&self.contract_id, || {
             GovernanceContract::get_quorum_decay(self.env.clone())
+        })
+    }
+
+    fn commit_vote(
+        &self,
+        voter: Address,
+        proposal_id: Symbol,
+        commitment: BytesN<32>,
+    ) -> Result<(), GovernanceError> {
+        self.env.as_contract(&self.contract_id, || {
+            GovernanceContract::commit_vote(
+                self.env.clone(),
+                voter,
+                proposal_id,
+                commitment,
+            )
+        })
+    }
+
+    fn reveal_vote(
+        &self,
+        voter: Address,
+        proposal_id: Symbol,
+        salt: Bytes,
+        support: bool,
+    ) -> Result<(), GovernanceError> {
+        self.env.as_contract(&self.contract_id, || {
+            GovernanceContract::reveal_vote(self.env.clone(), voter, proposal_id, salt, support)
+        })
+    }
+
+    /// Build a commitment = sha256(salt ++ support_byte) inside the contract context.
+    fn make_commitment(&self, salt: &Bytes, support: bool) -> BytesN<32> {
+        let mut preimage = salt.clone();
+        preimage.push_back(if support { 1u8 } else { 0u8 });
+        self.env.as_contract(&self.contract_id, || {
+            self.env.crypto().sha256(&preimage).into()
         })
     }
 }
@@ -614,4 +651,183 @@ fn quorum_decay_monotonic_non_increasing() {
         );
         prev = cur;
     }
+}
+
+// ---- Vote Salt (Commit-Reveal) Tests ----
+
+#[test]
+fn vote_salt_commit_reveal_full_lifecycle() {
+    let fixture = GovernanceFixture::new(100, 2);
+    let proposal_id = fixture.create_noop_proposal("salt_ok_1");
+
+    let salt_one = Bytes::from_slice(&fixture.env, b"random-salt-v1-a");
+    let salt_two = Bytes::from_slice(&fixture.env, b"random-salt-v1-b");
+
+    let commitment_one = fixture.make_commitment(&salt_one, true);
+    let commitment_two = fixture.make_commitment(&salt_two, true);
+
+    // Commit phase
+    fixture
+        .commit_vote(fixture.voter_one.clone(), proposal_id.clone(), commitment_one)
+        .unwrap();
+    fixture
+        .commit_vote(fixture.voter_two.clone(), proposal_id.clone(), commitment_two)
+        .unwrap();
+
+    // Reveal phase (within voting window)
+    fixture
+        .reveal_vote(fixture.voter_one.clone(), proposal_id.clone(), salt_one, true)
+        .unwrap();
+    fixture
+        .reveal_vote(fixture.voter_two.clone(), proposal_id.clone(), salt_two, true)
+        .unwrap();
+
+    // Advance past end_time and validate
+    fixture.advance_time(100);
+    let result = fixture.validate(proposal_id).unwrap();
+    assert_eq!(result, (true, String::from_str(&fixture.env, "passed")));
+}
+
+#[test]
+fn vote_salt_wrong_reveal_rejected() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_bad_1");
+
+    let real_salt = Bytes::from_slice(&fixture.env, b"correct-salt-xyz");
+    let wrong_salt = Bytes::from_slice(&fixture.env, b"wrong-salt-xyz00");
+
+    let commitment = fixture.make_commitment(&real_salt, true);
+    fixture
+        .commit_vote(fixture.voter_one.clone(), proposal_id.clone(), commitment)
+        .unwrap();
+
+    // Wrong salt → InvalidReveal
+    let err = fixture.reveal_vote(
+        fixture.voter_one.clone(),
+        proposal_id.clone(),
+        wrong_salt,
+        true,
+    );
+    assert_eq!(err, Err(GovernanceError::InvalidReveal));
+
+    // Wrong support value → InvalidReveal
+    let err2 = fixture.reveal_vote(
+        fixture.voter_one.clone(),
+        proposal_id.clone(),
+        real_salt.clone(),
+        false, // committed FOR but revealing AGAINST
+    );
+    assert_eq!(err2, Err(GovernanceError::InvalidReveal));
+
+    // Correct reveal succeeds
+    fixture
+        .reveal_vote(fixture.voter_one.clone(), proposal_id, real_salt, true)
+        .unwrap();
+}
+
+#[test]
+fn vote_salt_duplicate_commit_rejected() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_dup_1");
+
+    let salt = Bytes::from_slice(&fixture.env, b"salt-dup-test-aa");
+    let commitment = fixture.make_commitment(&salt, true);
+
+    fixture
+        .commit_vote(fixture.voter_one.clone(), proposal_id.clone(), commitment.clone())
+        .unwrap();
+
+    // Second commit by same voter → CommitmentExists
+    let err = fixture.commit_vote(fixture.voter_one.clone(), proposal_id, commitment);
+    assert_eq!(err, Err(GovernanceError::CommitmentExists));
+}
+
+#[test]
+fn vote_salt_reveal_without_commit_rejected() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_nocommit_1");
+
+    let salt = Bytes::from_slice(&fixture.env, b"some-salt-value1");
+    let err = fixture.reveal_vote(fixture.voter_one.clone(), proposal_id, salt, true);
+    assert_eq!(err, Err(GovernanceError::NoCommitment));
+}
+
+#[test]
+fn vote_salt_commit_rejected_after_voting_ends() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_late_1");
+
+    fixture.advance_time(100); // past end_time
+
+    let salt = Bytes::from_slice(&fixture.env, b"too-late-salt-aa");
+    let commitment = fixture.make_commitment(&salt, true);
+    let err = fixture.commit_vote(fixture.voter_one.clone(), proposal_id, commitment);
+    assert_eq!(err, Err(GovernanceError::VotingEnded));
+}
+
+#[test]
+fn vote_salt_reveal_rejected_after_voting_ends() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_lrev_1");
+
+    let salt = Bytes::from_slice(&fixture.env, b"late-reveal-salt");
+    let commitment = fixture.make_commitment(&salt, true);
+
+    // Commit while voting is open
+    fixture
+        .commit_vote(fixture.voter_one.clone(), proposal_id.clone(), commitment)
+        .unwrap();
+
+    // Advance past end_time before reveal
+    fixture.advance_time(100);
+
+    let err = fixture.reveal_vote(fixture.voter_one.clone(), proposal_id, salt, true);
+    assert_eq!(err, Err(GovernanceError::VotingEnded));
+}
+
+#[test]
+fn vote_salt_double_reveal_rejected() {
+    let fixture = GovernanceFixture::new(200, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_drev_1");
+
+    let salt = Bytes::from_slice(&fixture.env, b"double-reveal-s1");
+    let commitment = fixture.make_commitment(&salt, true);
+
+    fixture
+        .commit_vote(fixture.voter_one.clone(), proposal_id.clone(), commitment)
+        .unwrap();
+    fixture
+        .reveal_vote(fixture.voter_one.clone(), proposal_id.clone(), salt.clone(), true)
+        .unwrap();
+
+    // Second reveal → AlreadyVoted (commitment removed, Vote entry exists)
+    let err = fixture.reveal_vote(fixture.voter_one.clone(), proposal_id, salt, true);
+    assert_eq!(err, Err(GovernanceError::AlreadyVoted));
+}
+
+#[test]
+fn vote_salt_direct_vote_then_commit_rejected() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let proposal_id = fixture.create_noop_proposal("salt_dv_1");
+
+    // Cast direct vote first
+    fixture
+        .vote(fixture.voter_one.clone(), proposal_id.clone(), true)
+        .unwrap();
+
+    // Then try to commit → AlreadyVoted
+    let salt = Bytes::from_slice(&fixture.env, b"direct-then-salt");
+    let commitment = fixture.make_commitment(&salt, true);
+    let err = fixture.commit_vote(fixture.voter_one.clone(), proposal_id, commitment);
+    assert_eq!(err, Err(GovernanceError::AlreadyVoted));
+}
+
+#[test]
+fn vote_salt_commit_not_found_wrong_proposal() {
+    let fixture = GovernanceFixture::new(100, 1);
+    let real_salt = Bytes::from_slice(&fixture.env, b"salt-real-propid");
+    let fake_proposal = Symbol::new(&fixture.env, "no_exist");
+    let commitment = fixture.make_commitment(&real_salt, true);
+    let err = fixture.commit_vote(fixture.voter_one.clone(), fake_proposal, commitment);
+    assert_eq!(err, Err(GovernanceError::ProposalNotFound));
 }

--- a/docs/contracts/GOVERNANCE.md
+++ b/docs/contracts/GOVERNANCE.md
@@ -5,25 +5,28 @@ This document specifies proposal lifecycle behavior for `contracts/predictify-hy
 ## Scope
 
 - Proposal creation and storage
-- Voting windows and vote accounting
-- Quorum and pass/fail conditions
+- Voting windows and vote accounting — including commit-reveal (salted votes)
+- Quorum, quorum decay, and pass/fail conditions
 - Proposal execution semantics
+- Delegation
 - Security invariants and explicit non-goals
 
 ## Lifecycle
 
 ### 1) Initialize
 
-`GovernanceContract::initialize(env, admin, voting_period_seconds, quorum_votes)`
+`GovernanceContract::initialize(env, admin, voting_period_seconds, quorum_votes, quorum_decay)`
 
 - One-time, idempotent setup.
 - Rejects invalid config where:
   - `voting_period_seconds <= 0`
   - `quorum_votes == 0`
+  - `quorum_decay.floor_bps > 10000` or `quorum_decay.halving_seconds == 0`
 - Stores:
   - admin address
   - voting period (seconds)
   - quorum threshold (`for_votes` minimum)
+  - optional `QuorumDecay` configuration
   - empty proposal list
 
 ### 2) Create Proposal
@@ -42,18 +45,47 @@ A proposal is accepted only when all checks pass:
 
 A proposal starts immediately at current ledger timestamp and ends at `start + voting_period`.
 
-### 3) Vote
+### 3a) Direct Vote
 
-`GovernanceContract::vote(...) -> Result<(), GovernanceError>`
+`GovernanceContract::vote(env, voter, proposal_id, support) -> Result<(), GovernanceError>`
 
 Voting rules:
 
 - caller authorization: `voter.require_auth()`
-- one address, one vote per proposal
-- voting window is **inclusive start / exclusive end**:
-  - reject if `now < start_time` (`VotingNotStarted`)
-  - reject if `now >= end_time` (`VotingEnded`)
-- reject if proposal already executed
+- one address, one vote per proposal (includes revealed commit-reveal votes)
+- voting window: `[start_time, end_time)`
+- rejected if proposal already executed
+
+### 3b) Commit-Reveal Vote (Salted)
+
+Two-step process that prevents front-running and precomputation of vote outcomes:
+
+#### Commit Phase
+
+`GovernanceContract::commit_vote(env, voter, proposal_id, commitment) -> Result<(), GovernanceError>`
+
+- `commitment = sha256(salt ++ support_byte)` where `support_byte = 0x01` (FOR) or `0x00` (AGAINST)
+- Stored on-chain; vote preference is hidden until reveal.
+- One commitment per `(proposal, voter)` pair — cannot recommit.
+- Rejects if voter already cast a direct vote.
+- Voting window must be open.
+- Emits `GovernanceVoteCommittedEvent`.
+
+#### Reveal Phase
+
+`GovernanceContract::reveal_vote(env, voter, proposal_id, salt, support) -> Result<(), GovernanceError>`
+
+- Recomputes `sha256(salt ++ support_byte)` and verifies against stored commitment.
+- Tallies vote with delegation weight on match.
+- Returns `InvalidReveal` if salt or support do not match the commitment.
+- Returns `NoCommitment` if no commitment exists.
+- Voting window must still be open.
+- Removes commitment from storage after reveal (prevents double-reveal).
+- Re-uses `GovernanceVoteCastEvent` for the actual vote record.
+
+> **Security property**: Because voters only publish a hash, observers cannot determine vote
+> direction during the commit window.  Votes become legible only after reveal, protecting
+> against strategic last-second voting based on observed tally trends.
 
 ### 4) Validate
 
@@ -62,7 +94,9 @@ Voting rules:
 Validation availability and outcomes:
 
 - reject while voting still active (`VotingStillActive`) when `now < end_time`
-- fail when `for_votes < quorum_votes` (`"quorum not reached"`)
+- uses *effective quorum* (see Quorum Decay below)
+- fail when `for_votes < effective_quorum` (`"quorum not reached"`)
+  - if `for_votes < floor_quorum` an auto-rejection event is emitted
 - fail when `for_votes <= against_votes` (`"not enough for votes"`)
 - pass otherwise (`"passed"`)
 
@@ -82,32 +116,109 @@ Execution rules:
 
 If validation fails (quorum or vote majority), execution returns `NotPassed`.
 
+## Quorum Decay
+
+When initialized or configured with a `QuorumDecay` object, the effective quorum required for a proposal to pass decreases linearly over the proposal lifetime:
+
+```
+effective_quorum(elapsed) = base_quorum - (base_quorum - floor) * elapsed / (2 * halving_seconds)
+```
+
+- `floor = base_quorum * floor_bps / 10000`
+- Decay is complete (quorum equals floor) after `elapsed >= 2 * halving_seconds`
+- Quorum is monotone non-increasing
+
+### Fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `floor_bps` | `u32` | Floor as basis points of base quorum (≤ 10 000) |
+| `halving_seconds` | `u64` | Seconds to reach midpoint quorum (must be > 0) |
+
+### Admin API
+
+| Function | Description |
+|----------|-------------|
+| `set_quorum_decay(env, admin, decay)` | Set or disable decay config |
+| `get_quorum_decay(env)` | Read current decay config |
+
+## Delegation
+
+| Function | Description |
+|----------|-------------|
+| `set_delegate(env, delegator, delegate)` | Delegate vote weight to another address |
+| `unset_delegate(env, delegator)` | Remove active delegation |
+| `get_delegate(env, delegator)` | Query current delegate |
+
+Rules:
+- Each delegator holds at most **one** active delegation.
+- A delegate accepts at most **50** incoming delegations (griefing guard).
+- Self-delegation and two-hop cycles (A→B while B→A exists) are rejected.
+- Vote weight = `1 + incoming_delegation_count`.
+
+## Events
+
+| Symbol | Struct | Trigger |
+|--------|--------|---------|
+| `gov_prop` | `GovernanceProposalCreatedEvent` | Proposal created |
+| `gov_cmit` | `GovernanceVoteCommittedEvent` | Commit phase of commit-reveal |
+| `gov_vote` | `GovernanceVoteCastEvent` | Direct vote or revealed commit-reveal vote |
+| `gov_exec` | `GovernanceProposalExecutedEvent` | Proposal executed |
+| `gov_rej` | `GovernanceProposalAutoRejectedEvent` | Proposal auto-rejected (below floor quorum) |
+
+## Error Reference
+
+| Error | Cause |
+|-------|-------|
+| `ProposalExists` | Duplicate proposal id |
+| `ProposalNotFound` | Unknown proposal id |
+| `VotingNotStarted` | `now < start_time` |
+| `VotingEnded` | `now >= end_time` |
+| `VotingStillActive` | Validate/execute called before `end_time` |
+| `AlreadyVoted` | Voter already tallied |
+| `NotPassed` | Proposal failed validation |
+| `AlreadyExecuted` | Execute called twice |
+| `NotAdmin` | Non-admin called admin function |
+| `NotInitialized` | Governance not initialized |
+| `InvalidParams` | Zero/invalid config value |
+| `SelfDelegation` | Delegator == delegate |
+| `DelegationAlreadySet` | Delegator already has an active delegation |
+| `DelegateLimitReached` | Delegate at incoming-delegation cap |
+| `NoDelegationSet` | Unset called with no active delegation |
+| `DelegationCycle` | Two-hop cycle detected |
+| `NoCommitment` | Reveal called without a prior commit |
+| `InvalidReveal` | Hash mismatch — wrong salt or support value |
+| `CommitmentExists` | Second commit by same (proposal, voter) |
+
 ## Security Notes
 
 ### Threat Model (covered)
 
 - Unauthorized state changes via forged caller identities
-- Duplicate voting by same address
-- Parameter misuse that can cause ambiguous execution paths
+- Duplicate voting (both direct and commit-reveal paths are guarded)
+- Front-running / vote precomputation (mitigated by commit-reveal)
+- Parameter misuse causing ambiguous execution paths
 - Configuration mistakes that disable governance constraints
 - Premature execution before voting window closes
+- Delegation griefing (cap on incoming delegations + one-delegation-per-delegator limit)
 
 ### Invariants Enforced
 
 - `voting_period_seconds > 0`
 - `quorum_votes > 0`
 - Proposal IDs are unique
-- Votes are single-use per `(proposal_id, voter)`
+- Each `(proposal_id, voter)` pair contributes at most one vote to the tally
 - Voting only occurs in `[start_time, end_time)`
 - Execution occurs at most once per proposal
 - Passing requires both:
-  - `for_votes >= quorum_votes`
+  - `for_votes >= effective_quorum`
   - `for_votes > against_votes`
+- Commit-reveal: commitment is removed after reveal, preventing double-count
 
 ### Explicit Non-Goals
 
-- Weighted or token-based voting
-- Delegation and vote revocation
+- Token-weighted voting (all votes are weight-1 + delegations)
+- Vote revocation after cast
 - Batched/multi-call proposal payloads
 - Snapshot-based historical balance governance
 - Timelock queue semantics after passing
@@ -116,13 +227,33 @@ If validation fails (quorum or vote majority), execution returns `NotPassed`.
 
 Implemented in `contracts/predictify-hybrid/src/governance_tests.rs`:
 
+**Lifecycle tests:**
 - Create → vote → execute success path
 - Quorum failure path
 - Tie/majority failure path
-- Timing failures:
-  - vote before start
-  - vote at/after end
-  - execute while voting still active
+- Timing failures (before start, after end, execute while active)
 - Duplicate vote rejection
 - Invalid create/admin parameter handling
 - Uninitialized governance rejection
+
+**Quorum decay tests:**
+- `compute_effective_quorum` values at 0%, 25%, 50%, 75%, 100% elapsed
+- Proposal passes with decayed quorum
+- Floor respected after full decay
+- Auto-rejection event when below floor
+- Admin can configure and disable decay
+- Non-admin decay config rejected
+- Invalid decay params rejected
+- Monotone non-increasing property
+
+**Vote salt (commit-reveal) tests:**
+- Full commit → reveal → validate lifecycle
+- Wrong salt rejected (`InvalidReveal`)
+- Wrong support value rejected (`InvalidReveal`)
+- Duplicate commit rejected (`CommitmentExists`)
+- Reveal without commit rejected (`NoCommitment`)
+- Commit after voting ends rejected (`VotingEnded`)
+- Reveal after voting ends rejected (`VotingEnded`)
+- Double-reveal rejected (`AlreadyVoted`)
+- Direct vote then commit rejected (`AlreadyVoted`)
+- Commit for nonexistent proposal rejected (`ProposalNotFound`)


### PR DESCRIPTION
## Summary

Closes #712. Implements commit-reveal vote salt (prevents precomputation / front-running) and quorum decay (effective quorum decreases linearly toward a configurable floor after a proposal's deadline) for the `predictify-hybrid` governance module.

## Changes

### `src/governance.rs`
- Added `Bytes` / `BytesN` imports.
- New `StorageKey::VoteCommitment(Symbol, Address)` — stores per-voter commitments.
- New `GovernanceError` variants: `NoCommitment`, `InvalidReveal`, `CommitmentExists`.
- `commit_vote(env, voter, proposal_id, commitment)` — stores `sha256(salt ++ support_byte)` during the open voting window; guards against duplicate commits and mixing with direct votes.
- `reveal_vote(env, voter, proposal_id, salt, support)` — recomputes the hash, verifies against stored commitment, tallies vote with delegation weight, removes commitment to prevent double-reveal.
- Quorum decay (`compute_effective_quorum`, `set_quorum_decay`, `get_quorum_decay`) was already implemented; no changes required.

### `src/events.rs`
- New `GovernanceVoteCommittedEvent` struct (`#[contracttype]`).
- New `EventEmitter::emit_governance_vote_committed` — publishes under topic `gov_cmit`.

### `src/governance_tests.rs`
- Added `Bytes` / `BytesN` imports.
- Added `commit_vote`, `reveal_vote`, and `make_commitment` helpers to `GovernanceFixture`.
- 8 new focused tests:
  - `vote_salt_commit_reveal_full_lifecycle`
  - `vote_salt_wrong_reveal_rejected`
  - `vote_salt_duplicate_commit_rejected`
  - `vote_salt_reveal_without_commit_rejected`
  - `vote_salt_commit_rejected_after_voting_ends`
  - `vote_salt_reveal_rejected_after_voting_ends`
  - `vote_salt_double_reveal_rejected`
  - `vote_salt_direct_vote_then_commit_rejected`
  - `vote_salt_commit_not_found_wrong_proposal`

### Docs
- `docs/contracts/GOVERNANCE.md` — full rewrite: vote salt API, quorum decay formula/config table, delegation rules, event table, complete error reference, regression coverage index.
- `contracts/predictify-hybrid/README.md` — added Governance section with quick-reference snippets; replaced placeholder future-enhancement entry.

## Security Properties

| Property | Mechanism |
|---|---|
| Precomputation / front-running prevention | Commit-reveal: voters publish `sha256(salt ++ support_byte)`; direction hidden until reveal |
| Double-vote | Commitment removed post-reveal; `Vote` key guards both direct and commit-reveal paths |
| Griefing (re-commit) | `CommitmentExists` error prevents replacement after commitment |
| Quorum decay overflow | `saturating_mul` / `saturating_sub` throughout; floor enforced |
| require_auth | Every state-changing entrypoint calls `voter.require_auth()` or `caller.require_auth()` |

## Acceptance Criteria

- [x] Implementation matches description (vote salt + quorum decay)
- [x] Tests added and passing (`cargo test -p predictify-hybrid`)
- [x] Docs updated
- [x] `require_auth` on every state-changing entrypoint
- [x] Overflow-safe math (no `unwrap()` in production paths)
- [x] Clear `///` rustdoc on all public items