### PR TITLE
docs: storage tier matrix

### DIFF
--- a/docs/STORAGE_TIER.md
+++ b/docs/STORAGE_TIER.md
@@ -1,0 +1,150 @@
+# Storage Tier Matrix
+
+Reference for the storage tier and TTL policy applied to each data key in
+`contracts/predictify-hybrid`.
+
+Two orthogonal concepts are documented here, and they are easy to conflate:
+
+- **Durability tier** — the Soroban storage class a key lives in:
+  `instance`, `persistent`, or `temporary`. Chosen at the call site via
+  `env.storage().instance() / .persistent() / .temporary()`.
+- **TTL tier** — for persistent keys only, which rent-extension budget applies.
+  Modelled by the private `StorageTtlTier` enum in `storage.rs` and resolved
+  through `StorageOptimizer::persistent_ttl_for_tier`.
+
+A key has exactly one durability tier. Only persistent keys have a TTL tier.
+
+## TTL tier definitions
+
+Defaults are declared as constants in `storage.rs` and are overridable at
+runtime through the `StorageConfig` fields shown below.
+
+| TTL tier | Constant | Ledgers | ≈ Duration | `StorageConfig` field |
+| --- | --- | ---: | --- | --- |
+| Balance | `BALANCE_TTL_LEDGERS` | 535,680 | ~31 days | `balance_ttl_ledgers` |
+| Market | `MARKET_TTL_LEDGERS` | 6,307,200 | ~365 days | `market_ttl_ledgers` |
+| Event | `EVENT_TTL_LEDGERS` | 1,555,200 | ~90 days | `event_ttl_ledgers` |
+| Archive | `ARCHIVE_TTL_LEDGERS` | 6,307,200 | ~365 days | `archive_ttl_ledgers` |
+
+All durations assume `LEDGERS_PER_DAY = 17_280` (~5 s/ledger on Soroban
+mainnet). Two further TTLs sit outside the tier enum:
+
+| Constant | Ledgers | ≈ Duration | Applies to |
+| --- | ---: | --- | --- |
+| `PLACE_BETS_IDEM_TTL_LEDGERS` | 120,960 | ~7 days | `PlaceBetsIdem` (temporary) |
+| `MARKET_CACHE_TTL_LEDGERS` | 100 | ~8 minutes | `MarketCache` (instance) |
+
+### Clamping
+
+Every persistent write routed through `set_persistent_with_ttl` /
+`extend_persistent_ttl` is clamped by `clamp_persistent_ttl`:
+
+```rust
+effective_ttl = desired_ttl_ledgers.min(env.storage().max_ttl())
+```
+
+The configured value is therefore an upper bound, not a guarantee. On networks
+where `max_ttl()` is below the tier constant, the Market and Archive tiers
+collapse to the network maximum and become indistinguishable.
+
+`check_market_creation_rent` performs the matching pre-flight check at market
+creation, returning `Error::InsufficientStorageRent` if
+`ledger().sequence() + effective_ttl` would overflow `u32`.
+
+## Key matrix
+
+Tier assignment is made at each call site rather than by a central
+`DataKey -> tier` function, so this table is derived by reading the writes.
+See *Known deviations* for the consequences.
+
+| Data key | Durability | TTL tier | Effective TTL | Written by |
+| --- | --- | --- | --- | --- |
+| `ArchivedMarket(Symbol, u64)` | persistent | Archive | ~365 d | `archive_market_data` |
+| `MarketMetadata(Symbol)` | persistent | Market | ~365 d | `promote_market_to_persistent` |
+| `MarketScratch(Symbol)` | temporary | — | set at call site | scratch demotion path |
+| `MarketCache(Symbol)` | instance | — | ~8 min (shared) | `markets.rs` read cache |
+| `MarketExtensionTotal(Symbol)` | persistent | Market | ~365 d | market extension path |
+| `Whitelisted(Address)` | persistent | Market | ~365 d | admin access control |
+| `Blacklisted(Address)` | persistent | Market | ~365 d | admin access control |
+| `AdminOverrideNonce(Address)` | persistent | Market | ~365 d | admin override replay guard |
+| `DisputeHistory(Symbol)` | persistent | Market | ~365 d | dispute log |
+| `DisputeHistoryCap` | persistent | Market | ~365 d | dispute config |
+| `DisputeStakeCap(Symbol, Address)` | persistent | Market | ~365 d | dispute stake accounting |
+| `DisputeCumulativeStakeCap(Address)` | persistent | Market | ~365 d | per-user cumulative cap |
+| `AntiGriefFloor` | persistent | Market | ~365 d | `disputes.rs` |
+| `GlobalConfig` | persistent | Market | ~365 d | governance config |
+| `PlaceBetsIdem(Address, BytesN)` | temporary | — | ~7 d | `bets.rs` idempotency guard |
+
+Non-`DataKey` composite keys also carry tier assignments:
+
+| Key shape | Durability | TTL tier | Effective TTL | Written by |
+| --- | --- | --- | --- | --- |
+| `(Symbol("Event"), Symbol)` | persistent | Event | ~90 d | `EventManager::store_event` |
+| `(Symbol("ActiveEvents"), Address)` | persistent | Market | ~365 d | active-event counters |
+| `Symbol("storage_config")` | persistent | Archive | ~365 d | `update_storage_config` |
+| `Vec<Val>` balance key | persistent | Balance | ~31 d | `BalanceStorage` |
+| archive-derived keys (`compressed`, `compressed_ref`) | persistent | Market | ~365 d | compression path |
+| migration record (`Symbol`) | persistent | Archive | ~365 d | `store_migration_record` |
+
+## Instance storage note
+
+Soroban instance storage shares a single TTL across all instance keys, and it
+is bounded by the contract instance's own lifetime. Bumping any instance key
+extends every instance key. `MARKET_CACHE_TTL_LEDGERS` is therefore a floor on
+cache freshness, not a per-key expiry — `MarketCache` entries may outlive
+~8 minutes if another instance write bumps the shared TTL. Treat instance
+storage as a cache that may vanish, never as a source of truth.
+
+## Choosing a tier for a new key
+
+1. Is it a cache, cheaply rebuildable from persistent state? → **instance**.
+2. Does it expire on a fixed, short schedule with no audit value?
+   → **temporary**, with an explicit TTL constant.
+3. Otherwise → **persistent**, and pick the TTL tier by retention need:
+   Balance (~31 d) for user balances, Event (~90 d) for event records,
+   Market (~365 d) for live market state, Archive (~365 d) for records kept
+   for audit or migration.
+
+Route persistent writes through `StorageOptimizer::set_persistent_with_ttl`
+with a `persistent_ttl_for_tier` value rather than a raw literal, so the write
+picks up both the `StorageConfig` override and the `max_ttl()` clamp.
+
+## Known deviations
+
+These are accurate as of this document and are recorded rather than corrected,
+since this change is documentation-only.
+
+1. **`DataKey` does not compile.** `AdminOverrideNonce(Address)` is declared
+   twice in `storage.rs` (lines 74 and 89), which is `E0428`. Additionally
+   `AntiGriefFloor`, `GlobalConfig`, and `PlaceBetsIdem` are constructed in
+   `disputes.rs`, governance tests, and `bets.rs` respectively but are absent
+   from the enum. The tiers recorded above for those four keys reflect the
+   call sites that use them, not a declaration that currently exists.
+
+2. **`BalanceStorage::update_balance` bypasses the tier helpers.** It calls
+   `extend_ttl(&key, 535680, 535680)` with hardcoded literals rather than
+   `persistent_ttl_for_tier(env, StorageTtlTier::Balance)`. The literal equals
+   `BALANCE_TTL_LEDGERS` today, so behaviour matches by coincidence, but the
+   write ignores any `StorageConfig` override and skips the `max_ttl()` clamp.
+
+3. **No central key-to-tier mapping exists.** `StorageTtlTier` is private and
+   there is no `fn tier_for(key: &DataKey)`. Tier assignment lives at roughly
+   a dozen call sites, so this table can drift from the code without any test
+   failing.
+
+4. **`storage_tier_audit.rs` is unregistered and stale.** The module exists and
+   exports `get_storage_tier_audit`, but it is not declared in `lib.rs`, so it
+   is dead code that never compiles or runs — its `#[cfg(test)]` tests do not
+   execute. Its table also names keys that are not `DataKey` variants
+   (`Admin`, `Market`, `DisputeMultiSig`, `GovernanceMinBps`, `CumDisputeFee`,
+   `PlatformFee`, `OracleConfidence`, `AdminEmergency`) and omits most keys
+   that are. Where it disagrees with this document, this document reflects the
+   code. Reconciling or removing that module is left to a follow-up.
+
+## References
+
+- `contracts/predictify-hybrid/src/storage.rs` — tier constants, `StorageConfig`, TTL helpers
+- `contracts/predictify-hybrid/src/storage_layout_tests.rs` — TTL behaviour tests
+- `contracts/predictify-hybrid/src/storage_tier_audit.rs` — unregistered prior audit (see deviation 4)
+- `contracts/predictify-hybrid/src/bets.rs` — `PlaceBetsIdem` lifecycle
+- `contracts/predictify-hybrid/src/markets.rs` — `MarketCache` read cache


### PR DESCRIPTION
# Pull Request Description

## 📋 Basic Information

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🧪 Test addition/update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🎨 UI/UX improvement
- [ ] 🚀 Deployment/Infrastructure change

### Related Issues
Closes #836 
Related to #734 (prior storage-tier audit — see "Notes for Reviewers")

### Priority Level
- [ ] 🔴 Critical (blocking other development)
- [ ] 🟡 High (significant impact)
- [x] 🟢 Medium (moderate impact)
- [ ] 🔵 Low (minor improvement)

---

## 📝 Detailed Description

### What does this PR do?

Adds `docs/STORAGE_TIER.md`, a reference matrix documenting the storage tier
and TTL policy for every data key in `contracts/predictify-hybrid`.

The document separates two concepts that are easy to conflate:

- **Durability tier** — the Soroban storage class (`instance` / `persistent` /
  `temporary`) chosen at each call site.
- **TTL tier** — for persistent keys only, the rent-extension budget modelled
  by the private `StorageTtlTier` enum and resolved through
  `StorageOptimizer::persistent_ttl_for_tier`.

It covers: the four TTL tier constants with their ledger counts and durations,
the `StorageConfig` fields that override them, the `max_ttl()` clamping
behaviour, a per-key matrix for both `DataKey` variants and the non-`DataKey`
composite keys, guidance for choosing a tier for new keys, and a "Known
deviations" section recording places where the code diverges from the
documented policy.

This is a documentation-only change. No Rust source files are added or
modified.

### Why is this change needed?

Tier assignment is currently made at roughly a dozen individual call sites
rather than by a central `DataKey -> tier` function. There is no single place a
contributor can look to answer "which tier does this key use, and for how
long?" — the answer has to be reassembled by grepping
`persistent_ttl_for_tier` call sites. That makes it easy to add a new key with
an inappropriate tier, or to change a TTL constant without realising which
keys it affects.

### How was this tested?

No automated tests accompany this PR, and none can meaningfully be added — the
change introduces a single markdown file with no executable surface.

Verification performed instead:

1. Every tier constant, ledger count, and duration in the document was read
   directly from `storage.rs` rather than inferred.
2. Ledger arithmetic was recomputed independently against
   `LEDGERS_PER_DAY = 17_280` and matches the declared constants:
   Balance 535,680 (~31 d), Market 6,307,200 (~365 d), Event 1,555,200 (~90 d),
   Archive 6,307,200 (~365 d), `PlaceBetsIdem` 120,960 (~7 d).
3. Each `persistent_ttl_for_tier` / `set_persistent_with_ttl` call site was
   traced to the key it writes, so the matrix maps keys rather than line
   numbers.

**`cargo test` cannot currently be run on this branch.** See "Test Results"
below — this is a pre-existing condition on `main`, not a regression
introduced here.

### Alternative Solutions Considered

A larger change was considered and rejected for this PR: making
`StorageTtlTier` public, adding `pub fn tier_for(key: &DataKey) ->
StorageTtlTier`, routing `BalanceStorage::update_balance` through it, and
adding a test asserting every `DataKey` variant maps to a tier. That would make
the matrix enforceable rather than advisory and would satisfy the "tests added"
criterion.

It was rejected here because issue #836 scopes the work to a single new
documentation file and is labelled `documentation`. It also depends on first
fixing the `DataKey` compile error (deviation 1 below), which is a separate
concern. Recommended as a follow-up — happy to open it if maintainers agree.

---

## 🏗️ Smart Contract Specific

### Contract Changes
No contract code is modified by this PR. None of the following apply:

- [ ] Core contract logic modified
- [ ] Oracle integration changes (Pyth/Reflector)
- [ ] New functions added
- [ ] Existing functions modified
- [ ] Storage structure changes
- [ ] Events added/modified
- [ ] Error handling improved
- [ ] Gas optimization
- [ ] Access control changes
- [ ] Admin functions modified
- [ ] Fee structure changes

### Oracle Integration
Not applicable — no oracle code touched.

### Market Resolution Logic
Not applicable — no resolution code touched.

### Security Considerations
Not applicable to a documentation-only change. No executable surface is added,
so there is no access control, reentrancy, input validation, or overflow
exposure introduced.

---

## 🧪 Testing

### Test Coverage
No tests added — see "How was this tested?" for why, and "Notes for Reviewers"
for the follow-up that would make tests possible.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests passing locally
- [x] Manual testing completed (constants and arithmetic verified against source)
- [ ] Oracle integration tested
- [ ] Edge cases covered
- [ ] Error conditions tested
- [ ] Gas usage optimized
- [ ] Cross-contract interactions tested

### Test Results

`cargo test` does not currently run on `main`. `DataKey` in
`contracts/predictify-hybrid/src/storage.rs` declares the same variant twice:

```
error[E0428]: the name `AdminOverrideNonce` is defined multiple times
  --> contracts/predictify-hybrid/src/storage.rs:89:5
   |
74 |     AdminOverrideNonce(Address),
   |     --------------------------- previous definition of the type `AdminOverrideNonce` here
...
89 |     AdminOverrideNonce(Address),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `AdminOverrideNonce` redefined here
```

Additionally, `AntiGriefFloor`, `GlobalConfig`, and `PlaceBetsIdem` are
constructed in `disputes.rs`, the governance tests, and `bets.rs` respectively,
but are absent from the `DataKey` enum.

This is a pre-existing condition on `main` and is unrelated to this PR — the
branch inherits it. The 95% coverage requirement in #836 is not satisfiable by
any PR until it is resolved. Flagging it here because it likely blocks other
in-flight work.

### Manual Testing Steps
1. Read the tier constants, `StorageConfig` fields, and clamping helpers
   directly from `storage.rs` and cross-checked each against the document.
2. Recomputed all ledger-count arithmetic independently and confirmed it
   matches the declared constants.
3. Traced every `persistent_ttl_for_tier` and `set_persistent_with_ttl` call
   site to the key it writes, and confirmed each row of the matrix.
4. Rendered the markdown to confirm table formatting.

---

## 📚 Documentation

### Documentation Updates
- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Examples updated
- [ ] Deployment instructions updated
- [ ] Contributing guidelines updated
- [x] Architecture documentation updated (new `docs/STORAGE_TIER.md`)

### Breaking Changes
**None.** No public API, storage layout, or contract behaviour is changed.

**Migration Guide:** Not applicable.

---

## 🔍 Code Quality

### Code Review Checklist
- [x] Code follows Rust/Soroban best practices (no code added; documented
      guidance directs new keys through the existing tier helpers)
- [x] Self-review completed
- [x] No unnecessary code duplication
- [ ] Error handling is appropriate (not applicable)
- [ ] Logging/monitoring added where needed (not applicable)
- [x] Security considerations addressed (none applicable; stated above)
- [x] Performance implications considered (none)
- [x] Code is readable and well-commented
- [ ] Variable names are descriptive (not applicable)
- [ ] Functions are focused and small (not applicable)

### Performance Impact
- **Gas Usage**: No change — no contract code modified.
- **Storage Impact**: No change — no on-chain storage written.
- **Computational Complexity**: No change.

### Security Review
- [x] No obvious security vulnerabilities
- [ ] Access controls properly implemented (not applicable)
- [ ] Input validation in place (not applicable)
- [ ] Oracle data properly validated (not applicable)
- [x] No sensitive data exposed

---

## 🚀 Deployment & Integration

### Deployment Notes
- **Network**: Not applicable — no deployment required.
- **Contract Address**: Not applicable.
- **Migration Required**: No.
- **Special Instructions**: None.

### Integration Points
- [ ] Frontend integration considered (not applicable)
- [ ] API changes documented (no API changes)
- [x] Backward compatibility maintained (no behavioural change)
- [ ] Third-party integrations updated (not applicable)

---

## 📊 Impact Assessment

### User Impact
- **End Users**: None — no behavioural change.
- **Developers**: Single reference for tier and TTL policy; removes the need to
  grep call sites to determine a key's retention. Records four known code
  deviations that were previously undocumented.
- **Admins**: Clarifies which `StorageConfig` fields affect which keys, and
  that configured TTLs are upper bounds clamped by `max_ttl()`.

### Business Impact
- **Revenue**: None.
- **User Experience**: None directly.
- **Technical Debt**: Net reduction in undocumented behaviour, though the
  document records rather than resolves the deviations it identifies. Because
  no test enforces the matrix, it can drift from the code — the follow-up in
  "Alternative Solutions Considered" would close that gap.

---

## ✅ Final Checklist

### Pre-Submission
- [x] Code follows Rust/Soroban best practices
- [ ] All CI checks passing — CI cannot pass while `main` does not compile
      (see "Test Results"); unrelated to this change
- [x] No breaking changes (or breaking changes are documented)
- [x] Ready for review
- [x] PR description is complete and accurate
- [x] All required sections filled out
- [x] Test results included (including why the suite cannot run)
- [x] Documentation updated

### Review Readiness
- [x] Self-review completed
- [x] Code is clean and well-formatted
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No merge conflicts

---

## 📸 Screenshots (if applicable)
Not applicable.

## 🔗 Additional Resources
- **Design Document**: N/A
- **Technical Spec**: `contracts/predictify-hybrid/src/storage.rs`
- **Related Discussion**: #836, #734
- **External Documentation**:
  [[Soroban persisting data](https://developers.stellar.org/docs/build/guides/storage)](https://developers.stellar.org/docs/build/guides/storage)

---

## 💬 Notes for Reviewers

**Please pay special attention to:**

- **The "Known deviations" section of the new document.** It records four
  issues found while writing the matrix. These are documented, not fixed, since
  this PR is documentation-only:
  1. `DataKey` does not compile (duplicate `AdminOverrideNonce`; three variants
     used elsewhere but never declared).
  2. `BalanceStorage::update_balance` calls `extend_ttl(&key, 535680, 535680)`
     with hardcoded literals instead of `persistent_ttl_for_tier(Balance)`. The
     literal happens to equal `BALANCE_TTL_LEDGERS`, so behaviour matches
     today — but the write ignores any `StorageConfig` override and skips the
     `max_ttl()` clamp.
  3. No central `DataKey -> tier` mapping exists, so the matrix can drift
     silently.
  4. `storage_tier_audit.rs` exists but is not declared in `lib.rs`.

- **Overlap with #734.** `storage_tier_audit.rs` claims to answer that issue
  and exports `get_storage_tier_audit`, but as unregistered dead code it never
  compiles and its `#[cfg(test)]` tests never execute. Its table also names
  eight keys that are not `DataKey` variants (`Admin`, `PlatformFee`,
  `GovernanceMinBps`, `CumDisputeFee`, `DisputeMultiSig`, `OracleConfidence`,
  `AdminEmergency`, `Market`) while omitting most that are. Where it disagrees
  with this document, this document reflects the code.

- **Inferred rows in the matrix.** Tiers for `AntiGriefFloor`, `GlobalConfig`,
  `PlaceBetsIdem`, and `AdminOverrideNonce` are inferred from call sites, since
  no valid enum declaration currently exists to read. A few `Market`-tier rows
  (`Whitelisted`, `Blacklisted`) are inferred from the surrounding write
  pattern rather than a direct `persistent_ttl_for_tier` call. These are the
  rows most worth a maintainer's eye.

**Questions for reviewers:**

- Should this supersede #734, or should `storage_tier_audit.rs` be registered
  in `lib.rs` and reconciled against this matrix? Two disagreeing tier tables
  in the repo seems worse than either alone.
- Is the `DataKey` compile break known and already being addressed in one of
  the open PRs? If not, I'm happy to open a separate PR fixing the duplicate
  variant and adding the three missing ones.
- Would you like the follow-up adding `tier_for(&DataKey)` plus an
  exhaustive-mapping test, which would make this matrix enforceable rather than
  advisory?

---

**Thank you for your contribution to Predictify! 🚀**