### PR TITLE
test(markets): freeze error discriminants 443, 517-528, 660-674

### DIFF
--- a/contracts/predictify-hybrid/tests/err_stability.rs
+++ b/contracts/predictify-hybrid/tests/err_stability.rs
@@ -133,6 +133,35 @@ fn asset_decimals() {
     assert_eq!(Error::AssetDecimalsMismatch as u32, 439);
 }
 
+// ===== Market-specific & extension errors (443, 517-528) =====
+
+#[test]
+fn market_extension_errors() {
+    assert_eq!(Error::AdminActionTimelocked as u32, 443);
+    assert_eq!(Error::ForceResolveReplayed as u32, 517);
+    assert_eq!(Error::ForceResolveReasonEmpty as u32, 518);
+    assert_eq!(Error::NoPendingFeeCommit as u32, 519);
+    assert_eq!(Error::FeeRevealTooEarly as u32, 520);
+    assert_eq!(Error::FeePreimageMismatch as u32, 521);
+    assert_eq!(Error::DisputeStakeCapExceeded as u32, 522);
+    assert_eq!(Error::InsufficientStorageRentBudget as u32, 523);
+    assert_eq!(Error::ExtensionCapExceeded as u32, 524);
+    assert_eq!(Error::UpgradeChainMismatch as u32, 525);
+    assert_eq!(Error::OracleQuoteOutlier as u32, 527);
+    assert_eq!(Error::MaxParticipantsReached as u32, 528);
+}
+
+// ===== Overflow / cap errors (660-674) =====
+
+#[test]
+fn overflow_cap_errors() {
+    assert_eq!(Error::IdempotentBatchAlreadyApplied as u32, 660);
+    assert_eq!(Error::ReasonTableFull as u32, 670);
+    assert_eq!(Error::Overflow as u32, 672);
+    assert_eq!(Error::MaxBetCapExceeded as u32, 673);
+    assert_eq!(Error::InvalidCap as u32, 674);
+}
+
 // ===== op-count test ensuring we noticed all variants =====
 
 #[test]


### PR DESCRIPTION
## Summary

Adds stability tests for 17 previously-uncovered error code discriminants to `contracts/predictify-hybrid/tests/err_stability.rs`.

### New test: `market_extension_errors` (443, 517-528)
- `AdminActionTimelocked` (443)
- `ForceResolveReplayed` (517)
- `ForceResolveReasonEmpty` (518)
- `NoPendingFeeCommit` (519)
- `FeeRevealTooEarly` (520)
- `FeePreimageMismatch` (521)
- `DisputeStakeCapExceeded` (522)
- `InsufficientStorageRentBudget` (523)
- `ExtensionCapExceeded` (524)
- `UpgradeChainMismatch` (525)
- `OracleQuoteOutlier` (527)
- `MaxParticipantsReached` (528)

### New test: `overflow_cap_errors` (660-674)
- `IdempotentBatchAlreadyApplied` (660)
- `ReasonTableFull` (670)
- `Overflow` (672)
- `MaxBetCapExceeded` (673)
- `InvalidCap` (674)

## Motivation

These error codes were added to `err.rs` but never frozen in the stability suite, meaning accidental reordering or deletion would go undetected by CI.

## Test Plan
- [x] `cargo test --test err_stability`
- [x] No production code changes; test-only

Closes #860