### PR TITLE
test: betting err stability, markets auth snapshot & rustdoc (#867, #859, #857)

### DIFF
--- a/contracts/predictify-hybrid/Cargo.toml
+++ b/contracts/predictify-hybrid/Cargo.toml
@@ -27,6 +27,18 @@ soroban-sdk = { workspace = true }
 name = "err_stability"
 path = "tests/err_stability.rs"
 
+# #867 — betting error-code stability: freezes client-facing Error discriminants
+# for every error variant reachable from betting entrypoints.
+[[test]]
+name = "err_stab"
+path = "tests/err_stab.rs"
+
+# #859 — per-entrypoint auth snapshot: asserts which address each market
+# entrypoint requires authorization from (admin, user, or none).
+[[test]]
+name = "auth_snap"
+path = "tests/auth_snap.rs"
+
 [[test]]
 name = "stateful"
 path = "tests/stateful.rs"

--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -30,8 +30,6 @@ use crate::types::*;
 pub struct MarketCreator;
 
 impl MarketCreator {
-    /// Create a new market with full configuration
-
     /// Creates a new prediction market with comprehensive configuration options.
     ///
     /// This is the primary market creation function that supports all oracle types
@@ -92,7 +90,6 @@ impl MarketCreator {
     ///     oracle_config
     /// ).expect("Market creation should succeed");
     /// ```
-
     pub fn create_market(
         env: &Env,
         admin: Address,
@@ -204,7 +201,6 @@ impl MarketCreator {
     ///     String::from_str(&env, "gt")
     /// ).expect("Reflector market creation should succeed");
     /// ```
-
     pub fn create_reflector_market(
         _env: &Env,
         admin: Address,
@@ -640,7 +636,57 @@ impl MarketValidator {
         Ok(())
     }
 
-    /// Validate outcome for a market
+    /// Validates that a user-supplied outcome string is a valid choice for a market.
+    ///
+    /// This function checks the given `outcome` against the list of outcomes
+    /// defined at market creation time.  The comparison is exact (byte-for-byte),
+    /// so casing and whitespace must match the stored outcome strings precisely.
+    ///
+    /// # Parameters
+    ///
+    /// * `_env` - The Soroban environment (reserved for future use).
+    /// * `outcome` - The outcome string supplied by the caller (e.g. `"yes"`,
+    ///   `"no"`, `"draw"`).
+    /// * `market_outcomes` - The ordered vector of valid outcome strings that
+    ///   were recorded when the market was created.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - The outcome is present in `market_outcomes`.
+    /// * `Err(Error::InvalidOutcome)` - The outcome is not recognised for this
+    ///   market.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::InvalidOutcome`] — Returned when `outcome` does not match any
+    ///   entry in `market_outcomes`.  Callers should surface this to the user as
+    ///   an invalid selection rather than retrying automatically.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use soroban_sdk::{Env, String, Vec};
+    /// use predictify_hybrid::markets::MarketValidator;
+    ///
+    /// let env = Env::default();
+    /// let mut valid_outcomes = Vec::new(&env);
+    /// valid_outcomes.push_back(String::from_str(&env, "yes"));
+    /// valid_outcomes.push_back(String::from_str(&env, "no"));
+    ///
+    /// // Valid outcome — should succeed.
+    /// assert!(MarketValidator::validate_outcome(
+    ///     &env,
+    ///     &String::from_str(&env, "yes"),
+    ///     &valid_outcomes,
+    /// ).is_ok());
+    ///
+    /// // Unrecognised outcome — should fail.
+    /// assert!(MarketValidator::validate_outcome(
+    ///     &env,
+    ///     &String::from_str(&env, "maybe"),
+    ///     &valid_outcomes,
+    /// ).is_err());
+    /// ```
     pub fn validate_outcome(
         _env: &Env,
         outcome: &String,
@@ -707,6 +753,44 @@ impl MarketValidator {
         Ok(())
     }
 
+    /// Validates that the market has not yet reached its maximum participant cap.
+    ///
+    /// When a market is created with an optional `max_participants` limit, this
+    /// function enforces that cap before a new vote or bet is recorded.  Markets
+    /// without a configured cap always pass this check.
+    ///
+    /// # Parameters
+    ///
+    /// * `market` - Immutable reference to the market whose participant count
+    ///   should be checked.  The check is performed against `market.votes.len()`
+    ///   because every participant casts exactly one vote.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - The market has room for at least one more participant.
+    /// * `Err(Error::MaxParticipantsReached)` - The market is at capacity; no
+    ///   additional participants are accepted.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::MaxParticipantsReached`] — Returned when `market.votes.len() >= max`.
+    ///   Callers should present this to the user as a "market is full" message and
+    ///   should not retry; the condition will only resolve if existing participants
+    ///   cancel their votes (which is not currently supported).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use predictify_hybrid::markets::MarketValidator;
+    /// // markets without a cap always pass:
+    /// // assert!(MarketValidator::validate_participant_cap(&uncapped_market).is_ok());
+    ///
+    /// // markets at capacity return MaxParticipantsReached:
+    /// // assert_eq!(
+    /// //     MarketValidator::validate_participant_cap(&full_market),
+    /// //     Err(Error::MaxParticipantsReached)
+    /// // );
+    /// ```
     pub fn validate_participant_cap(market: &Market) -> Result<(), Error> {
         if let Some(max) = market.max_participants {
             if market.votes.len() >= max {
@@ -742,6 +826,32 @@ pub struct MarketReadCache<'a> {
 }
 
 impl<'a> MarketReadCache<'a> {
+    /// Creates a new `MarketReadCache` bound to the given Soroban environment.
+    ///
+    /// The returned cache borrows `env` for its entire lifetime.  All reads and
+    /// writes go through `env.storage().instance()`, which is fast but shared
+    /// across all keys in the contract instance.  Call `invalidate` after every
+    /// persistent write to keep the cache coherent.
+    ///
+    /// # Parameters
+    ///
+    /// * `env` - Reference to the Soroban environment.  Must outlive the cache.
+    ///
+    /// # Returns
+    ///
+    /// A freshly initialised (empty) `MarketReadCache`.  No storage reads are
+    /// performed during construction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use soroban_sdk::Env;
+    /// use predictify_hybrid::markets::MarketReadCache;
+    ///
+    /// let env = Env::default();
+    /// let cache = MarketReadCache::new(&env);
+    /// // cache is ready; all lookups miss until a market is populated via `set`.
+    /// ```
     pub fn new(env: &'a Env) -> Self {
         Self { env }
     }
@@ -791,7 +901,33 @@ impl<'a> MarketReadCache<'a> {
 pub struct MarketStateManager;
 
 impl MarketStateManager {
-    /// Create MarketStateManager instance from environment
+    /// Creates a `MarketStateManager` instance bound to the given Soroban environment.
+    ///
+    /// `MarketStateManager` is a zero-sized utility struct — all methods are
+    /// associated functions that receive `env` as an explicit argument.  This
+    /// constructor exists for API consistency and for callers that prefer an
+    /// OOP-style call chain (`MarketStateManager::from_env(env).get_market(…)`)
+    /// over the free-function form.
+    ///
+    /// # Parameters
+    ///
+    /// * `_env` - The Soroban environment.  Accepted but not stored; every method
+    ///   receives `env` directly.
+    ///
+    /// # Returns
+    ///
+    /// A new `MarketStateManager`.  Construction is infallible and performs no
+    /// I/O.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use soroban_sdk::Env;
+    /// use predictify_hybrid::markets::MarketStateManager;
+    ///
+    /// let env = Env::default();
+    /// let _mgr = MarketStateManager::from_env(&env);
+    /// ```
     pub fn from_env(_env: &Env) -> Self {
         Self
     }
@@ -1044,8 +1180,6 @@ impl MarketStateManager {
         // No state change for voting
     }
 
-    /// Add dispute stake to market
-
     /// Adds a user's dispute stake to challenge the market's oracle result.
     ///
     /// This function allows users to stake tokens to dispute the oracle's
@@ -1104,7 +1238,6 @@ impl MarketStateManager {
     ///
     /// MarketStateManager::update_market(&env, &market_id, &market);
     /// ```
-
     pub fn add_dispute_stake(
         market: &mut Market,
         user: Address,
@@ -2864,8 +2997,6 @@ impl MarketStateLogic {
         }
     }
 
-    /// Check if a function is allowed in the given state
-
     /// Validates that a specific function can be executed in the given market state.
     ///
     /// This function enforces access control based on market state, ensuring
@@ -2913,7 +3044,6 @@ impl MarketStateLogic {
     ///     MarketState::Resolved
     /// ).is_ok());
     /// ```
-
     pub fn check_function_access_for_state(
         function: &str,
         state: MarketState,

--- a/contracts/predictify-hybrid/tests/auth_snap.rs
+++ b/contracts/predictify-hybrid/tests/auth_snap.rs
@@ -1,0 +1,588 @@
+//! Per-entrypoint authorization snapshot tests for market entrypoints.
+//!
+//! This integration suite **snapshots** the Soroban authorization required by
+//! every state-changing market entrypoint of [`PredictifyHybrid`].  Instead of
+//! only checking that an authorized call succeeds and an unauthorized one
+//! fails, these tests inspect [`Env::auths`] immediately after each call and
+//! assert **which address the host actually required an authorization from**.
+//!
+//! ## Why a snapshot?
+//!
+//! * If a `require_auth` call is ever dropped from an entrypoint, `env.auths()`
+//!   for that call becomes empty and the matching test fails immediately.
+//! * If the auth subject is rebound to the wrong argument (e.g. a setter that
+//!   starts authorizing an attacker-controlled address), the captured subject
+//!   no longer matches the expected one and the test fails.
+//! * Read-only market entrypoints are pinned to *require no auth at all*,
+//!   documenting the read/write authorization boundary.
+//!
+//! ## Verification strategy
+//!
+//! The Soroban host records an authorization only for an invocation that
+//! **commits**.  When a call traps or returns `Err`, its recorded auths are
+//! rolled back and `env.auths()` comes back empty.  Most snapshots below
+//! therefore drive the entrypoint through a fully satisfied happy path
+//! ("committed snapshot").
+//!
+//! A small number of entrypoints need runtime state this fixture deliberately
+//! does not build.  For those the auth boundary is pinned directly instead
+//! ("auth boundary"): authorized calls must get *past* `require_auth` and fail
+//! on domain logic (`Err(Ok(..))`), while unauthorized calls must trap in
+//! `require_auth` (a matching `#[should_panic]` test).
+//!
+//! ## Entrypoint auth matrix
+//!
+//! | Entrypoint                      | Required auth subject | Verified by        |
+//! |---------------------------------|-----------------------|--------------------|
+//! | `create_market`                 | admin                 | committed snapshot |
+//! | `resolve_market_manual`         | admin                 | committed snapshot |
+//! | `resolve_market_with_ties`      | admin                 | auth boundary      |
+//! | `force_resolve_market`          | admin                 | auth boundary      |
+//! | `extend_deadline`               | admin                 | committed snapshot |
+//! | `set_platform_fee`              | admin                 | committed snapshot |
+//! | `set_treasury`                  | admin                 | committed snapshot |
+//! | `archive_event`                 | admin                 | auth boundary      |
+//! | `set_resolution_cooldown`       | admin                 | committed snapshot |
+//! | `vote`                          | user                  | committed snapshot |
+//! | `place_bet`                     | user                  | committed snapshot |
+//! | `cancel_bet`                    | user                  | committed snapshot |
+//! | `claim_winnings`                | user                  | auth boundary      |
+//! | `get_market` (read-only)        | none                  | committed snapshot |
+//! | `get_market_bet_stats` (r/o)    | none                  | committed snapshot |
+//! | `get_bet` (read-only)           | none                  | committed snapshot |
+
+use predictify_hybrid::{
+    Error, OracleConfig, OracleProvider, PredictifyHybrid, PredictifyHybridClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env, String, Symbol, Vec,
+};
+
+// ============================================================
+// Test fixture
+// ============================================================
+
+/// A fully wired contract: registered Stellar Asset Contract for stake
+/// transfers, `TokenID` stored in contract state, and an initialized admin.
+struct Fixture {
+    env: Env,
+    cid: Address,
+    admin: Address,
+    token_id: Address,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let cid = env.register(PredictifyHybrid, ());
+
+        // Register a Stellar asset so the contract's token client resolves.
+        let token_id = env
+            .register_stellar_asset_contract_v2(Address::generate(&env))
+            .address();
+
+        // Wire the token before initializing so stake transfers work.
+        env.as_contract(&cid, || {
+            env.storage()
+                .persistent()
+                .set(&Symbol::new(&env, "TokenID"), &token_id);
+        });
+
+        PredictifyHybridClient::new(&env, &cid).initialize(&admin, &Some(200i128), &None);
+
+        Fixture { env, cid, admin, token_id }
+    }
+
+    fn client(&self) -> PredictifyHybridClient<'_> {
+        PredictifyHybridClient::new(&self.env, &self.cid)
+    }
+
+    /// Create a funded user able to cover any stake used in these tests.
+    fn user(&self) -> Address {
+        let u = Address::generate(&self.env);
+        StellarAssetClient::new(&self.env, &self.token_id).mint(&u, &100_000_000_000i128);
+        u
+    }
+
+    fn oracle(&self) -> OracleConfig {
+        OracleConfig {
+            provider: OracleProvider::reflector(),
+            oracle_address: Address::from_str(
+                &self.env,
+                "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            ),
+            feed_id: String::from_str(&self.env, "BTC/USD"),
+            threshold: 50_000,
+            comparison: String::from_str(&self.env, "gt"),
+        }
+    }
+
+    /// Create a standard two-outcome, 30-day market owned by `admin`.
+    fn market(&self) -> Symbol {
+        let mut outcomes = Vec::new(&self.env);
+        outcomes.push_back(String::from_str(&self.env, "yes"));
+        outcomes.push_back(String::from_str(&self.env, "no"));
+        self.client().create_market(
+            &self.admin,
+            &String::from_str(&self.env, "Will BTC reach 100k?"),
+            &outcomes,
+            &30u32,
+            &self.oracle(),
+            &None,
+            &86_400u64,
+            &None,
+            &None,
+            &None,
+        )
+    }
+
+    fn yes(&self) -> String {
+        String::from_str(&self.env, "yes")
+    }
+
+    /// Advance ~31 days so a 30-day market is past its end time.
+    fn advance_past_end(&self) {
+        self.env
+            .ledger()
+            .with_mut(|l| l.timestamp += 31 * 24 * 60 * 60);
+    }
+
+    /// Advance past the default 86_400 s dispute window.
+    fn advance_past_dispute(&self) {
+        self.env.ledger().with_mut(|l| l.timestamp += 86_401);
+    }
+
+    /// Addresses the most recent top-level invocation required auth from.
+    fn required_auth(&self) -> std::vec::Vec<Address> {
+        self.env
+            .auths()
+            .iter()
+            .map(|(addr, _)| addr.clone())
+            .collect()
+    }
+
+    /// Assert the last invocation required an authorization from `expected`.
+    ///
+    /// An empty auth set means either the entrypoint performed no
+    /// `require_auth`, or the call failed and the host rolled its auths back.
+    fn assert_requires_auth(&self, expected: &Address, label: &str) {
+        let required = self.required_auth();
+        assert!(
+            !required.is_empty(),
+            "{label}: no auth recorded — the entrypoint either skipped \
+             require_auth or the call failed before committing"
+        );
+        assert!(
+            required.contains(expected),
+            "{label}: expected auth from {expected:?}, captured {required:?}"
+        );
+    }
+
+    /// Assert the last invocation required *no* authorization (read-only).
+    fn assert_no_auth(&self, label: &str) {
+        let required = self.required_auth();
+        assert!(
+            required.is_empty(),
+            "{label}: expected no auth for a read-only entrypoint, captured {required:?}"
+        );
+    }
+}
+
+// ============================================================
+// Auth-boundary helpers for entrypoints whose happy path
+// requires state this fixture does not construct.
+// ============================================================
+
+/// Assert the call got *past* `require_auth`.
+///
+/// A `try_*` invocation reports a contract-level failure as `Err(Ok(..))` and a
+/// host-level trap — which is how a rejected `require_auth` surfaces — as
+/// `Err(Err(InvokeError))`.  Reaching a contract error proves that authorization
+/// succeeded; the call failed later on domain logic.
+fn assert_auth_passed<T, E, F>(
+    result: &Result<Result<T, E>, Result<F, soroban_sdk::InvokeError>>,
+    label: &str,
+) {
+    if let Err(Err(invoke_err)) = result {
+        panic!(
+            "{label}: expected the call to pass require_auth and fail on domain \
+             logic, but it trapped at the host level: {invoke_err:?}"
+        );
+    }
+}
+
+// ============================================================
+// Admin-scoped market entrypoints — committed snapshot
+// ============================================================
+
+/// `create_market` must require admin authorization.
+#[test]
+fn snap_create_market_requires_admin_auth() {
+    let f = Fixture::new();
+    let _ = f.market();
+    f.assert_requires_auth(&f.admin, "create_market");
+}
+
+/// `resolve_market_manual` must require admin authorization.
+#[test]
+fn snap_resolve_market_manual_requires_admin_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.advance_past_end();
+    f.client()
+        .resolve_market_manual(&f.admin, &market_id, &f.yes());
+    f.assert_requires_auth(&f.admin, "resolve_market_manual");
+}
+
+/// `extend_deadline` must require admin authorization.
+#[test]
+fn snap_extend_deadline_requires_admin_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.client().extend_deadline(
+        &f.admin,
+        &market_id,
+        &7u32,
+        &String::from_str(&f.env, "additional time needed"),
+    );
+    f.assert_requires_auth(&f.admin, "extend_deadline");
+}
+
+/// `set_platform_fee` must require admin authorization.
+#[test]
+fn snap_set_platform_fee_requires_admin_auth() {
+    let f = Fixture::new();
+    f.client().set_platform_fee(&f.admin, &250i128);
+    f.assert_requires_auth(&f.admin, "set_platform_fee");
+}
+
+/// `set_treasury` must require admin authorization.
+#[test]
+fn snap_set_treasury_requires_admin_auth() {
+    let f = Fixture::new();
+    let treasury = Address::generate(&f.env);
+    f.client().set_treasury(&f.admin, &treasury);
+    f.assert_requires_auth(&f.admin, "set_treasury");
+}
+
+/// `set_resolution_cooldown` must require admin authorization.
+#[test]
+fn snap_set_resolution_cooldown_requires_admin_auth() {
+    let f = Fixture::new();
+    f.client().set_resolution_cooldown(&f.admin, &3600u64);
+    f.assert_requires_auth(&f.admin, "set_resolution_cooldown");
+}
+
+// ============================================================
+// Admin-scoped market entrypoints — auth boundary
+// ============================================================
+
+/// `resolve_market_with_ties` must require admin authorization.
+///
+/// The tie-resolution path needs a resolved market with multiple outcomes, so
+/// we pin the auth boundary rather than building the full state.
+#[test]
+fn snap_resolve_market_with_ties_requires_admin_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.advance_past_end();
+    let mut outcomes = Vec::new(&f.env);
+    outcomes.push_back(String::from_str(&f.env, "yes"));
+    let result = f
+        .client()
+        .try_resolve_market_with_ties(&f.admin, &market_id, &outcomes);
+    assert_auth_passed(&result, "resolve_market_with_ties");
+}
+
+#[test]
+#[should_panic]
+fn edge_resolve_market_with_ties_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.advance_past_end();
+    f.env.set_auths(&[]);
+    let mut outcomes = Vec::new(&f.env);
+    outcomes.push_back(String::from_str(&f.env, "yes"));
+    f.client()
+        .resolve_market_with_ties(&f.admin, &market_id, &outcomes);
+}
+
+/// `force_resolve_market` must require admin authorization.
+#[test]
+fn snap_force_resolve_market_requires_admin_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let idempotency_key = String::from_str(&f.env, "key_001");
+    let result = f.client().try_force_resolve_market(
+        &f.admin,
+        &market_id,
+        &f.yes(),
+        &idempotency_key,
+        &String::from_str(&f.env, "manual override"),
+    );
+    assert_auth_passed(&result, "force_resolve_market");
+}
+
+#[test]
+#[should_panic]
+fn edge_force_resolve_market_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.env.set_auths(&[]);
+    f.client().force_resolve_market(
+        &f.admin,
+        &market_id,
+        &f.yes(),
+        &String::from_str(&f.env, "key_001"),
+        &String::from_str(&f.env, "manual override"),
+    );
+}
+
+/// `archive_event` must require admin authorization.
+#[test]
+fn snap_archive_event_requires_admin_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let result = f.client().try_archive_event(&f.admin, &market_id);
+    assert_auth_passed(&result, "archive_event");
+}
+
+#[test]
+#[should_panic]
+fn edge_archive_event_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    f.env.set_auths(&[]);
+    f.client().archive_event(&f.admin, &market_id);
+}
+
+// ============================================================
+// User-scoped market entrypoints — committed snapshot
+// ============================================================
+
+/// `vote` must require the acting user's authorization.
+#[test]
+fn snap_vote_requires_user_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client().vote(&user, &market_id, &f.yes(), &1_000_000i128);
+    f.assert_requires_auth(&user, "vote");
+}
+
+/// `place_bet` must require the acting user's authorization.
+#[test]
+fn snap_place_bet_requires_user_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client()
+        .place_bet(&user, &market_id, &f.yes(), &1_000_000i128, &250i128);
+    f.assert_requires_auth(&user, "place_bet");
+}
+
+/// `cancel_bet` must require the acting user's authorization.
+#[test]
+fn snap_cancel_bet_requires_user_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client()
+        .place_bet(&user, &market_id, &f.yes(), &1_000_000i128, &250i128);
+    f.client().cancel_bet(&user, &market_id);
+    f.assert_requires_auth(&user, "cancel_bet");
+}
+
+/// `claim_winnings` must require the acting user's authorization.
+///
+/// The claim path requires a resolved, past-dispute-window market, which is
+/// harder to drive to completion here, so we pin the auth boundary.
+#[test]
+fn snap_claim_winnings_requires_user_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client()
+        .vote(&user, &market_id, &f.yes(), &10_000_000i128);
+    f.advance_past_end();
+    f.client()
+        .resolve_market_manual(&f.admin, &market_id, &f.yes());
+    f.advance_past_dispute();
+
+    let result = f.client().try_claim_winnings(&user, &market_id);
+    assert_auth_passed(&result, "claim_winnings");
+}
+
+#[test]
+#[should_panic]
+fn edge_claim_winnings_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.env.set_auths(&[]);
+    f.client().claim_winnings(&user, &market_id);
+}
+
+// ============================================================
+// Read-only market entrypoints — no auth required
+// ============================================================
+
+/// `get_market` is a read-only query; it must not require any authorization.
+#[test]
+fn snap_get_market_requires_no_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let _ = f.client().get_market(&market_id);
+    f.assert_no_auth("get_market");
+}
+
+/// `get_market_bet_stats` is a read-only query; it must not require any
+/// authorization.
+#[test]
+fn snap_get_market_bet_stats_requires_no_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let _ = f.client().get_market_bet_stats(&market_id);
+    f.assert_no_auth("get_market_bet_stats");
+}
+
+/// `get_bet` is a read-only query; it must not require any authorization.
+#[test]
+fn snap_get_bet_requires_no_auth() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    let _ = f.client().get_bet(&market_id, &user);
+    f.assert_no_auth("get_bet");
+}
+
+// ============================================================
+// Subject-binding correctness tests
+// ============================================================
+
+/// A user entrypoint must bind `require_auth` to the acting user, never to
+/// the admin — even though the admin is authorized in the same environment.
+#[test]
+fn snap_vote_subject_is_user_not_admin() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client().vote(&user, &market_id, &f.yes(), &1_000_000i128);
+
+    let required = f.required_auth();
+    assert!(
+        required.contains(&user),
+        "vote must require the acting user, captured {required:?}"
+    );
+    assert!(
+        !required.contains(&f.admin),
+        "vote must not require admin auth, captured {required:?}"
+    );
+}
+
+/// `place_bet` must bind `require_auth` to the bettor, not to the admin.
+#[test]
+fn snap_place_bet_subject_is_user_not_admin() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.client()
+        .place_bet(&user, &market_id, &f.yes(), &1_000_000i128, &250i128);
+
+    let required = f.required_auth();
+    assert!(
+        required.contains(&user),
+        "place_bet must require the acting user, captured {required:?}"
+    );
+    assert!(
+        !required.contains(&f.admin),
+        "place_bet must not require admin auth, captured {required:?}"
+    );
+}
+
+/// Two distinct users submit votes: each call must capture that user's
+/// address, never the other user's address.
+#[test]
+fn snap_vote_subject_tracks_argument_across_users() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user_a = f.user();
+    let user_b = f.user();
+
+    f.client()
+        .vote(&user_a, &market_id, &f.yes(), &1_000_000i128);
+    f.assert_requires_auth(&user_a, "vote(user_a)");
+
+    f.client().vote(
+        &user_b,
+        &market_id,
+        &String::from_str(&f.env, "no"),
+        &1_000_000i128,
+    );
+    let required = f.required_auth();
+    assert!(
+        required.contains(&user_b),
+        "vote must require user_b, captured {required:?}"
+    );
+    assert!(
+        !required.contains(&user_a),
+        "user_a's auth must not satisfy user_b's vote, captured {required:?}"
+    );
+}
+
+// ============================================================
+// Negative / edge cases
+// ============================================================
+
+/// Calling an admin entrypoint with a non-admin address must be rejected with
+/// `Error::Unauthorized`, even while `mock_all_auths` satisfies the signature
+/// check — because admin entrypoints verify identity against the stored admin.
+#[test]
+fn edge_non_admin_set_platform_fee_is_unauthorized() {
+    let f = Fixture::new();
+    let attacker = Address::generate(&f.env);
+    let result = f.client().try_set_platform_fee(&attacker, &250i128);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
+        "non-admin must not be able to set the platform fee"
+    );
+}
+
+/// With no auths mocked, `vote` must trap in `require_auth`, not silently
+/// succeed.
+#[test]
+#[should_panic]
+fn edge_vote_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.env.set_auths(&[]);
+    f.client().vote(&user, &market_id, &f.yes(), &1_000_000i128);
+}
+
+/// With no auths mocked, `place_bet` must trap in `require_auth`.
+#[test]
+#[should_panic]
+fn edge_place_bet_without_auth_panics() {
+    let f = Fixture::new();
+    let market_id = f.market();
+    let user = f.user();
+    f.env.set_auths(&[]);
+    f.client()
+        .place_bet(&user, &market_id, &f.yes(), &1_000_000i128, &250i128);
+}
+
+/// With no auths mocked, an admin entrypoint must trap in `require_auth`.
+#[test]
+#[should_panic]
+fn edge_create_market_without_auth_panics() {
+    let f = Fixture::new();
+    f.env.set_auths(&[]);
+    let _ = f.market();
+}

--- a/contracts/predictify-hybrid/tests/err_stab.rs
+++ b/contracts/predictify-hybrid/tests/err_stab.rs
@@ -1,0 +1,213 @@
+//! Betting error-code stability tests.
+//!
+//! This test suite **freezes** the numeric discriminant values for every
+//! `Error` variant that a client application can receive from a betting
+//! entrypoint (`place_bet`, `place_bets`, `cancel_bet`, `claim_winnings`,
+//! `set_max_bet_cap`).
+//!
+//! ## Why this matters
+//!
+//! Client applications (web front-ends, indexers, bots) typically pattern-match
+//! on the raw `u32` error code returned by the Soroban host — not on the Rust
+//! variant name.  Reordering, inserting without an explicit discriminant, or
+//! renaming a variant while keeping its discriminant are all **client-visible
+//! API changes** that must be treated as breaking changes.
+//!
+//! These assertions will fail if any of the following happen:
+//!
+//! * A variant is reordered relative to another (shifting the auto-incremented
+//!   value assigned by the compiler).
+//! * A variant is inserted before an existing one without an explicit
+//!   discriminant, causing all subsequent variants to shift.
+//! * A variant is deleted, causing later ones to shift.
+//! * A variant is renamed but its discriminant stays the same (name change is
+//!   still a source-level breaking change even though the wire value is stable).
+//!
+//! ## Stability policy
+//!
+//! Every variant in the `Error` enum carries an explicit `= <N>` discriminant.
+//! New betting errors **must** choose a fresh number that has never been used
+//! and must never reuse a retired discriminant.  See the enum-level doc comment
+//! in `src/err.rs` for the full policy.
+
+use predictify_hybrid::Error;
+
+// ============================================================
+// Betting path — user operation errors (100-range)
+// ============================================================
+
+/// Core user-operation errors reachable from every betting entrypoint.
+///
+/// These codes appear in `place_bet`, `place_bets`, `cancel_bet`,
+/// `claim_winnings` and related flows.
+#[test]
+fn bet_user_operation_error_codes_are_stable() {
+    let table: &[(Error, u32)] = &[
+        // The user attempted to interact with a market that does not exist.
+        (Error::MarketNotFound, 101),
+        // The market deadline has passed; no new bets are accepted.
+        (Error::MarketClosed, 102),
+        // The market has already been resolved; no new bets are accepted.
+        (Error::MarketResolved, 103),
+        // The market has not yet been resolved; winnings cannot be claimed.
+        (Error::MarketNotResolved, 104),
+        // The user has no bet on this market to claim or cancel.
+        (Error::NothingToClaim, 105),
+        // Winnings have already been claimed; duplicate claim rejected.
+        (Error::AlreadyClaimed, 106),
+        // Bet amount is below the market's configured minimum.
+        (Error::InsufficientStake, 107),
+        // The chosen outcome does not exist in this market's outcome list.
+        (Error::InvalidOutcome, 108),
+        // The user already has an active bet on this market.
+        (Error::AlreadyBet, 110),
+        // Bets have been placed; further state-mutating operations blocked.
+        (Error::BetsAlreadyPlaced, 111),
+        // User's token balance is insufficient to cover the bet amount.
+        (Error::InsufficientBalance, 112),
+    ];
+
+    for &(error, expected) in table {
+        assert_eq!(
+            error as u32,
+            expected,
+            "betting user-operation error code changed for {error:?}; \
+             this is a client-facing API break"
+        );
+    }
+}
+
+// ============================================================
+// Betting path — fee and cap errors (500/600-range)
+// ============================================================
+
+/// Fee-protection and bet-cap errors emitted during `place_bet` / `place_bets`.
+///
+/// `FeeExceedsMax` protects callers from unexpected fee increases: if the
+/// effective platform fee (in basis points) has risen above the caller-supplied
+/// `max_fee_bps` guard, the transaction is rejected rather than silently
+/// overcharged.
+///
+/// `MaxBetCapExceeded` is returned when a user's cumulative stake across all
+/// markets would surpass the per-address cap set by the admin.
+///
+/// `InvalidCap` is returned when an admin attempts to configure a cap value
+/// that is zero or otherwise invalid.
+#[test]
+fn bet_fee_and_cap_error_codes_are_stable() {
+    let table: &[(Error, u32)] = &[
+        // Effective fee (bps) exceeds the caller-supplied max_fee_bps guard.
+        (Error::FeeExceedsMax, 508),
+        // Cumulative stake would exceed the per-address bet cap.
+        (Error::MaxBetCapExceeded, 673),
+        // Admin tried to set a bet cap that is zero or negative.
+        (Error::InvalidCap, 674),
+    ];
+
+    for &(error, expected) in table {
+        assert_eq!(
+            error as u32,
+            expected,
+            "betting fee/cap error code changed for {error:?}; \
+             this is a client-facing API break"
+        );
+    }
+}
+
+// ============================================================
+// Betting path — batch idempotency errors (500-range)
+// ============================================================
+
+/// Idempotency key reuse rejection for the `place_bets` batch entrypoint.
+///
+/// When a `place_bets` call is submitted with a key that was already
+/// successfully consumed, this error is returned so that clients can
+/// distinguish a network retry from a genuine duplicate.
+#[test]
+fn bet_batch_idempotency_error_codes_are_stable() {
+    // The 509 slot is the canonical client-facing code.
+    assert_eq!(
+        Error::IdempotentBatchAlreadyApplied as u32,
+        509,
+        "IdempotentBatchAlreadyApplied error code changed; \
+         clients that match on 509 will break"
+    );
+}
+
+// ============================================================
+// General / state errors reachable from betting entrypoints
+// ============================================================
+
+/// General errors that may surface on the betting path.
+///
+/// These are not exclusive to betting, but they are part of the visible error
+/// surface of the betting entrypoints and must remain stable.
+#[test]
+fn bet_general_error_codes_are_stable() {
+    let table: &[(Error, u32)] = &[
+        // Caller is not authorised for an admin-only operation (e.g. set_max_bet_cap).
+        (Error::Unauthorized, 100),
+        // Generic input validation failure (empty batch, invalid parameter, etc.).
+        (Error::InvalidInput, 401),
+        // Contract/market state is inconsistent; an invariant was violated.
+        (Error::InvalidState, 400),
+    ];
+
+    for &(error, expected) in table {
+        assert_eq!(
+            error as u32,
+            expected,
+            "betting general error code changed for {error:?}; \
+             this is a client-facing API break"
+        );
+    }
+}
+
+// ============================================================
+// Uniqueness guard
+// ============================================================
+
+/// No two betting error codes share the same discriminant.
+///
+/// This test collects every code exercised by the suite above and asserts
+/// they are pairwise distinct.  A failure here means a new error was added
+/// with a discriminant that duplicates an existing one.
+#[test]
+fn bet_error_codes_are_unique() {
+    let codes: &[u32] = &[
+        // user-operation range
+        Error::MarketNotFound as u32,
+        Error::MarketClosed as u32,
+        Error::MarketResolved as u32,
+        Error::MarketNotResolved as u32,
+        Error::NothingToClaim as u32,
+        Error::AlreadyClaimed as u32,
+        Error::InsufficientStake as u32,
+        Error::InvalidOutcome as u32,
+        Error::AlreadyBet as u32,
+        Error::BetsAlreadyPlaced as u32,
+        Error::InsufficientBalance as u32,
+        // fee / cap range
+        Error::FeeExceedsMax as u32,
+        Error::MaxBetCapExceeded as u32,
+        Error::InvalidCap as u32,
+        // batch idempotency
+        Error::IdempotentBatchAlreadyApplied as u32,
+        // general
+        Error::Unauthorized as u32,
+        Error::InvalidInput as u32,
+        Error::InvalidState as u32,
+    ];
+
+    for (i, &a) in codes.iter().enumerate() {
+        for (j, &b) in codes.iter().enumerate() {
+            if i != j {
+                assert_ne!(
+                    a, b,
+                    "duplicate betting error code {a} found at positions {i} and {j}; \
+                     each error must have a unique discriminant"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements three buffered tasks against the `predictify-hybrid` contract:

---

### Closes #867 — Betting error-code stability

**New file:** `contracts/predictify-hybrid/tests/err_stab.rs`

Freezes every client-facing `Error` discriminant that can be returned by a betting entrypoint (`place_bet`, `place_bets`, `cancel_bet`, `claim_winnings`, `set_max_bet_cap`).

| Test | Codes covered |
|---|---|
| `bet_user_operation_error_codes_are_stable` | 101–112 (MarketNotFound … InsufficientBalance) |
| `bet_fee_and_cap_error_codes_are_stable` | 508 FeeExceedsMax, 673 MaxBetCapExceeded, 674 InvalidCap |
| `bet_batch_idempotency_error_codes_are_stable` | 509 IdempotentBatchAlreadyApplied |
| `bet_general_error_codes_are_stable` | 100 Unauthorized, 400 InvalidState, 401 InvalidInput |
| `bet_error_codes_are_unique` | Pairwise uniqueness guard across all 18 codes |

Follows the same pattern established by the existing `tests/err_stability.rs` and `contracts/oracles/tests/err_stab.rs`.

---

### Closes #859 — Per-entrypoint auth snapshot for markets

**New file:** `contracts/predictify-hybrid/tests/auth_snap.rs`

24 tests that snapshot which address each market entrypoint requires authorization from.

**Auth matrix:**

| Entrypoint | Required auth | Strategy |
|---|---|---|
| `create_market` | admin | committed snapshot |
| `resolve_market_manual` | admin | committed snapshot |
| `extend_deadline` | admin | committed snapshot |
| `set_platform_fee` | admin | committed snapshot |
| `set_treasury` | admin | committed snapshot |
| `set_resolution_cooldown` | admin | committed snapshot |
| `resolve_market_with_ties` | admin | auth boundary |
| `force_resolve_market` | admin | auth boundary |
| `archive_event` | admin | auth boundary |
| `vote` | user | committed snapshot |
| `place_bet` | user | committed snapshot |
| `cancel_bet` | user | committed snapshot |
| `claim_winnings` | user | auth boundary |
| `get_market` | none | committed snapshot |
| `get_market_bet_stats` | none | committed snapshot |
| `get_bet` | none | committed snapshot |

Follows the same fixture / assertion helpers as `tests/auth_snapshot.rs` and `tests/auth_snapshot_disputes.rs`.

---

### Closes #857 — Rustdoc on markets public entrypoints

**Modified:** `contracts/predictify-hybrid/src/markets.rs`

Added full `///`-style rustdoc (params, returns, errors, example) to every previously undocumented or stub-documented public function:

- `MarketValidator::validate_outcome` — replaced one-liner with full doc
- `MarketValidator::validate_participant_cap` — new full doc block
- `MarketReadCache::new` — new full doc block
- `MarketStateManager::from_env` — replaced one-liner with full doc

Also cleaned up pre-existing structural issues:
- Removed redundant one-liner stubs that sat before full doc blocks (`create_market`, `create_reflector_market`, `add_dispute_stake`, `check_function_access_for_state`)
- Fixed blank lines between closing code-fence (````) and `pub fn` that break rustdoc attachment

---

## Files changed

| File | Change |
|---|---|
| `tests/err_stab.rs` | **new** — 5 betting error stability tests |
| `tests/auth_snap.rs` | **new** — 24 market auth snapshot tests |
| `src/markets.rs` | rustdoc added / stubs cleaned up |
| `Cargo.toml` | registered `[[test]] err_stab` and `[[test]] auth_snap` |

## Testing

```sh
cargo test -p predictify-hybrid --test err_stab
cargo test -p predictify-hybrid --test auth_snap
cargo test -p predictify-hybrid
```