### PR TITLE
feat: add pause_market with reason enum (#840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
+name = "betting"
+version = "0.0.0"
+dependencies = [
+ "predictify-hybrid",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +259,8 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -483,6 +493,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "disputes"
+version = "0.0.0"
+dependencies = [
+ "predictify-hybrid",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +667,17 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -819,6 +848,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,13 +937,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "markets"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
 ]
 
 [[package]]
@@ -1022,6 +1064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "predictify-hybrid-fuzz"
+version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "libfuzzer-sys",
+ "predictify-hybrid",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,7 +1169,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1128,6 +1186,14 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "resolution"
+version = "0.0.0"
+dependencies = [
+ "predictify-hybrid",
+ "soroban-sdk",
+]
 
 [[package]]
 name = "rfc6979"
@@ -1378,7 +1444,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.15",
  "hex-literal",
  "hmac",
  "k256",

--- a/contracts/predictify-hybrid/src/disputes.rs
+++ b/contracts/predictify-hybrid/src/disputes.rs
@@ -3185,8 +3185,6 @@ impl DisputeUtils {
         // The validation will use the per-market per-user cap already implemented.
         0
     }
-}
-
 pub struct DisputeAnalytics;
 
 impl DisputeAnalytics {

--- a/contracts/predictify-hybrid/src/disputes.rs
+++ b/contracts/predictify-hybrid/src/disputes.rs
@@ -3050,7 +3050,6 @@ impl DisputeUtils {
             fees_distributed: false,
         }))
     }
-    }
 
     /// Persist a [`DisputeEscalation`] under the `dispute_e` + `dispute_id` key.
     pub fn store_dispute_escalation(

--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -3660,6 +3660,7 @@ impl MarketPauseManager {
         admin: Address,
         market_id: &Symbol,
         duration_hours: u32,
+        reason: PauseReason,
     ) -> Result<(), Error> {
         Self::verify_admin(env, &admin)?;
 
@@ -3682,7 +3683,14 @@ impl MarketPauseManager {
             paused_by: admin.clone(),
             pause_end_time,
             original_state: market.state,
+            reason: reason.clone(),
         };
+
+        env.storage().persistent().set(&market_id, &pause_info);
+        Self::emit_pause_event(env, market_id, duration_hours, &admin, &reason);
+
+        Ok(())
+    };
 
         env.storage().persistent().set(&market_id, &pause_info);
         Self::emit_pause_event(env, market_id, duration_hours, &admin);
@@ -3970,10 +3978,10 @@ impl MarketPauseManager {
         Ok(())
     }
 
-    fn emit_pause_event(env: &Env, market_id: &Symbol, duration: u32, admin: &Address) {
+    fn emit_pause_event(env: &Env, market_id: &Symbol, duration: u32, admin: &Address, reason: &PauseReason) {
         env.events().publish(
             ("market_paused", market_id),
-            (duration, admin, env.ledger().timestamp()),
+            (duration, admin, env.ledger().timestamp(), reason),
         );
     }
 

--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -3652,10 +3652,53 @@ impl MarketPauseManager {
     /// let admin = Address::generate(&env);
     /// let market_id = Symbol::new(&env, "market_123");
     ///
-    /// // Pause market for 24 hours
-    /// MarketPauseManager::pause_market(&env, admin, &market_id, 24)?;
+    /// // Pause market for 24 hours    /// Pauses a market temporarily for maintenance or emergency situations.
+    ///
+    /// This function allows administrators to temporarily suspend market operations
+    /// while preserving the market state. The market will automatically resume
+    /// after the specified duration expires.
+    ///
+    /// # Parameters
+    ///
+    /// * `env` - The Soroban environment for blockchain operations
+    /// * `admin` - Address of the administrator pausing the market
+    /// * `market_id` - Unique identifier of the market to pause
+    /// * `duration_hours` - Duration of the pause in hours (1-168 hours)
+    /// * `reason` - The reason for pausing the market (for audit clarity)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - Market paused successfully
+    /// * `Err(Error)` - Pause operation failed
+    ///
+    /// # Errors
+    ///
+    /// * `Error::Unauthorized` - Caller is not an authorized administrator
+    /// * `Error::MarketNotFound` - Market doesn't exist
+    /// * `Error::InvalidState` - Market is already paused or in invalid state
+    /// * `Error::InvalidDuration` - Duration is outside allowed range
+    ///
+    /// # State Requirements
+    ///
+    /// * Market must not already be paused
+    /// * Market must be in Active, Ended, or Disputed state
+    /// * Caller must be contract admin
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use soroban_sdk::{Env, Address, Symbol};
+    /// use crate::pause::MarketPauseManager;
+    /// use crate::types::PauseReason;
+    ///
+    /// let env = Env::default();
+    /// let admin = Address::generate(&env);
+    /// let market_id = Symbol::new(&env, "market_123");
+    ///
+    /// // Pause market for 24 hours due to maintenance
+    /// MarketPauseManager::pause_market(&env, admin, &market_id, 24, PauseReason::Maintenance)?;
     /// ```
-    pub fn pause_market(
+    ,pub fn pause_market(
         env: &Env,
         admin: Address,
         market_id: &Symbol,
@@ -3693,7 +3736,7 @@ impl MarketPauseManager {
     };
 
         env.storage().persistent().set(&market_id, &pause_info);
-        Self::emit_pause_event(env, market_id, duration_hours, &admin);
+        Self::emit_pause_event(env, market_id, duration_hours, Self::emit_pause_event(env, market_id, duration_hours, &admin);admin, Self::emit_pause_event(env, market_id, duration_hours, &admin);reason);
 
         Ok(())
     }
@@ -3970,6 +4013,7 @@ impl MarketPauseManager {
             paused_by: paused_by,
             pause_end_time,
             original_state: market.state,
+            reason: reason.clone(),
         };
         env.storage()
             .persistent()

--- a/contracts/predictify-hybrid/src/markets.rs
+++ b/contracts/predictify-hybrid/src/markets.rs
@@ -3698,7 +3698,7 @@ impl MarketPauseManager {
     /// // Pause market for 24 hours due to maintenance
     /// MarketPauseManager::pause_market(&env, admin, &market_id, 24, PauseReason::Maintenance)?;
     /// ```
-    ,pub fn pause_market(
+    pub fn pause_market(
         env: &Env,
         admin: Address,
         market_id: &Symbol,
@@ -3731,12 +3731,6 @@ impl MarketPauseManager {
 
         env.storage().persistent().set(&market_id, &pause_info);
         Self::emit_pause_event(env, market_id, duration_hours, &admin, &reason);
-
-        Ok(())
-    };
-
-        env.storage().persistent().set(&market_id, &pause_info);
-        Self::emit_pause_event(env, market_id, duration_hours, Self::emit_pause_event(env, market_id, duration_hours, &admin);admin, Self::emit_pause_event(env, market_id, duration_hours, &admin);reason);
 
         Ok(())
     }
@@ -4010,15 +4004,15 @@ impl MarketPauseManager {
             is_paused: true,
             paused_at: current_time,
             pause_duration_hours: duration_hours.max(1),
-            paused_by: paused_by,
+            paused_by: paused_by.clone(),
             pause_end_time,
             original_state: market.state,
-            reason: reason.clone(),
+            reason: PauseReason::OracleIssue,
         };
         env.storage()
             .persistent()
             .set(market_id, &pause_info);
-        Self::emit_pause_event(env, market_id, duration_hours, &pause_info.paused_by);
+        Self::emit_pause_event(env, market_id, duration_hours, &paused_by, &PauseReason::OracleIssue);
         Ok(())
     }
 

--- a/contracts/predictify-hybrid/src/types.rs
+++ b/contracts/predictify-hybrid/src/types.rs
@@ -3479,6 +3479,7 @@ pub struct CommunityConsensus {
     pub percentage: i128,
 }
 
+
 ///////////////////////////////////////////////////
 /// Market pause information tracking   //////////
 /////////////////////////////////////////////////
@@ -3491,9 +3492,32 @@ pub struct MarketPauseInfo {
     pub paused_by: Address,
     pub pause_end_time: u64,
     pub original_state: MarketState,
+    pub reason: PauseReason,
+}
+
+///////////////////////////////////////////////////
+/// Pause Reason   //////////
+/////////////////////////////////////////////////
+#[contracttype]
+pub enum PauseReason {
+    /// Market paused due to emergency or security issue
+    Emergency,
+    /// Market paused for regulatory compliance
+    Regulatory,
+    /// Market paused for maintenance or upgrade
+    Maintenance,
+    /// Market paused due to oracle issues
+    OracleIssue,
+    /// Market paused due to liquidity concerns
+    LiquidityConcern,
+    /// Market paused due to suspicious activity
+    SuspiciousActivity,
+    /// Market paused with custom reason (string)
+    Custom(String),
 }
 
 // ===== QUERY RESPONSE TYPES =====
+
 
 /// Market/event status enumeration for queries.
 ///


### PR DESCRIPTION
# Closes #840 

## Summary
Adds structured reason to market pause functionality for better audit clarity.

## Changes
- Add `reason` field to `MarketPauseInfo` struct
- Update `pause_market` function to accept `PauseReason` parameter
- Update `emit_pause_event` to include reason
- Add `PauseReason` enum with 7 variants
- Update `auto_pause_market` to use `PauseReason::OracleIssue`

Closes #840