### PR TITLE
docs: add rustdoc for markets read cache constructor

### DIFF
--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -725,6 +725,11 @@ pub struct MarketReadCache<'a> {
 }
 
 impl<'a> MarketReadCache<'a> {
+    /// Creates a market read cache bound to the current contract environment.
+    ///
+    /// The cache uses instance storage for read-only market lookups, so callers
+    /// should create it per operation and continue to treat persistent storage as
+    /// the source of truth for mutations.
     pub fn new(env: &'a Env) -> Self {
         Self { env }
     }


### PR DESCRIPTION
Fixes #857.

## Summary
- adds the missing `///` rustdoc for `MarketReadCache::new`
- keeps the change scoped to `contracts/predictify-hybrid/src/markets.rs`
- does not change contract behavior or storage logic

## Validation
- Static raw-file inspection confirmed every `pub fn` in `markets.rs` now has immediate `///` rustdoc.
- Compare is 1 commit ahead / 0 behind and changes only docs (`+5/-0`).
- Not run locally: docs-only change; this workspace is avoiding project toolchain execution.