### PR TITLE
test: add dispute state invariant proptests

### DIFF
--- a/contracts/predictify-hybrid/src/disputes.rs
+++ b/contracts/predictify-hybrid/src/disputes.rs
@@ -2863,17 +2863,32 @@ impl DisputeUtils {
         let mut voting_data = Self::get_dispute_voting(env, dispute_id)?;
 
         // Update voting statistics
-        voting_data.total_votes += 1;
+        voting_data.total_votes = voting_data
+            .total_votes
+            .checked_add(1)
+            .ok_or(Error::Overflow)?;
         
         // Calculate the decayed stake using tally_votes
         let decayed_stake = Self::tally_votes(env, vote.stake, vote.timestamp, voting_data.voting_start);
 
         if vote.vote {
-            voting_data.support_votes += 1;
-            voting_data.total_support_stake += decayed_stake;
+            voting_data.support_votes = voting_data
+                .support_votes
+                .checked_add(1)
+                .ok_or(Error::Overflow)?;
+            voting_data.total_support_stake = voting_data
+                .total_support_stake
+                .checked_add(decayed_stake)
+                .ok_or(Error::Overflow)?;
         } else {
-            voting_data.against_votes += 1;
-            voting_data.total_against_stake += decayed_stake;
+            voting_data.against_votes = voting_data
+                .against_votes
+                .checked_add(1)
+                .ok_or(Error::Overflow)?;
+            voting_data.total_against_stake = voting_data
+                .total_against_stake
+                .checked_add(decayed_stake)
+                .ok_or(Error::Overflow)?;
         }
 
         // Store updated voting data
@@ -2911,9 +2926,13 @@ impl DisputeUtils {
         let diff = weight_at_n.saturating_sub(weight_at_n_plus_1);
         let exact_weight = weight_at_n.saturating_sub((diff as u64 * rem / cfg.half_life_seconds) as u32);
         
-        let final_weight = exact_weight.max(cfg.floor_bps);
-        
-        (raw_stake * final_weight as i128) / 10000
+        // A misconfigured floor must never amplify a vote above its raw stake.
+        let final_weight = exact_weight.max(cfg.floor_bps).min(10_000) as i128;
+
+        // Split before multiplying so every i128 input remains overflow-safe.
+        let whole = raw_stake / 10_000;
+        let remainder = raw_stake % 10_000;
+        whole * final_weight + (remainder * final_weight) / 10_000
     }
 
     pub fn set_dispute_decay_config(env: &Env, admin: Address, config: DisputeDecayConfig) -> Result<(), Error> {

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -173,6 +173,9 @@ mod force_resolve_tests;
 mod analytics_snapshot_tests;
 #[cfg(test)]
 mod property_based_tests;
+#[cfg(test)]
+#[path = "tests/disputes_proptest.rs"]
+mod disputes_proptest;
 mod analytics_snapshot;
 
 #[cfg(test)]

--- a/contracts/predictify-hybrid/src/tests/disputes_proptest.rs
+++ b/contracts/predictify-hybrid/src/tests/disputes_proptest.rs
@@ -1,0 +1,206 @@
+//! Property tests for dispute voting state invariants.
+//!
+//! These tests operate on the same Soroban storage helpers used by dispute
+//! entrypoints. Generated vote sequences are checked after every transition so
+//! proptest can shrink a failure to the smallest state-changing sequence.
+
+use alloc::vec::Vec as StdVec;
+
+use proptest::prelude::*;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Symbol};
+
+use crate::{
+    disputes::{DisputeDecayConfig, DisputeUtils, DisputeVote, DisputeVoting, DisputeVotingStatus},
+    Error, PredictifyHybrid,
+};
+
+const MAX_GENERATED_STAKE: i128 = 1_000_000_000_000;
+
+/// Converts a typed contract error into a shrink-friendly proptest failure.
+fn contract_result<T>(result: Result<T, Error>) -> Result<T, TestCaseError> {
+    result.map_err(|error| TestCaseError::fail(alloc::format!("contract error: {error:?}")))
+}
+
+/// Runs a property inside registered contract storage.
+fn with_contract<T>(test: impl FnOnce(&Env) -> T) -> T {
+    let env = Env::default();
+    let contract_id = env.register(PredictifyHybrid, ());
+    env.as_contract(&contract_id, || test(&env))
+}
+
+/// Builds an active voting record with deterministic timestamps.
+fn active_voting(env: &Env, dispute_id: &Symbol) -> DisputeVoting {
+    DisputeVoting {
+        dispute_id: dispute_id.clone(),
+        voting_start: 1_000,
+        voting_end: 100_000,
+        total_votes: 0,
+        support_votes: 0,
+        against_votes: 0,
+        total_support_stake: 0,
+        total_against_stake: 0,
+        status: DisputeVotingStatus::Active,
+    }
+}
+
+/// Creates a generated vote for the supplied side and stake.
+fn vote(
+    env: &Env,
+    dispute_id: &Symbol,
+    supports: bool,
+    stake: i128,
+    timestamp: u64,
+) -> DisputeVote {
+    DisputeVote {
+        user: Address::generate(env),
+        dispute_id: dispute_id.clone(),
+        vote: supports,
+        stake,
+        timestamp,
+        reason: None,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 128,
+        max_shrink_iters: 2_048,
+        ..ProptestConfig::default()
+    })]
+
+    /// Every successful vote preserves count and stake conservation.
+    #[test]
+    fn generated_vote_sequences_preserve_tally_invariants(
+        votes in prop::collection::vec(
+            (any::<bool>(), 0i128..=MAX_GENERATED_STAKE),
+            0..64,
+        ),
+    ) {
+        with_contract(|env| {
+            let dispute_id = Symbol::new(env, "inv_seq");
+            let initial = active_voting(env, &dispute_id);
+            contract_result(DisputeUtils::store_dispute_voting(env, &dispute_id, &initial))?;
+
+            let mut expected_support_votes = 0u32;
+            let mut expected_against_votes = 0u32;
+            let mut expected_support_stake = 0i128;
+            let mut expected_against_stake = 0i128;
+
+            for (index, (supports, stake)) in votes.iter().enumerate() {
+                let generated_vote = vote(
+                    env,
+                    &dispute_id,
+                    *supports,
+                    *stake,
+                    1_000 + index as u64,
+                );
+                contract_result(DisputeUtils::add_vote_to_dispute(env, &dispute_id, generated_vote))?;
+
+                if *supports {
+                    expected_support_votes += 1;
+                    expected_support_stake += *stake;
+                } else {
+                    expected_against_votes += 1;
+                    expected_against_stake += *stake;
+                }
+
+                let stored = contract_result(DisputeUtils::get_dispute_voting(env, &dispute_id))?;
+                prop_assert_eq!(
+                    stored.total_votes,
+                    stored.support_votes + stored.against_votes,
+                );
+                prop_assert_eq!(stored.support_votes, expected_support_votes);
+                prop_assert_eq!(stored.against_votes, expected_against_votes);
+                prop_assert_eq!(stored.total_support_stake, expected_support_stake);
+                prop_assert_eq!(stored.total_against_stake, expected_against_stake);
+                prop_assert_eq!(stored.dispute_id, dispute_id.clone());
+                prop_assert!(matches!(stored.status, DisputeVotingStatus::Active));
+            }
+
+            Ok::<(), TestCaseError>(())
+        })?;
+    }
+
+    /// Decay never creates stake and cannot increase as a vote gets later.
+    #[test]
+    fn decayed_stake_is_bounded_and_monotonic(
+        raw_stake in 0i128..=i128::MAX,
+        half_life in 1u64..=604_800,
+        floor_bps in 0u32..=20_000,
+        first_elapsed in 0u64..=10_000_000,
+        extra_elapsed in 0u64..=10_000_000,
+    ) {
+        with_contract(|env| {
+            env.storage().persistent().set(
+                &symbol_short!("decaycfg"),
+                &DisputeDecayConfig {
+                    half_life_seconds: half_life,
+                    floor_bps,
+                },
+            );
+
+            let later_elapsed = first_elapsed.saturating_add(extra_elapsed);
+            let first = DisputeUtils::tally_votes(env, raw_stake, first_elapsed, 0);
+            let later = DisputeUtils::tally_votes(env, raw_stake, later_elapsed, 0);
+
+            prop_assert!(first >= 0);
+            prop_assert!(first <= raw_stake);
+            prop_assert!(later >= 0);
+            prop_assert!(later <= first);
+        });
+    }
+
+    /// The outcome is support only for a strict support-stake majority.
+    #[test]
+    fn outcome_matches_strict_stake_majority(
+        support in 0i128..=i128::MAX,
+        against in 0i128..=i128::MAX,
+    ) {
+        let env = Env::default();
+        let dispute_id = Symbol::new(&env, "inv_out");
+        let mut voting = active_voting(&env, &dispute_id);
+        voting.total_support_stake = support;
+        voting.total_against_stake = against;
+
+        prop_assert_eq!(
+            DisputeUtils::calculate_stake_weighted_outcome(&voting),
+            support > against,
+        );
+    }
+
+    /// Overflow errors are atomic: rejected votes leave stored state unchanged.
+    #[test]
+    fn overflow_rejection_preserves_stored_state(
+        supports in any::<bool>(),
+        counter_overflow in any::<bool>(),
+    ) {
+        with_contract(|env| {
+            let dispute_id = Symbol::new(env, "inv_ovf");
+            let mut initial = active_voting(env, &dispute_id);
+            if counter_overflow {
+                initial.total_votes = u32::MAX;
+            } else if supports {
+                initial.total_support_stake = i128::MAX;
+            } else {
+                initial.total_against_stake = i128::MAX;
+            }
+            contract_result(DisputeUtils::store_dispute_voting(env, &dispute_id, &initial))?;
+
+            let result = DisputeUtils::add_vote_to_dispute(
+                env,
+                &dispute_id,
+                vote(env, &dispute_id, supports, 1, 1_000),
+            );
+            prop_assert_eq!(result, Err(Error::Overflow));
+
+            let stored = contract_result(DisputeUtils::get_dispute_voting(env, &dispute_id))?;
+            prop_assert_eq!(stored.total_votes, initial.total_votes);
+            prop_assert_eq!(stored.support_votes, initial.support_votes);
+            prop_assert_eq!(stored.against_votes, initial.against_votes);
+            prop_assert_eq!(stored.total_support_stake, initial.total_support_stake);
+            prop_assert_eq!(stored.total_against_stake, initial.total_against_stake);
+
+            Ok::<(), TestCaseError>(())
+        })?;
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Comprehensive security documentation and guidelines:
 - **[Security Best Practices](./security/SECURITY_BEST_PRACTICES.md)** - Development and deployment security guidelines
 - **[Security Considerations](./security/SECURITY_CONSIDERATIONS.md)** - Important security considerations for the system
 - **[Security Testing Guide](./security/SECURITY_TESTING_GUIDE.md)** - Executable security checklist mapped to automated tests
+- **[Dispute Invariant Property Tests](./security/DISPUTE_INVARIANT_PROPTEST.md)** - Generated dispute-state invariants and overflow safety
 
 ### ⛽ [Gas Optimization Documentation](./gas/)
 

--- a/docs/security/DISPUTE_INVARIANT_PROPTEST.md
+++ b/docs/security/DISPUTE_INVARIANT_PROPTEST.md
@@ -1,0 +1,48 @@
+# Dispute invariant property tests
+
+Issue #879 adds state-invariant property coverage for dispute voting in
+`contracts/predictify-hybrid/src/tests/disputes_proptest.rs`.
+
+## Invariants
+
+Generated inputs verify that:
+
+- `total_votes` always equals `support_votes + against_votes`;
+- support and against stakes are conserved independently after every vote;
+- dispute identity, lifecycle status, and unrelated tally fields do not change;
+- stake decay stays between zero and the raw stake and is monotonic over time;
+- exact stake ties reject the dispute, while only a strict support majority
+  upholds it;
+- arithmetic overflow returns `Error::Overflow` without partially writing the
+  voting record.
+
+The generators include empty vote sequences, zero stakes, maximum `i128` stakes,
+oversized decay floors, saturated timestamps, ties, and both voting sides.
+Failures are automatically shrunk and can be persisted by proptest as regression
+seeds.
+
+## Security changes
+
+Dispute vote counters and stake totals now use checked addition. Stake decay
+splits division and multiplication to avoid intermediate `i128` overflow, and
+misconfigured floors are capped at 10,000 basis points so decay cannot amplify a
+vote.
+
+Every state-changing public dispute entrypoint retains its existing
+`require_auth` boundary. This change adds no entrypoint and relaxes no
+authorization requirement.
+
+## API changes
+
+There are no public contract API, storage-key, event, or visible UI changes.
+Arithmetic overflow from internal dispute tally updates is now reported as the
+existing `Error::Overflow` value instead of panicking.
+
+## Running
+
+```sh
+cargo test -p predictify-hybrid disputes_proptest
+cargo test -p predictify-hybrid
+cargo fmt --all -- --check
+cargo clippy -p predictify-hybrid --all-targets -- -D warnings
+```


### PR DESCRIPTION
## Description

Adds property-based coverage for dispute voting state invariants in the maintained `predictify-hybrid` contract. The issue's suggested standalone `contracts/disputes` path does not exist on current `master`; dispute logic lives in `contracts/predictify-hybrid/src/disputes.rs`.

## Changes

- Adds 128-case proptests over generated dispute vote sequences.
- Checks vote-count and stake conservation after every stored transition.
- Verifies support/against side isolation, stable dispute identity, and active lifecycle status.
- Verifies strict-majority outcome behavior, including exact ties.
- Covers empty sequences, zero stakes, `i128::MAX`, both vote sides, oversized decay floors, and saturated elapsed times.
- Verifies counter and stake overflow failures are atomic and preserve stored state.
- Replaces unchecked dispute counter/stake additions with `checked_add` and `Error::Overflow`.
- Makes decay multiplication overflow-safe and caps decay weight at 10,000 basis points.
- Documents invariants, security behavior, API impact, and commands.

## Security and authorization

- No new contract entrypoints or storage keys.
- Existing state-changing dispute entrypoints retain their `require_auth` boundaries.
- No `unwrap()` was added to a production path.
- Arithmetic overflow now returns the existing typed `Error::Overflow` rather than panicking or partially persisting a tally.

## API changes

No public contract API, event, storage-key, or UI changes. Internal dispute tally overflow behavior is now explicitly typed as `Error::Overflow`.

## Testing

- `rustfmt --edition 2021 --check contracts/predictify-hybrid/src/tests/disputes_proptest.rs` — passed.
- `git diff --check` — passed.
- `cargo test -p predictify-hybrid disputes_proptest --no-fail-fast` — blocked by pre-existing upstream compile failures before test-module compilation. The first failures include:
  - invalid `symbol_short!("fwd_ok").clone()` syntax in `src/events.rs`;
  - duplicate `OracleResolutionManager`, `SYM_ADMIN`, modules, and error variants;
  - overlength `symbol_short!("max_bet_cap")` values;
  - unresolved modules/macros and hundreds of follow-on errors.
- `cargo fmt --all -- --check` — blocked by the same existing `events.rs` parse error and unrelated formatting drift.

Because the current upstream crate does not compile, coverage measurement and the full standard suite cannot produce a valid result on this baseline. The focused proptest file itself is rustfmt-clean and wired into the unit-test target.

Closes #879