### PR TITLE
feat: per-user cool-off – storage keys and error code

### DIFF
--- a/contracts/predictify-hybrid/src/err.rs
+++ b/contracts/predictify-hybrid/src/err.rs
@@ -53,6 +53,10 @@ pub enum Error {
     BetsAlreadyPlaced = 111,
     /// The user's balance is insufficient for the requested operation.
     InsufficientBalance = 112,
+    /// The user is within the cool-off period for this market and must wait before
+    /// placing another bet.  The cool-off window is configurable per-market or globally
+    /// by the contract admin.
+    BetCoolOffActive = 113,
 
     // ===== ORACLE ERRORS =====
     /// The oracle service is unavailable. External data source may be temporarily
@@ -805,6 +809,7 @@ impl ErrorHandler {
             Error::InvalidState | Error::InvalidOracleConfig => RecoveryStrategy::NoRecovery,
             Error::FeeExceedsMax => RecoveryStrategy::Retry,
             Error::BetExceedsCap => RecoveryStrategy::NoRecovery,
+            Error::BetCoolOffActive => RecoveryStrategy::RetryWithDelay,
             Error::OperationWouldExceedBudget => RecoveryStrategy::NoRecovery,
             _ => RecoveryStrategy::Abort,
         }
@@ -1506,6 +1511,7 @@ impl Error {
                 "Bets have already been placed on this market (cannot update)"
             }
             Error::InsufficientBalance => "Insufficient balance for operation",
+            Error::BetCoolOffActive => "User is within the cool-off period; wait before placing another bet",
             Error::InsufficientStorageRentBudget => "Insufficient storage rent for persistent key allocation",
             Error::OracleUnavailable => "Oracle is unavailable",
             Error::InvalidOracleConfig => "Invalid oracle configuration",
@@ -1620,6 +1626,7 @@ impl Error {
             Error::AlreadyBet => "ALREADY_BET",
             Error::BetsAlreadyPlaced => "BETS_ALREADY_PLACED",
             Error::InsufficientBalance => "INSUFFICIENT_BALANCE",
+            Error::BetCoolOffActive => "BET_COOL_OFF_ACTIVE",
             Error::OracleUnavailable => "ORACLE_UNAVAILABLE",
             Error::InvalidOracleConfig => "INVALID_ORACLE_CONFIG",
             Error::GasBudgetExceeded => "GAS_BUDGET_EXCEEDED",

--- a/contracts/predictify-hybrid/src/storage.rs
+++ b/contracts/predictify-hybrid/src/storage.rs
@@ -127,7 +127,8 @@ pub struct StorageTtlPressure {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
-    PlaceBetsIdem(Address, soroban_sdk::BytesN<32>),
+    /// Consumed `place_bets` idempotency key, scoped per (user, key).
+    PlaceBetsIdem(Address, BytesN<32>),
     Whitelisted(Address),
     Blacklisted(Address),
     ArchivedMarket(Symbol, u64),
@@ -147,10 +148,26 @@ pub enum DataKey {
     AntiGriefFloor,
     /// Global protocol configuration record.
     GlobalConfig,
-    /// Consumed `place_bets` idempotency key, scoped per user.
-    PlaceBetsIdem(Address, BytesN<32>),
     /// Replay protection nonce for events, stored per topic.
     EventNonce(Symbol),
+    /// Cumulative stake a user has locked on a specific market.
+    /// Value: `i128` (total amount in base token units).
+    UserStake(Symbol, Address),
+    /// Global per-user maximum cumulative bet cap across a single market.
+    /// Value: `i128` (cap amount in base token units).
+    MaxBetCap,
+    // ===== COOL-OFF KEYS =====
+    /// Ledger timestamp (u64) of the last accepted bet placed by `(market_id, user)`.
+    /// Used to enforce the per-user cool-off period between consecutive bets on the
+    /// same market.
+    UserLastBetTime(Symbol, Address),
+    /// Global cool-off period in seconds (u64).
+    /// When set, all markets without a per-market override must wait this many seconds
+    /// between consecutive bets from the same user on the same market.
+    CoolOffPeriod,
+    /// Per-market cool-off override in seconds (u64) for a specific `market_id`.
+    /// Takes precedence over `CoolOffPeriod` when present.
+    PerMarketCoolOff(Symbol),
 }
 
 /// Storage format version for migration tracking


### PR DESCRIPTION
Add DataKey variants for cool-off:
  - UserLastBetTime(Symbol, Address): ledger timestamp of last bet
  - CoolOffPeriod: global cool-off in seconds
  - PerMarketCoolOff(Symbol): per-market override in seconds

Also adds previously missing DataKey variants referenced by bets.rs:
  - UserStake(Symbol, Address)
  - MaxBetCap

Removes duplicate PlaceBetsIdem variant from DataKey.

Adds Error::BetCoolOffActive = 113 with human-readable message, error code string, and RetryWithDelay recovery strategy.
closes #820