### PR TITLE
feat: add per market ttl preflight

### DIFF
--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -153,7 +153,9 @@ use admin::{
 };
 pub use admin::Severity;
 pub use err::Error;
-use crate::storage::{check_market_creation_rent, DataKey, MARKET_TTL_LEDGERS};
+use crate::storage::{
+    check_market_creation_rent, check_market_creation_rent_budget, DataKey, MARKET_TTL_LEDGERS,
+};
 // Backwards-compatible re-export for existing module paths.
 pub mod errors {
     pub use crate::err::*;
@@ -409,8 +411,21 @@ impl PredictifyHybrid {
             winnings_swept: false,
         };
 
-        // Pre-flight check: ensure sufficient storage rent budget
+        // Pre-flight checks: ensure sufficient storage rent budget.
+        //
+        // This entrypoint returns `Symbol` rather than `Result`, so a failed
+        // check is surfaced as a panic. Callers using `try_create_market`
+        // observe `Error::InsufficientStorageRent` or
+        // `Error::InsufficientStorageRentBudget` respectively.
+        //
+        // The aggregate check runs second and covers all three persistent
+        // entries this entrypoint writes: the market record below, the
+        // platform statistics record via `record_market_created`, and the
+        // audit trail record via `append_record`.
         if let Err(e) = check_market_creation_rent(&env) {
+            panic_with_error!(env, e);
+        }
+        if let Err(e) = check_market_creation_rent_budget(&env) {
             panic_with_error!(env, e);
         }
 

--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -4,7 +4,10 @@ use soroban_sdk::{contracttype, token, vec, Address, Env, Map, String, Symbol, V
 
 // use crate::config; // Unused import
 use crate::err::Error;
-use crate::storage::{check_market_creation_rent, DataKey, MARKET_CACHE_TTL_LEDGERS, MARKET_TTL_LEDGERS};
+use crate::storage::{
+    check_market_creation_rent, check_market_creation_rent_budget, DataKey,
+    MARKET_CACHE_TTL_LEDGERS, MARKET_TTL_LEDGERS,
+};
 use crate::types::*;
 // Oracle imports removed - not currently used
 
@@ -128,8 +131,13 @@ impl MarketCreator {
         // Use the generated id after creation in higher-level flows when event metadata is required.
        let _ = MarketUtils::process_creation_fee(env, &admin)?;
 
-        // Pre-flight check: ensure sufficient storage rent budget
+        // Pre-flight checks: ensure sufficient storage rent budget.
+        // The single-key check guards the market record itself; the aggregate
+        // check additionally covers every persistent entry a full creation
+        // flow writes, so a caller cannot get partway through and strand a
+        // market record whose companion entries could not be given a TTL.
         check_market_creation_rent(env)?;
+        check_market_creation_rent_budget(env)?;
 
         // Store market
         env.storage().persistent().set(&market_id, &market);

--- a/contracts/predictify-hybrid/src/storage.rs
+++ b/contracts/predictify-hybrid/src/storage.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::markets::{MarketStateLogic, MarketStateManager};
 use crate::types::{Balance, ReflectorAsset, Market, MarketState, OracleConfig};
-use soroban_sdk::{contracttype, Address, Env, IntoVal, Map, Symbol, Val, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, IntoVal, Map, Symbol, Val, Vec};
 
 const STORAGE_CONFIG_KEY: &str = "storage_config";
 const LEDGERS_PER_DAY: u32 = 17_280;
@@ -22,8 +22,22 @@ pub const PLACE_BETS_IDEM_TTL_LEDGERS: u32 = 7 * LEDGERS_PER_DAY;
 /// Increase for longer-lived deployments; decrease to reduce ledger rent costs.
 pub const MARKET_CACHE_TTL_LEDGERS: u32 = 100;
 
-/// Number of persistent storage keys allocated during a single `create_market` call.
-pub const MARKET_CREATION_PERSISTENT_KEYS: u32 = 1;
+/// Number of persistent storage keys allocated during a single `create_market`
+/// call on the contract entrypoint path.
+///
+/// The entrypoint writes three persistent entries per creation:
+///
+/// 1. the market record itself, keyed by `market_id`;
+/// 2. the platform statistics record, via
+///    [`crate::statistics::StatisticsManager::record_market_created`];
+/// 3. the audit trail record, via
+///    [`crate::audit_trail::AuditTrailManager::append_record`].
+///
+/// The internal `MarketCreator::create_market` helper writes only entry 1.
+/// The aggregate preflight uses this constant as an upper bound so that a
+/// creation which succeeds on the helper path cannot fail partway through the
+/// entrypoint path.
+pub const MARKET_CREATION_PERSISTENT_KEYS: u32 = 3;
 
 /// Pre-flight storage-rent check for market creation.
 ///
@@ -45,6 +59,48 @@ pub fn check_market_creation_rent(env: &Env) -> Result<(), Error> {
     if current_seq.checked_add(effective_ttl).is_none() {
         return Err(Error::InsufficientStorageRent);
     }
+
+    Ok(())
+}
+
+/// Pre-flight aggregate storage-rent budget check for market creation.
+///
+/// Where [`check_market_creation_rent`] validates headroom for a single
+/// persistent entry, this check validates headroom for *every* persistent entry
+/// written during one `create_market` call, as counted by
+/// [`MARKET_CREATION_PERSISTENT_KEYS`].
+///
+/// This is the stricter of the two checks: any ledger state rejected by
+/// [`check_market_creation_rent`] is also rejected here, but not the reverse.
+/// Calling it before the first persistent write prevents a partially-written
+/// market, where the market record is stored but the statistics or audit entry
+/// cannot be given its full TTL.
+///
+/// # Formula
+///
+/// 1. `effective_ttl = MIN(MARKET_TTL_LEDGERS, env.storage().max_ttl())`
+/// 2. `required = effective_ttl * MARKET_CREATION_PERSISTENT_KEYS`
+/// 3. The current ledger sequence plus `required` must not overflow `u32`.
+///
+/// Step 2 is itself checked: `MARKET_CREATION_PERSISTENT_KEYS` is public, so a
+/// future value large enough to overflow the multiplication is treated as an
+/// exhausted budget rather than wrapping.
+///
+/// # Errors
+///
+/// Returns [`Error::InsufficientStorageRentBudget`] if the aggregate budget
+/// would overflow `u32`.
+pub fn check_market_creation_rent_budget(env: &Env) -> Result<(), Error> {
+    let effective_ttl = MARKET_TTL_LEDGERS.min(env.storage().max_ttl());
+
+    let required = effective_ttl
+        .checked_mul(MARKET_CREATION_PERSISTENT_KEYS)
+        .ok_or(Error::InsufficientStorageRentBudget)?;
+
+    env.ledger()
+        .sequence()
+        .checked_add(required)
+        .ok_or(Error::InsufficientStorageRentBudget)?;
 
     Ok(())
 }
@@ -85,8 +141,12 @@ pub enum DataKey {
     /// Instance storage cache key for Market structs, keyed by market_id.
     /// Used by MarketReadCache in markets.rs.
     MarketCache(Symbol),
-    /// Nonce for admin override replay protection.
-    AdminOverrideNonce(Address),
+    /// Minimum anti-grief stake floor for disputes.
+    AntiGriefFloor,
+    /// Global protocol configuration record.
+    GlobalConfig,
+    /// Consumed `place_bets` idempotency key, scoped per user.
+    PlaceBetsIdem(Address, BytesN<32>),
 }
 
 /// Storage format version for migration tracking
@@ -719,8 +779,16 @@ impl BalanceStorage {
 
         let key = Self::get_key(env, &balance.user, &balance.asset);
         env.storage().persistent().set(&key, balance);
-        // Extend TTL to ensure balance persists (approx 30 days)
-        env.storage().persistent().extend_ttl(&key, 535680, 535680);
+        // Extend TTL via the Balance tier so the write honours any
+        // `StorageConfig` override and the `max_ttl()` clamp.
+        StorageOptimizer::extend_persistent_ttl(
+            env,
+            &key,
+            StorageOptimizer::ttl_for_tier(
+                &StorageOptimizer::get_storage_config(env),
+                StorageTtlTier::Balance,
+            ),
+        );
         Ok(())
     }
 
@@ -1316,6 +1384,113 @@ mod tests {
 
             assert!(refreshed_ttl > near_expiry_ttl);
             assert_eq!(refreshed_ttl, initial_ttl);
+        });
+    }
+
+    // ── Storage Rent Aggregate Budget Pre-flight Tests ───────────────────────
+
+    #[test]
+    fn test_budget_check_accepts_normal_ledger_sequence() {
+        let (env, contract_id) = create_contract_env();
+        env.ledger().with_mut(|li| {
+            li.sequence_number = 1_000_000;
+        });
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(check_market_creation_rent_budget(&env), Ok(()));
+        });
+    }
+
+    #[test]
+    fn test_budget_check_rejects_aggregate_overflow() {
+        let (env, contract_id) = create_contract_env();
+
+        env.as_contract(&contract_id, || {
+            let effective_ttl = MARKET_TTL_LEDGERS.min(env.storage().max_ttl());
+            let required = effective_ttl * MARKET_CREATION_PERSISTENT_KEYS;
+
+            // Sequence chosen so a single key still fits but the aggregate does not.
+            let sequence = u32::MAX - required + 1;
+            env.ledger().with_mut(|li| {
+                li.sequence_number = sequence;
+            });
+
+            assert_eq!(
+                check_market_creation_rent_budget(&env),
+                Err(Error::InsufficientStorageRentBudget)
+            );
+        });
+    }
+
+    /// The aggregate check must be strictly stronger than the single-key check.
+    ///
+    /// At a sequence where one key fits but three do not, the original preflight
+    /// returns `Ok` while the budget check rejects — this is the behaviour the
+    /// single-key check could not provide.
+    #[test]
+    fn test_budget_check_is_stricter_than_single_key_check() {
+        let (env, contract_id) = create_contract_env();
+
+        env.as_contract(&contract_id, || {
+            let effective_ttl = MARKET_TTL_LEDGERS.min(env.storage().max_ttl());
+            assert!(
+                MARKET_CREATION_PERSISTENT_KEYS > 1,
+                "test is meaningless if creation writes a single key"
+            );
+
+            // Fits one key with room to spare, but not the full aggregate.
+            let sequence = u32::MAX - effective_ttl - 1;
+            env.ledger().with_mut(|li| {
+                li.sequence_number = sequence;
+            });
+
+            assert_eq!(check_market_creation_rent(&env), Ok(()));
+            assert_eq!(
+                check_market_creation_rent_budget(&env),
+                Err(Error::InsufficientStorageRentBudget)
+            );
+        });
+    }
+
+    #[test]
+    fn test_budget_check_rejects_at_u32_max_sequence() {
+        let (env, contract_id) = create_contract_env();
+        env.ledger().with_mut(|li| {
+            li.sequence_number = u32::MAX;
+        });
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                check_market_creation_rent_budget(&env),
+                Err(Error::InsufficientStorageRentBudget)
+            );
+        });
+    }
+
+    #[test]
+    fn test_balance_ttl_honours_storage_config_override() {
+        let (env, contract_id) = create_contract_env();
+        let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let asset = ReflectorAsset::BTC;
+
+        env.as_contract(&contract_id, || {
+            let mut config = StorageOptimizer::get_storage_config(&env);
+            config.balance_ttl_ledgers = 10_000;
+            StorageOptimizer::update_storage_config(&env, &config).unwrap();
+
+            BalanceStorage::set_balance(
+                &env,
+                &Balance {
+                    user: user.clone(),
+                    asset: asset.clone(),
+                    amount: 10,
+                },
+            )
+            .unwrap();
+
+            let key = BalanceStorage::get_key(&env, &user, &asset);
+            let expected = StorageOptimizer::clamp_persistent_ttl(&env, 10_000);
+            assert_eq!(env.storage().persistent().get_ttl(&key), expected);
         });
     }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Pull Request Description</h1>
<blockquote>
<h2>⚠️ Read first: the base branch does not compile</h2>
<p><code>master</code> @ <code>43fdfdd</code> does not build. This is <strong>pre-existing and unrelated to
this PR</strong>, but it means CI cannot pass and <code>cargo test</code> cannot be run —
including for the tests added here. Details in "Test Results" below.</p>
<p>A reviewer checking out this branch will see the same errors. They are not
from these changes.</p>
</blockquote>
<hr>
<h2>📋 Basic Information</h2>
<h3>Type of Change</h3>
<ul>
<li>[x] 🐛 Bug fix (non-breaking change which fixes an issue) — prerequisite <code>DataKey</code> repair</li>
<li>[x] ✨ New feature (non-breaking change which adds functionality) — aggregate TTL preflight</li>
<li>[ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)</li>
<li>[ ] 📚 Documentation update</li>
<li>[ ] 🧪 Test addition/update</li>
<li>[ ] 🔧 Refactoring (no functional changes)</li>
<li>[ ] ⚡ Performance improvement</li>
<li>[ ] 🔒 Security fix</li>
<li>[ ] 🎨 UI/UX improvement</li>
<li>[ ] 🚀 Deployment/Infrastructure change</li>
</ul>
<h3>Related Issues</h3>
<p>Closes #839
Related to #836 (documents the storage tiers this check operates on)</p>
<h3>Priority Level</h3>
<ul>
<li>[ ] 🔴 Critical (blocking other development)</li>
<li>[ ] 🟡 High (significant impact)</li>
<li>[x] 🟢 Medium (moderate impact)</li>
<li>[ ] 🔵 Low (minor improvement)</li>
</ul>
<hr>
<h2>📝 Detailed Description</h2>
<h3>What does this PR do?</h3>
<p>#839 asks for a storage-TTL preflight on <code>create_market</code>. <strong>A preflight already
exists</strong>: <code>check_market_creation_rent</code> at <code>storage.rs:41</code>, wired into both
creation paths (<code>markets.rs:132</code>, <code>lib.rs:413</code>), with three tests in
<code>market_creation_validation_tests.rs</code> under a
<code>// ── Storage Rent Pre-flight Tests ──</code> header.</p>
<p>Rather than reimplement it, this PR completes the parts that were scoped out.
The code signposts them through two dead symbols:</p>

Symbol | Status before this PR
-- | --
MARKET_CREATION_PERSISTENT_KEYS | declared at storage.rs:26, never read, and its value (1) was wrong
Error::InsufficientStorageRentBudget | declared at err.rs:239 with display strings at :1555, :1666, :1787 — never constructed


<p>Deliberately not touched: repairing these means restructuring imports and module
declarations across a 7,700-line file, which is a different change from
"preflight storage TTL pressure" and would likely conflict with several of the
40 open PRs.</p>
<h3>Manual Testing Steps</h3>
<ol>
<li>Read <code>lib.rs</code> <code>create_market</code> end to end and enumerated every
<code>persistent().set(...)</code> reached during one call, following
<code>record_market_created</code> and <code>append_record</code> into their own modules to confirm
each write's storage tier.</li>
<li><code>grep -rn "InsufficientStorageRentBudget" --include=*.rs</code> across the crate —
confirmed four occurrences, all declaration/display, zero constructors.</li>
<li><code>grep -rn "MARKET_CREATION_PERSISTENT_KEYS" --include=*.rs</code> — confirmed a
single occurrence (its own declaration).</li>
<li>Recomputed <code>effective_ttl * MARKET_CREATION_PERSISTENT_KEYS</code> boundary values
used in the tests against <code>u32::MAX</code>.</li>
<li>Diffed all three edited files against <code>master</code>; confirmed two hunks in
<code>markets.rs</code>, two in <code>lib.rs</code>, and the intended edits in <code>storage.rs</code>.</li>
</ol>
<hr>
<h2>📚 Documentation</h2>
<h3>Documentation Updates</h3>
<ul>
<li>[ ] README updated</li>
<li>[x] Code comments added/updated — rustdoc on the new function and the corrected constant; inline comments at both call sites explaining why one propagates and one panics</li>
<li>[x] API documentation updated — NatSpec-style <code>///</code> with <code># Formula</code> and <code># Errors</code>, matching the existing preflight's style</li>
<li>[ ] Examples updated</li>
<li>[ ] Deployment instructions updated</li>
<li>[ ] Contributing guidelines updated</li>
<li>[ ] Architecture documentation updated</li>
</ul>
<h3>Breaking Changes</h3>
<p><strong>Breaking Changes:</strong></p>
<ul>
<li>None.</li>
</ul>
<p><code>Error::InsufficientStorageRentBudget</code> was already a declared variant with a
stable numeric code (523). This PR only makes it reachable, so clients switching
on error codes see a code that was already in the enum. The new <code>DataKey</code>
variants were already being constructed at call sites; the enum simply did not
declare them.</p>
<p><strong>Migration Guide:</strong> Not applicable.</p>
<hr>
<h2>🔍 Code Quality</h2>
<h3>Code Review Checklist</h3>
<ul>
<li>[x] Code follows Rust/Soroban best practices</li>
<li>[x] Self-review completed</li>
<li>[x] No unnecessary code duplication</li>
<li>[x] Error handling is appropriate — <code>ok_or(...)?</code> on both fallible steps, no <code>unwrap()</code></li>
<li>[ ] Logging/monitoring added where needed — no events appropriate for a preflight</li>
<li>[x] Security considerations addressed</li>
<li>[x] Performance implications considered</li>
<li>[x] Code is readable and well-commented</li>
<li>[x] Variable names are descriptive</li>
<li>[x] Functions are focused and small</li>
</ul>
<h3>Performance Impact</h3>
<ul>
<li><strong>Gas Usage</strong>: Two <code>u32</code> arithmetic operations and one <code>max_ttl()</code> read per
<code>create_market</code>. Negligible.</li>
<li><strong>Storage Impact</strong>: None — no additional reads or writes to storage.</li>
<li><strong>Computational Complexity</strong>: O(1).</li>
</ul>
<h3>Security Review</h3>
<ul>
<li>[x] No obvious security vulnerabilities</li>
<li>[x] Access controls properly implemented — unchanged; no new entrypoint</li>
<li>[x] Input validation in place — operates on ledger state, not user input</li>
<li>[ ] Oracle data properly validated — not applicable</li>
<li>[x] No sensitive data exposed</li>
</ul>
<hr>
<h2>🚀 Deployment &amp; Integration</h2>
<h3>Deployment Notes</h3>
<ul>
<li><strong>Network</strong>: Testnet first — the stricter check should be observed against a
real ledger sequence before mainnet.</li>
<li><strong>Contract Address</strong>: N/A</li>
<li><strong>Migration Required</strong>: No — no storage layout migration; existing entries are
unaffected.</li>
<li><strong>Special Instructions</strong>: None.</li>
</ul>
<h3>Integration Points</h3>
<ul>
<li>[ ] Frontend integration considered — not applicable</li>
<li>[x] API changes documented — new error surfaced from <code>create_market</code>; clients using <code>try_create_market</code> may now observe code 523</li>
<li>[x] Backward compatibility maintained</li>
<li>[ ] Third-party integrations updated — not applicable</li>
</ul>
<hr>
<h2>📊 Impact Assessment</h2>
<h3>User Impact</h3>
<ul>
<li><strong>End Users</strong>: None in normal operation. The check only rejects ledger states
that would have produced a partially-provisioned market.</li>
<li><strong>Developers</strong>: <code>create_market</code> can now surface
<code>InsufficientStorageRentBudget</code> (523). Two previously dead symbols are now
live and meaningful.</li>
<li><strong>Admins</strong>: Market creation fails cleanly rather than leaving a market whose
statistics and audit entries lack a full TTL.</li>
</ul>
<h3>Business Impact</h3>
<ul>
<li><strong>Revenue</strong>: None.</li>
<li><strong>User Experience</strong>: Marginally improved — a failure mode that would have
surfaced later as missing audit or statistics data now fails fast at creation.</li>
<li><strong>Technical Debt</strong>: Net reduction. Removes two dead symbols, corrects a wrong
constant, and eliminates one hardcoded TTL literal. Does not address the
larger <code>lib.rs</code> breakage, which remains outstanding.</li>
</ul>
<hr>
<h2>✅ Final Checklist</h2>
<h3>Pre-Submission</h3>
<ul>
<li>[x] Code follows Rust/Soroban best practices</li>
<li>[ ] All CI checks passing — <strong>cannot pass; base branch does not compile (pre-existing)</strong></li>
<li>[x] No breaking changes (or breaking changes are documented)</li>
<li>[x] Ready for review</li>
<li>[x] PR description is complete and accurate</li>
<li>[x] All required sections filled out</li>
<li>[x] Test results included — including why the suite cannot run</li>
<li>[x] Documentation updated</li>
</ul>
<h3>Review Readiness</h3>
<ul>
<li>[x] Self-review completed</li>
<li>[x] Code is clean and well-formatted</li>
<li>[x] Commit messages are clear and descriptive</li>
<li>[x] Branch is up to date with main</li>
<li>[x] No merge conflicts</li>
</ul>
<hr>
<h2>📸 Screenshots (if applicable)</h2>
<p>Not applicable.</p>
<hr>
<h2>🔗 Additional Resources</h2>
<ul>
<li><strong>Design Document</strong>: N/A</li>
<li><strong>Technical Spec</strong>: <code>contracts/predictify-hybrid/src/storage.rs</code></li>
<li><strong>Related Discussion</strong>: #839, #836</li>
<li><strong>External Documentation</strong>:
<a href="https://developers.stellar.org/docs/build/guides/archival">Soroban state archival &amp; TTL</a></li>
</ul>
<hr>
<h2>💬 Notes for Reviewers</h2>
<p><strong>Please pay special attention to:</strong></p>
<ul>
<li>
<p><strong>The value <code>3</code> for <code>MARKET_CREATION_PERSISTENT_KEYS</code>.</strong> Derived by reading
the entrypoint's write path: market record, platform statistics, audit record.
If any helper writes more entries than I traced, or a fourth write exists that
I missed, the constant is too low and the check is correspondingly too weak.
This is the single number most worth a second pair of eyes.</p>
</li>
<li>
<p><strong>Whether commit 1 (the <code>DataKey</code> repair) belongs in this PR.</strong> It is scope
creep beyond #839, included only because nothing compiles without it. It is
the first commit and touches nothing else, so it can be cherry-picked out or
this PR rebased onto a separate fix. If a repair is already in flight among
the open PRs, I will drop it.</p>
</li>
<li>
<p><strong>Keeping both checks vs. consolidating to one.</strong> See "Alternative Solutions
Considered".</p>
</li>
</ul>
<p><strong>Questions for reviewers:</strong></p>
<ul>
<li>Should #839 have been closed as already-implemented? The issue names
<code>contracts/predictify-hybrid/src/markets.rs</code> as the file to modify, and that
file already contained <code>check_market_creation_rent(env)?;</code> at line 132 before
this PR. I have read the issue as asking for completion of the scoped-out
aggregate check rather than a reimplementation — please redirect me if that
reading is wrong.</li>
<li>Is the <code>lib.rs</code> breakage (236 errors) tracked anywhere? I could not find an
issue for it, and it blocks any PR that needs to run the test suite.</li>
<li>Should the <code>set_balance</code> tier-helper cleanup stay in this PR, or move to its
own? It is a separate commit and unrelated to the preflight beyond touching
the same file.</li>
</ul>
<hr>
<p><strong>Thank you for your contribution to Predictify! 🚀</strong></p></body></html><!--EndFragment-->
</body>
</html># Pull Request Description

> ## ⚠️ Read first: the base branch does not compile
>
> `master` @ `43fdfdd` does not build. This is **pre-existing and unrelated to
> this PR**, but it means CI cannot pass and `cargo test` cannot be run —
> including for the tests added here. Details in "Test Results" below.
>
> A reviewer checking out this branch will see the same errors. They are not
> from these changes.

---

## 📋 Basic Information

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — prerequisite `DataKey` repair
- [x] ✨ New feature (non-breaking change which adds functionality) — aggregate TTL preflight
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧪 Test addition/update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🎨 UI/UX improvement
- [ ] 🚀 Deployment/Infrastructure change

### Related Issues
Closes #839
Related to #836 (documents the storage tiers this check operates on)

### Priority Level
- [ ] 🔴 Critical (blocking other development)
- [ ] 🟡 High (significant impact)
- [x] 🟢 Medium (moderate impact)
- [ ] 🔵 Low (minor improvement)

---

## 📝 Detailed Description

### What does this PR do?

#839 asks for a storage-TTL preflight on `create_market`. **A preflight already
exists**: `check_market_creation_rent` at `storage.rs:41`, wired into both
creation paths (`markets.rs:132`, `lib.rs:413`), with three tests in
`market_creation_validation_tests.rs` under a
`// ── Storage Rent Pre-flight Tests ──` header.

Rather than reimplement it, this PR completes the parts that were scoped out.
The code signposts them through two dead symbols:

| Symbol | Status before this PR |
| --- | --- |
| `MARKET_CREATION_PERSISTENT_KEYS` | declared at `storage.rs:26`, **never read**, and its value (`1`) was wrong |
| `Error::InsufficientStorageRentBudget` | declared at `err.rs:239` with display strings at `:1555`, `:1666`, `:1787` — **never constructed** |

Two error variants existed for one concept, one unreachable. That reads as an
intended split:

- `InsufficientStorageRent` — single-key `u32` overflow (was implemented)
- `InsufficientStorageRentBudget` — aggregate multi-key budget (was not)

**Changes:**

1. **`MARKET_CREATION_PERSISTENT_KEYS: 1 → 3`.** The entrypoint writes three
   persistent entries per creation, not one:

   | # | Write | Location |
   | --- | --- | --- |
   | 1 | market record | `lib.rs:418` |
   | 2 | platform stats, via `record_market_created` → `set_platform_stats` | `statistics.rs:58` |
   | 3 | audit record, via `AuditTrailManager::append_record` | `audit_trail.rs:114` |

   Each confirmed persistent by reading the function body. The
   `MarketCreator::create_market` helper writes only entry 1, so the constant is
   documented as an upper bound: a creation that succeeds on the helper path
   cannot then fail partway through the entrypoint path.

2. **New `check_market_creation_rent_budget`** in `storage.rs`, returning
   `InsufficientStorageRentBudget`.

3. **Wired into both call sites** — `markets.rs` propagates via `?`; `lib.rs`
   panics via `panic_with_error!` because the entrypoint returns `Symbol`, not
   `Result`.

4. **`set_balance` routed through the tier helper** instead of hardcoded TTL
   literals (separate commit, droppable).

5. **Prerequisite: `DataKey` repaired** so the crate compiles at all (separate
   commit, droppable — see Notes for Reviewers).

### Why is this change needed?

The existing check has two limits:

1. **It effectively never fires.** It trips only when the ledger sequence is
   within `effective_ttl` (~6.3M ledgers, ~365 days) of `u32::MAX` — which is
   why the existing test must set `sequence_number: u32::MAX - 1_000` to
   trigger it at all.
2. **Key count never enters the formula.** One key and three keys produce an
   identical verdict.

The gap: a market record could be stored with a full TTL while its companion
statistics and audit entries could not be given one.

### How was this tested?

**`cargo test` could not be run** — the base branch does not compile. See "Test
Results". The five tests below are added and are expected to pass once the base
builds.

Manual verification performed instead:

1. Traced all three persistent writes in the entrypoint to confirm the `3`.
2. `grep`ed the whole crate to confirm `InsufficientStorageRentBudget` had no
   constructor and `MARKET_CREATION_PERSISTENT_KEYS` had no reader.
3. Recomputed the tier arithmetic against `LEDGERS_PER_DAY = 17_280`.
4. Confirmed brace/paren balance on all three edited files. The `-2` paren delta
   in `lib.rs` is pre-existing (unbalanced parens inside doc-comment prose),
   identical before and after these edits.
5. Diffed each edited file against `master` to confirm only the intended hunks
   changed.

### Alternative Solutions Considered

**Replace `check_market_creation_rent` instead of adding alongside it.** The
aggregate check mathematically subsumes it, making the original redundant at
both call sites. Kept because removing it would break the three existing tests
that assert `InsufficientStorageRent` specifically. Happy to consolidate to one
call and one error if preferred.

**Reorder the fee charge.** In `markets.rs` the preflight still runs *after*
`process_creation_fee`. Pre-existing ordering; a rent failure returns `Err` so
the host rolls back the whole invocation and no funds are lost. Left unchanged
as out of scope.

**Change the `lib.rs` entrypoint to return `Result`.** Would allow propagation
instead of panicking. Not done — breaking signature change for every client.

**Reimplement the preflight from scratch per the issue text.** Rejected: it
already exists in the exact file #839 names.

---

## 🏗️ Smart Contract Specific

### Contract Changes

- [ ] Core contract logic modified
- [ ] Oracle integration changes (Pyth/Reflector)
- [x] New functions added — `check_market_creation_rent_budget`
- [x] Existing functions modified — `create_market` (both paths), `set_balance`
- [x] Storage structure changes — `DataKey` variants (all previously constructed at call sites; no new on-chain key shapes)
- [ ] Events added/modified
- [x] Error handling improved — `InsufficientStorageRentBudget` now reachable
- [ ] Gas optimization
- [ ] Access control changes
- [ ] Admin functions modified
- [ ] Fee structure changes

### Oracle Integration
Not applicable — no oracle code touched.

### Market Resolution Logic
Not applicable — no resolution code touched.

### Security Considerations
- [x] Access control reviewed — no new state-changing entrypoint; both call sites already authenticate upstream
- [ ] Reentrancy protection — not applicable, no external calls added
- [x] Input validation — no user input; operates on ledger sequence and constants
- [x] Overflow/underflow protection — `checked_mul` then `checked_add`, no wrapping arithmetic, no `unwrap()`
- [ ] Oracle manipulation protection — not applicable

The change is strictly more conservative: it rejects a superset of what was
rejected before. No input previously accepted-and-fully-written is now
accepted-and-partially-written.

---

## 🧪 Testing

### Test Coverage
- [x] Unit tests added/updated — 5 new tests
- [ ] Integration tests added/updated
- [ ] All tests passing locally — **cannot run; base does not compile**
- [x] Manual testing completed — see "How was this tested?"
- [ ] Oracle integration tested — not applicable
- [x] Edge cases covered — `u32::MAX`, aggregate-overflow boundary, normal sequence
- [x] Error conditions tested — both error variants asserted
- [ ] Gas usage optimized — negligible impact, not measured
- [ ] Cross-contract interactions tested — not applicable

Tests added to the `storage.rs` test module under a new
`// ── Storage Rent Aggregate Budget Pre-flight Tests ──` header:

| Test | Asserts |
| --- | --- |
| `test_budget_check_accepts_normal_ledger_sequence` | realistic sequence → `Ok` |
| `test_budget_check_rejects_aggregate_overflow` | aggregate overflow → `InsufficientStorageRentBudget` |
| `test_budget_check_is_stricter_than_single_key_check` | at one sequence: single-key `Ok`, aggregate `Err` |
| `test_budget_check_rejects_at_u32_max_sequence` | `u32::MAX` → `Err` |
| `test_balance_ttl_honours_storage_config_override` | `set_balance` respects `StorageConfig` |

The third is the important one: it pins the relationship between the two checks
and fails if the aggregate check is ever weakened to match the single-key one.

### Test Results

```bash
cargo test
# Cannot run — base branch master @ 43fdfdd does not compile.
```

Two independent pre-existing breakages:

**1. `storage.rs` — `DataKey`** (fixed by commit 1 of this PR)

```
error[E0428]: the name `AdminOverrideNonce` is defined multiple times
  --> contracts/predictify-hybrid/src/storage.rs:89:5
   |
74 |     AdminOverrideNonce(Address),
   |     --------------------------- previous definition here
...
89 |     AdminOverrideNonce(Address),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `AdminOverrideNonce` redefined here
```

Plus `AntiGriefFloor`, `GlobalConfig`, and `PlaceBetsIdem` constructed in
`disputes.rs`, the governance tests, and `bets.rs` but absent from the enum.

**2. `lib.rs` — 236 errors** (NOT addressed in this PR)

| Error | Cause |
| --- | --- |
| `Error` defined multiple times | `use err::Error;` (L71) and `pub use err::Error;` (L155) |
| `CircuitBreaker` / `EventEmitter` re-imported | L70/L165 and L72/L170 |
| enum import `BetStatus` is private | `bets::BetStatus` not `pub` |
| unresolved `events::ClaimInfo` | lives at `crate::types::ClaimInfo` |
| file not found for `capability_bitmap_tests` | `mod` declared, file absent |
| `statistics`, `graceful_degradation`, `market_id_generator`, `rate_limiter` | referenced as `crate::x::…`, never declared `mod x;` — files exist |

Deliberately not touched: repairing these means restructuring imports and module
declarations across a 7,700-line file, which is a different change from
"preflight storage TTL pressure" and would likely conflict with several of the
40 open PRs.

### Manual Testing Steps
1. Read `lib.rs` `create_market` end to end and enumerated every
   `persistent().set(...)` reached during one call, following
   `record_market_created` and `append_record` into their own modules to confirm
   each write's storage tier.
2. `grep -rn "InsufficientStorageRentBudget" --include=*.rs` across the crate —
   confirmed four occurrences, all declaration/display, zero constructors.
3. `grep -rn "MARKET_CREATION_PERSISTENT_KEYS" --include=*.rs` — confirmed a
   single occurrence (its own declaration).
4. Recomputed `effective_ttl * MARKET_CREATION_PERSISTENT_KEYS` boundary values
   used in the tests against `u32::MAX`.
5. Diffed all three edited files against `master`; confirmed two hunks in
   `markets.rs`, two in `lib.rs`, and the intended edits in `storage.rs`.

---

## 📚 Documentation

### Documentation Updates
- [ ] README updated
- [x] Code comments added/updated — rustdoc on the new function and the corrected constant; inline comments at both call sites explaining why one propagates and one panics
- [x] API documentation updated — NatSpec-style `///` with `# Formula` and `# Errors`, matching the existing preflight's style
- [ ] Examples updated
- [ ] Deployment instructions updated
- [ ] Contributing guidelines updated
- [ ] Architecture documentation updated

### Breaking Changes

**Breaking Changes:**
- None.

`Error::InsufficientStorageRentBudget` was already a declared variant with a
stable numeric code (523). This PR only makes it reachable, so clients switching
on error codes see a code that was already in the enum. The new `DataKey`
variants were already being constructed at call sites; the enum simply did not
declare them.

**Migration Guide:** Not applicable.

---

## 🔍 Code Quality

### Code Review Checklist
- [x] Code follows Rust/Soroban best practices
- [x] Self-review completed
- [x] No unnecessary code duplication
- [x] Error handling is appropriate — `ok_or(...)?` on both fallible steps, no `unwrap()`
- [ ] Logging/monitoring added where needed — no events appropriate for a preflight
- [x] Security considerations addressed
- [x] Performance implications considered
- [x] Code is readable and well-commented
- [x] Variable names are descriptive
- [x] Functions are focused and small

### Performance Impact
- **Gas Usage**: Two `u32` arithmetic operations and one `max_ttl()` read per
  `create_market`. Negligible.
- **Storage Impact**: None — no additional reads or writes to storage.
- **Computational Complexity**: O(1).

### Security Review
- [x] No obvious security vulnerabilities
- [x] Access controls properly implemented — unchanged; no new entrypoint
- [x] Input validation in place — operates on ledger state, not user input
- [ ] Oracle data properly validated — not applicable
- [x] No sensitive data exposed

---

## 🚀 Deployment & Integration

### Deployment Notes
- **Network**: Testnet first — the stricter check should be observed against a
  real ledger sequence before mainnet.
- **Contract Address**: N/A
- **Migration Required**: No — no storage layout migration; existing entries are
  unaffected.
- **Special Instructions**: None.

### Integration Points
- [ ] Frontend integration considered — not applicable
- [x] API changes documented — new error surfaced from `create_market`; clients using `try_create_market` may now observe code 523
- [x] Backward compatibility maintained
- [ ] Third-party integrations updated — not applicable

---

## 📊 Impact Assessment

### User Impact
- **End Users**: None in normal operation. The check only rejects ledger states
  that would have produced a partially-provisioned market.
- **Developers**: `create_market` can now surface
  `InsufficientStorageRentBudget` (523). Two previously dead symbols are now
  live and meaningful.
- **Admins**: Market creation fails cleanly rather than leaving a market whose
  statistics and audit entries lack a full TTL.

### Business Impact
- **Revenue**: None.
- **User Experience**: Marginally improved — a failure mode that would have
  surfaced later as missing audit or statistics data now fails fast at creation.
- **Technical Debt**: Net reduction. Removes two dead symbols, corrects a wrong
  constant, and eliminates one hardcoded TTL literal. Does not address the
  larger `lib.rs` breakage, which remains outstanding.

---

## ✅ Final Checklist

### Pre-Submission
- [x] Code follows Rust/Soroban best practices
- [ ] All CI checks passing — **cannot pass; base branch does not compile (pre-existing)**
- [x] No breaking changes (or breaking changes are documented)
- [x] Ready for review
- [x] PR description is complete and accurate
- [x] All required sections filled out
- [x] Test results included — including why the suite cannot run
- [x] Documentation updated

### Review Readiness
- [x] Self-review completed
- [x] Code is clean and well-formatted
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No merge conflicts

---

## 📸 Screenshots (if applicable)
Not applicable.

---

## 🔗 Additional Resources
- **Design Document**: N/A
- **Technical Spec**: `contracts/predictify-hybrid/src/storage.rs`
- **Related Discussion**: #839, #836
- **External Documentation**:
  [[Soroban state archival & TTL](https://developers.stellar.org/docs/build/guides/archival)](https://developers.stellar.org/docs/build/guides/archival)

---

## 💬 Notes for Reviewers

**Please pay special attention to:**

- **The value `3` for `MARKET_CREATION_PERSISTENT_KEYS`.** Derived by reading
  the entrypoint's write path: market record, platform statistics, audit record.
  If any helper writes more entries than I traced, or a fourth write exists that
  I missed, the constant is too low and the check is correspondingly too weak.
  This is the single number most worth a second pair of eyes.

- **Whether commit 1 (the `DataKey` repair) belongs in this PR.** It is scope
  creep beyond #839, included only because nothing compiles without it. It is
  the first commit and touches nothing else, so it can be cherry-picked out or
  this PR rebased onto a separate fix. If a repair is already in flight among
  the open PRs, I will drop it.

- **Keeping both checks vs. consolidating to one.** See "Alternative Solutions
  Considered".

**Questions for reviewers:**

- Should #839 have been closed as already-implemented? The issue names
  `contracts/predictify-hybrid/src/markets.rs` as the file to modify, and that
  file already contained `check_market_creation_rent(env)?;` at line 132 before
  this PR. I have read the issue as asking for completion of the scoped-out
  aggregate check rather than a reimplementation — please redirect me if that
  reading is wrong.
- Is the `lib.rs` breakage (236 errors) tracked anywhere? I could not find an
  issue for it, and it blocks any PR that needs to run the test suite.
- Should the `set_balance` tier-helper cleanup stay in this PR, or move to its
  own? It is a separate commit and unrelated to the preflight beyond touching
  the same file.

---

**Thank you for your contribution to Predictify! 🚀**