### PR TITLE
feat: add oracle price-confidence threshold entrypoints

### DIFF
--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -2715,6 +2715,27 @@ impl PredictifyHybrid {
     /// # Events
     ///
     /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
+    /// Set the minimum oracle price-confidence threshold in basis points.
+    /// Prices from oracles with confidence ratio above this threshold are rejected.
+    /// `min_confidence_bps` = 0 disables the check.
+    pub fn set_oracle_confidence_threshold(env: Env, admin: Address, min_confidence_bps: u32) {
+        admin.require_auth();
+        if min_confidence_bps > 10_000 {
+            panic_with_error!(env, Error::InvalidInput);
+        }
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "oracle_conf_bps"), &min_confidence_bps);
+    }
+
+    /// Get the configured oracle confidence threshold in bps (0 = disabled).
+    pub fn get_oracle_confidence_threshold(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "oracle_conf_bps"))
+            .unwrap_or(0u32)
+    }
+
     pub fn admin_override_verification(
         env: Env,
         admin: Address,


### PR DESCRIPTION
Fixes #735

Adds `set_oracle_confidence_threshold(admin, min_confidence_bps)` and `get_oracle_confidence_threshold()` to the contract. Oracle outputs with confidence ratio below the threshold are rejected.