### PR TITLE
 feat: per-market max bet cap (#745)

### DIFF
--- a/contracts/predictify-hybrid/src/bets.rs
+++ b/contracts/predictify-hybrid/src/bets.rs
@@ -55,6 +55,8 @@ fn guard_scope_unlock_funds() -> Symbol {
 const GLOBAL_BET_LIMITS_KEY: &str = "bet_limits_global";
 /// Storage key for per-event bet limits map (Symbol -> BetLimits).
 const PER_EVENT_BET_LIMITS_KEY: &str = "bet_limits_evt";
+/// Storage key for per-market max single-bet cap map (Symbol -> i128).
+const PER_MARKET_MAX_BET_CAP_KEY: &str = "max_bet_cap_mkt";
 
 // ===== STORAGE KEY TYPES =====
 
@@ -128,6 +130,64 @@ pub fn set_event_bet_limits(
     per_event.set(market_id.clone(), limits.clone());
     env.storage().persistent().set(&key, &per_event);
     Ok(())
+}
+
+/// Set a per-market max single-bet cap (admin only).
+///
+/// Once set, any individual bet whose `amount` exceeds `cap` will be rejected
+/// with [`Error::BetExceedsCap`].  The cap is independent of (and checked in
+/// addition to) the global/per-event `max_bet` in [`BetLimits`].
+///
+/// # Parameters
+///
+/// - `env`       – Soroban environment
+/// - `market_id` – Identifies the market
+/// - `cap`       – Maximum single-bet amount in base token units
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidInput`] when:
+/// - `cap` is zero or negative
+/// - `cap` exceeds [`MAX_BET_AMOUNT`]
+pub fn set_market_max_bet_cap(env: &Env, market_id: &Symbol, cap: i128) -> Result<(), Error> {
+    if cap <= 0 || cap > MAX_BET_AMOUNT {
+        return Err(Error::InvalidInput);
+    }
+    let key = Symbol::new(env, PER_MARKET_MAX_BET_CAP_KEY);
+    let mut caps: soroban_sdk::Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(soroban_sdk::Map::new(env));
+    caps.set(market_id.clone(), cap);
+    env.storage().persistent().set(&key, &caps);
+    Ok(())
+}
+
+/// Remove the per-market max bet cap for a market (admin only).
+///
+/// After removal, bets on this market are bounded only by the global/per-event
+/// [`BetLimits`] max (or [`MAX_BET_AMOUNT`] when no limits are configured).
+pub fn remove_market_max_bet_cap(env: &Env, market_id: &Symbol) {
+    let key = Symbol::new(env, PER_MARKET_MAX_BET_CAP_KEY);
+    let mut caps: soroban_sdk::Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(soroban_sdk::Map::new(env));
+    caps.remove(market_id.clone());
+    env.storage().persistent().set(&key, &caps);
+}
+
+/// Get the per-market max bet cap, or `None` if no cap has been set.
+pub fn get_market_max_bet_cap(env: &Env, market_id: &Symbol) -> Option<i128> {
+    let key = Symbol::new(env, PER_MARKET_MAX_BET_CAP_KEY);
+    let caps: soroban_sdk::Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(soroban_sdk::Map::new(env));
+    caps.get(market_id.clone())
 }
 
 /// Validate that min <= max and both are within absolute bounds.
@@ -1099,6 +1159,7 @@ impl BetValidator {
     ///
     /// Uses effective bet limits (per-event if set, else global, else default min/max).
     /// Rejects bets below min with InsufficientStake, above max with InvalidInput.
+    /// Rejects bets exceeding the per-market cap with BetExceedsCap (when set).
     pub fn validate_bet_parameters(
         env: &Env,
         market_id: &Symbol,
@@ -1110,22 +1171,30 @@ impl BetValidator {
         Self::validate_bet_amount_against_limits(env, market_id, amount)
     }
 
-    /// Validate bet amount against effective limits (per-event or global or defaults).
+    /// Validate bet amount against effective limits (per-event or global or defaults)
+    /// and the per-market max bet cap (when set).
+    ///
+    /// Checks in order:
+    /// 1. Amount >= effective `min_bet` (→ `InsufficientStake`)
+    /// 2. Amount <= effective `max_bet` (→ `InvalidInput`)
+    /// 3. Amount <= per-market cap when configured (→ `BetExceedsCap`)
     pub fn validate_bet_amount_against_limits(
         env: &Env,
         market_id: &Symbol,
         amount: i128,
     ) -> Result<(), Error> {
         let limits = get_effective_bet_limits(env, market_id);
-        // Temporarily disabled due to validation module being disabled
-        // validation::validate_bet_amount_against_limits(amount, &limits)
-
-        // Simple validation for now
         if amount < limits.min_bet {
             return Err(Error::InsufficientStake);
         }
         if amount > limits.max_bet {
             return Err(Error::InvalidInput);
+        }
+        // Check the per-market single-bet cap (most specific check, own error code).
+        if let Some(cap) = get_market_max_bet_cap(env, market_id) {
+            if amount > cap {
+                return Err(Error::BetExceedsCap);
+            }
         }
         Ok(())
     }

--- a/contracts/predictify-hybrid/src/err.rs
+++ b/contracts/predictify-hybrid/src/err.rs
@@ -227,6 +227,12 @@ pub enum Error {
     /// The effective fee (in basis points) exceeds the maximum the caller is willing to accept.
     /// The bet is rejected to protect the caller from unexpected fee changes.
     FeeExceedsMax = 508,
+    /// The single-bet amount exceeds the per-market maximum bet cap.
+    ///
+    /// An admin can set a per-market cap via `set_market_max_bet_cap`. Once set,
+    /// any individual bet whose `amount` exceeds the cap will be rejected with this
+    /// error. Use `get_market_max_bet_cap` to query the current cap before placing.
+    BetExceedsCap = 509,
     /// No pending fee config commit was found for reveal or apply.
     NoPendingFeeCommit = 519,
     /// Fee config reveal was attempted too early (before timelock expiry).
@@ -782,6 +788,7 @@ impl ErrorHandler {
             Error::AdminNotSet | Error::DisputeFeeFailed => RecoveryStrategy::ManualIntervention,
             Error::InvalidState | Error::InvalidOracleConfig => RecoveryStrategy::NoRecovery,
             Error::FeeExceedsMax => RecoveryStrategy::Retry,
+            Error::BetExceedsCap => RecoveryStrategy::NoRecovery,
             Error::OperationWouldExceedBudget => RecoveryStrategy::NoRecovery,
             _ => RecoveryStrategy::Abort,
         }
@@ -1364,6 +1371,11 @@ impl ErrorHandler {
                 ErrorCategory::Financial,
                 RecoveryStrategy::Retry,
             ),
+            Error::BetExceedsCap => (
+                ErrorSeverity::Low,
+                ErrorCategory::Financial,
+                RecoveryStrategy::NoRecovery,
+            ),
             Error::OperationWouldExceedBudget => (
                 ErrorSeverity::Critical,
                 ErrorCategory::System,
@@ -1507,6 +1519,7 @@ impl Error {
             Error::ExtensionDenied => "Market extension not allowed",
             Error::AdminNotSet => "Admin address not set",
             Error::FeeExceedsMax => "Fee is above the acceptable threshold",
+            Error::BetExceedsCap => "Bet amount exceeds the per-market maximum bet cap",
             Error::OracleStale => "Oracle data is stale",
             Error::OracleNoConsensus => "Oracle consensus not reached",
             Error::OracleVerified => "Oracle result already verified",
@@ -1618,6 +1631,7 @@ impl Error {
             Error::ExtensionDenied => "EXTENSION_DENIED",
             Error::AdminNotSet => "ADMIN_NOT_SET",
             Error::FeeExceedsMax => "FEE_ABOVE_ACCEPTABLE",
+            Error::BetExceedsCap => "BET_EXCEEDS_CAP",
             Error::OracleStale => "ORACLE_STALE",
             Error::OracleNoConsensus => "ORACLE_NO_CONSENSUS",
             Error::OracleVerified => "ORACLE_VERIFIED",

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -3883,6 +3883,90 @@ impl PredictifyHybrid {
         crate::bets::get_effective_bet_limits(&env, &market_id)
     }
 
+    /// Set the per-market maximum single-bet cap (admin only).
+    ///
+    /// Once set, any individual bet whose `amount` exceeds `cap` is rejected with
+    /// [`Error::BetExceedsCap`].  The cap is checked after, and in addition to, the
+    /// global/per-event `max_bet` in [`BetLimits`].
+    ///
+    /// Pass `cap = 0` to remove the cap (equivalent to calling
+    /// [`remove_market_max_bet_cap`]).  Any other value must satisfy
+    /// `0 < cap <= MAX_BET_AMOUNT`.
+    ///
+    /// # Parameters
+    ///
+    /// - `admin`     – Must be the primary admin address
+    /// - `market_id` – Identifies the target market
+    /// - `cap`       – Maximum single-bet amount in base token units (stroops)
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::Unauthorized`] when `admin` is not the primary admin
+    /// - [`Error::InvalidInput`] when `cap` is negative or exceeds [`MAX_BET_AMOUNT`]
+    ///
+    /// # Events
+    ///
+    /// Emits a `bet_limits_updated` event scoped to `market_id` so that indexers
+    /// can track cap changes.
+    pub fn set_market_max_bet_cap(
+        env: Env,
+        admin: Address,
+        market_id: Symbol,
+        cap: i128,
+    ) -> Result<(), Error> {
+        Self::require_primary_admin(&env, &admin)?;
+        // cap == 0 is treated as "remove the cap"
+        if cap == 0 {
+            crate::bets::remove_market_max_bet_cap(&env, &market_id);
+        } else {
+            crate::bets::set_market_max_bet_cap(&env, &market_id, cap)?;
+        }
+        // Emit so indexers can observe
+        EventEmitter::emit_bet_limits_updated(&env, &admin, &market_id, 0, cap);
+
+        crate::audit_trail::AuditTrailManager::append_record(
+            &env,
+            crate::audit_trail::AuditAction::BetLimitsUpdated,
+            admin.clone(),
+            Map::new(&env),
+            None,
+        );
+
+        Ok(())
+    }
+
+    /// Get the per-market max single-bet cap, or `None` if no cap is configured.
+    ///
+    /// # Events
+    ///
+    /// State-changing paths may emit events through internal managers; read-only query paths emit no events.
+    pub fn get_market_max_bet_cap(env: Env, market_id: Symbol) -> Option<i128> {
+        crate::bets::get_market_max_bet_cap(&env, &market_id)
+    }
+
+    /// Remove the per-market max single-bet cap (admin only).
+    ///
+    /// After removal, bets on this market are bounded only by the global/per-event
+    /// [`BetLimits`] `max_bet` (or [`MAX_BET_AMOUNT`] when no limits are configured).
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::Unauthorized`] when `admin` is not the primary admin
+    ///
+    /// # Events
+    ///
+    /// Emits a `bet_limits_updated` event with `max_bet = 0` to signal removal.
+    pub fn remove_market_max_bet_cap(
+        env: Env,
+        admin: Address,
+        market_id: Symbol,
+    ) -> Result<(), Error> {
+        Self::require_primary_admin(&env, &admin)?;
+        crate::bets::remove_market_max_bet_cap(&env, &market_id);
+        EventEmitter::emit_bet_limits_updated(&env, &admin, &market_id, 0, 0);
+        Ok(())
+    }
+
     /// Set global oracle validation config (admin only).
     ///
     /// - `max_staleness_secs`: maximum allowed age in seconds.


### PR DESCRIPTION
closes #745

<pre> <b>Summary</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> Implements a dedicated per-market single-bet size cap, allowing admins to
<span style="background-color:#FF80FF"> </span> limit the maximum amount any single bet may stake on a given market
<span style="background-color:#FF80FF"> </span> independently of the global/per-event <font color="#2A7BDE">BetLimits</font>.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ──────────────────────────────────────────────────────────────────────────────
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Changes</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE"><b>contracts/predictify-hybrid/src/bets.rs</b></font>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - Added <font color="#2A7BDE">PER_MARKET_MAX_BET_CAP_KEY</font> — a new persistent storage key
<span style="background-color:#FF80FF"> </span> (<font color="#2A7BDE">&quot;max_bet_cap_mkt&quot;</font>) that stores a <font color="#2A7BDE">Map&lt;Symbol, i128&gt;</font> of per-market caps.
<span style="background-color:#FF80FF"> </span> - Added three public helpers:
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">set_market_max_bet_cap(env, market_id, cap)</font> — validates <font color="#2A7BDE">0 &lt; cap &lt;=</font>
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">MAX_BET_AMOUNT</font> and writes the cap.
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">get_market_max_bet_cap(env, market_id) -&gt; Option&lt;i128&gt;</font> — reads the cap,
<span style="background-color:#FF80FF"> </span> returns <font color="#2A7BDE">None</font> when unset.
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">remove_market_max_bet_cap(env, market_id)</font> — removes the cap entry (no-op
<span style="background-color:#FF80FF"> </span> if absent).
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - Updated <font color="#2A7BDE">BetValidator::validate_bet_amount_against_limits</font> to enforce the cap
<span style="background-color:#FF80FF"> </span> after the existing <font color="#2A7BDE">min_bet</font>/<font color="#2A7BDE">max_bet</font> checks; exceeding it returns
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">Error::BetExceedsCap</font>.
<span style="background-color:#FF80FF"> </span> - Updated <font color="#2A7BDE">validate_bet_parameters</font> doc-comment to reflect the new check.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE"><b>contracts/predictify-hybrid/src/err.rs</b></font>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - Added <font color="#2A7BDE">BetExceedsCap = 509</font> to the <font color="#2A7BDE">Error</font> enum.
<span style="background-color:#FF80FF"> </span> - Added <font color="#2A7BDE">BetExceedsCap</font> to all required match arms: recovery strategy
<span style="background-color:#FF80FF"> </span> (<font color="#2A7BDE">NoRecovery</font>), severity/category (<font color="#2A7BDE">Low</font> / <font color="#2A7BDE">Financial</font>), human-readable message, and
<span style="background-color:#FF80FF"> </span> machine-readable code string (<font color="#2A7BDE">&quot;BET_EXCEEDS_CAP&quot;</font>).
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE"><b>contracts/predictify-hybrid/src/lib.rs</b></font>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - Exposed three new contract entrypoints:
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">set_market_max_bet_cap(env, admin, market_id, cap)</font> — admin-only; <font color="#2A7BDE">cap = 0</font>
<span style="background-color:#FF80FF"> </span>  removes the cap; emits <font color="#2A7BDE">bet_limits_updated</font> event and appends an audit-trail
<span style="background-color:#FF80FF"> </span> record.
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">get_market_max_bet_cap(env, market_id)</font> — read-only query.
<span style="background-color:#FF80FF"> </span>   - <font color="#2A7BDE">remove_market_max_bet_cap(env, admin, market_id)</font> — admin-only; emits
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">bet_limits_updated</font> with <font color="#2A7BDE">max_bet = 0</font> to signal removal.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - All state-changing entrypoints call <font color="#2A7BDE">require_primary_admin</font> and carry
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">require_auth</font> through the admin check.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ──────────────────────────────────────────────────────────────────────────────
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>How it works</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> The cap sits as the innermost, most-specific constraint in bet validation:
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> amount &gt;= min_bet      (InsufficientStake)
<span style="background-color:#FF80FF"> </span> amount &lt;= max_bet      (InvalidInput)
<span style="background-color:#FF80FF"> </span> amount &lt;= per-mkt cap  (BetExceedsCap)   ← new, only when cap is set
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> When no cap is stored for a market, validation is unchanged. The cap is stored
<span style="background-color:#FF80FF"> </span> separately from <font color="#2A7BDE">BetLimits</font> so it can be updated or removed without touching the
<span style="background-color:#FF80FF"> </span> existing min/max configuration.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ──────────────────────────────────────────────────────────────────────────────
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>API surface (new entrypoints)</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ┌──────────────────────────────────────────────┬───────┬───────────────────┐
<span style="background-color:#FF80FF"> </span> │ <b>Entrypoint</b>                                   │ <b>Auth</b>  │ <b>Returns</b>           │
<span style="background-color:#FF80FF"> </span> ├──────────────────────────────────────────────┼───────┼───────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">set_market_max_bet_cap(admin, market_id,     │ admin │ Result&lt;(), Error&gt;</font> │
<span style="background-color:#FF80FF"> </span> │ cap)                                         │       │                   │
<span style="background-color:#FF80FF"> </span> ├──────────────────────────────────────────────┼───────┼───────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">get_market_max_bet_cap(market_id)</font>            │ none  │ <font color="#2A7BDE">Option&lt;i128&gt;</font>      │
<span style="background-color:#FF80FF"> </span> ├──────────────────────────────────────────────┼───────┼───────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">remove_market_max_bet_cap(admin, market_id)</font>  │ admin │ <font color="#2A7BDE">Result&lt;(), Error&gt;</font> │
<span style="background-color:#FF80FF"> </span> └──────────────────────────────────────────────┴───────┴───────────────────┘
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>New error code</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ┌──────┬───────────────┬───────────────────────────────────────────────────┐
<span style="background-color:#FF80FF"> </span> │ <b>Code</b> │ <b>Name</b>          │ <b>Meaning</b>                                           │
<span style="background-color:#FF80FF"> </span> ├──────┼───────────────┼───────────────────────────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">509</font>  │ <font color="#2A7BDE">BetExceedsCap</font> │ Bet amount exceeds the per-market maximum bet cap │
<span style="background-color:#FF80FF"> </span> └──────┴───────────────┴───────────────────────────────────────────────────┘
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ──────────────────────────────────────────────────────────────────────────────
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Testing</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> The implementation follows the existing <font color="#2A7BDE">BetTestSetup</font> pattern. Tests to
<span style="background-color:#FF80FF"> </span> add/verify:
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - <b>Happy path</b> — bet at exactly the cap amount succeeds.
<span style="background-color:#FF80FF"> </span> - <b>Over-cap rejection</b> — bet one stroop above cap returns <font color="#2A7BDE">Error::BetExceedsCap</font>.
<span style="background-color:#FF80FF"> </span> - <b>No cap set</b> — bets up to <font color="#2A7BDE">MAX_BET_AMOUNT</font> are unaffected.
<span style="background-color:#FF80FF"> </span> - <b>Cap removal</b> — after <font color="#2A7BDE">remove_market_max_bet_cap</font>, previously-rejected amount
<span style="background-color:#FF80FF"> </span> succeeds.
<span style="background-color:#FF80FF"> </span> - <b>Cap = 0 on setter</b> — <font color="#2A7BDE">set_market_max_bet_cap(..., 0)</font> removes the cap.
<span style="background-color:#FF80FF"> </span> - <b>Invalid cap</b> — negative or <font color="#2A7BDE">&gt; MAX_BET_AMOUNT</font> values return
<span style="background-color:#FF80FF"> </span> - <b>Admin auth</b> — non-admin caller is rejected on setter/remover.
<span style="background-color:#FF80FF"> </span> - <b>Isolation</b> — cap on market A does not affect market B.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> Run with:
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> cargo <font color="#2AA1B3">test</font> -p predictify-hybrid
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ──────────────────────────────────────────────────────────────────────────────
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Checklist</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - [x] <font color="#2A7BDE">require_auth</font> on every state-changing entrypoint
<span style="background-color:#FF80FF"> </span> - [x] Overflow-safe math (all comparisons on <font color="#2A7BDE">i128</font>, no arithmetic)
<span style="background-color:#FF80FF"> </span> - [x] No <font color="#2A7BDE">unwrap()</font> in production paths
<span style="background-color:#FF80FF"> </span> - [x] New error code in the reserved <font color="#2A7BDE">509–518</font> range
<span style="background-color:#FF80FF"> </span> - [x] Audit trail record on <font color="#2A7BDE">set_market_max_bet_cap</font>
<span style="background-color:#FF80FF"> </span> - [x] Event emitted on set/remove for indexer visibility
<span style="background-color:#FF80FF"> </span> - [x] Docs updated for all new public items
</pre>