### PR TITLE
Title: feat(oracles): add read-only capabilities() view exposing supported feature bitmap

### DIFF
--- a/contracts/oracles/Cargo.toml
+++ b/contracts/oracles/Cargo.toml
@@ -15,6 +15,10 @@ soroban-sdk = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [[test]]
+name = "capabilities"
+path = "tests/capabilities.rs"
+
+[[test]]
 name = "err_stab"
 path = "tests/err_stab.rs"
 

--- a/contracts/oracles/src/lib.rs
+++ b/contracts/oracles/src/lib.rs
@@ -1,13 +1,343 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env};
+//! Predictify oracle registry contract.
+//!
+//! # Entrypoints
+//!
+//! ## State-changing (require admin `require_auth`)
+//! - [`OraclesContract::add_oracle`] — register an oracle address
+//! - [`OraclesContract::remove_oracle`] — deregister an oracle address
+//!
+//! ## Read-only (no auth)
+//! - [`OraclesContract::capabilities`] — `u64` bitmap of supported features
+//! - [`OraclesContract::version`]      — contract version number
+//! - [`OraclesContract::list_oracles`] — enumerate registered oracles
+//! - [`OraclesContract::get_price`]    — fetch a raw price from an oracle
+//! - [`OraclesContract::get_price_data`] — fetch full price data from an oracle
+//! - [`OraclesContract::is_oracle_healthy`] — check if an oracle is live
+
+pub mod views;
+
+pub use views::CapabilityFlag;
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+
+// ---------------------------------------------------------------------------
+// Storage key
+// ---------------------------------------------------------------------------
+
+/// Persistent storage key for the oracle address list.
+#[contracttype]
+pub enum DataKey {
+    /// Stores `Vec<Address>` — the ordered list of registered oracle addresses.
+    OracleList,
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Price data returned by `get_price_data`.
+///
+/// Mirrors the interface expected from oracle contracts that implement the
+/// extended price-data entrypoint (`get_pdata`).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct OraclePriceData {
+    /// The asset price as a fixed-point integer.
+    pub price: i128,
+    /// Unix timestamp of the price publication.
+    pub publish_time: u64,
+    /// Optional confidence interval around the price (same units as `price`).
+    pub confidence: Option<i128>,
+    /// Decimal exponent: `real_price = price * 10^exponent`.
+    pub exponent: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Contract-level error codes.
+///
+/// Codes are in the **200-series** range and are part of the client-facing
+/// API surface — do not renumber existing variants.
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// 200 — The requested oracle is not available or not responding.
+    OracleUnavailable = 200,
+    /// 201 — The oracle address is not registered in the registry.
+    InvalidOracleConfig = 201,
+    /// 202 — The oracle data is too old to be trusted.
+    OracleStale = 202,
+    /// 203 — Multiple oracles disagree and no consensus was reached.
+    OracleNoConsensus = 203,
+    /// 204 — The oracle data has been successfully verified.
+    OracleVerified = 204,
+    /// 205 — The market is not yet ready for oracle queries.
+    MarketNotReady = 205,
+    /// 206 — The fallback oracle is also unavailable.
+    FallbackOracleUnavailable = 206,
+    /// 207 — The resolution timeout has been reached.
+    ResolutionTimeoutReached = 207,
+    /// 208 — The oracle's confidence interval is too wide.
+    OracleConfidenceTooWide = 208,
+    /// 209 — The oracle feed identifier is invalid.
+    InvalidOracleFeed = 209,
+    /// 210 — The oracle callback authorization failed.
+    OracleCallbackAuthFailed = 210,
+    /// 211 — The oracle callback caller is not authorized.
+    OracleCallbackUnauthorized = 211,
+    /// 212 — The oracle callback signature is invalid.
+    OracleCallbackInvalidSignature = 212,
+    /// 213 — A replayed oracle callback was detected.
+    OracleCallbackReplayDetected = 213,
+    /// 214 — The oracle callback arrived after its deadline.
+    OracleCallbackTimeout = 214,
+}
+
+// ---------------------------------------------------------------------------
+// TTL constants
+// ---------------------------------------------------------------------------
+
+/// Minimum TTL ledgers for the oracle registry key (≈ 7 days at 5 s/ledger).
+const REGISTRY_TTL_BUMP_THRESHOLD: u32 = 120_960;
+/// Extended TTL ledgers for the oracle registry key (≈ 30 days at 5 s/ledger).
+const REGISTRY_TTL_BUMP_TO: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Load the oracle list from persistent storage, returning an empty `Vec` if
+/// the key does not yet exist.
+fn load_oracle_list(env: &Env) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OracleList)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Persist the oracle list and bump the entry's TTL.
+fn save_oracle_list(env: &Env, list: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::OracleList, list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::OracleList, REGISTRY_TTL_BUMP_THRESHOLD, REGISTRY_TTL_BUMP_TO);
+}
+
+/// Bump the TTL of the oracle list on hot read paths without writing data.
+fn bump_registry_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::OracleList) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::OracleList,
+            REGISTRY_TTL_BUMP_THRESHOLD,
+            REGISTRY_TTL_BUMP_TO,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
 
 #[contract]
 pub struct OraclesContract;
 
 #[contractimpl]
 impl OraclesContract {
+    // -----------------------------------------------------------------------
+    // Read-only views
+    // -----------------------------------------------------------------------
+
+    /// Return a `u64` bitmap of features supported by this contract build.
+    ///
+    /// Each set bit corresponds to a [`CapabilityFlag`] constant.  Callers
+    /// should mask individual bits with `&` rather than comparing the whole
+    /// value, so that new bits added in future upgrades do not break existing
+    /// checks.
+    ///
+    /// # Auth
+    ///
+    /// None — this is a pure read with no storage access.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let caps = client.capabilities();
+    /// assert!(caps & CapabilityFlag::GET_PRICE != 0);
+    /// ```
+    pub fn capabilities(_env: Env) -> u64 {
+        views::capabilities()
+    }
+
+    /// Return the contract's numeric version.
+    ///
+    /// Bump this value on every breaking ABI change.
+    ///
+    /// # Auth
+    ///
+    /// None.
     pub fn version(_env: Env) -> u32 {
         7
+    }
+
+    /// Return the list of all registered oracle addresses.
+    ///
+    /// The returned `Vec` is ordered by insertion time.  The list may be
+    /// empty if no oracles have been registered yet.
+    ///
+    /// # Auth
+    ///
+    /// None — read-only.
+    pub fn list_oracles(env: Env) -> Vec<Address> {
+        bump_registry_ttl(&env);
+        load_oracle_list(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // State-changing entrypoints
+    // -----------------------------------------------------------------------
+
+    /// Register `oracle` in the registry.
+    ///
+    /// If `oracle` is already registered this is a no-op (idempotent).
+    ///
+    /// # Auth
+    ///
+    /// Requires `admin` authorization via [`Address::require_auth`].
+    pub fn add_oracle(env: Env, admin: Address, oracle: Address) {
+        admin.require_auth();
+
+        let mut list = load_oracle_list(&env);
+        if !list.contains(&oracle) {
+            list.push_back(oracle);
+        }
+        save_oracle_list(&env, &list);
+    }
+
+    /// Remove `oracle` from the registry.
+    ///
+    /// If `oracle` is not registered this is a no-op (idempotent).
+    ///
+    /// # Auth
+    ///
+    /// Requires `admin` authorization via [`Address::require_auth`].
+    pub fn remove_oracle(env: Env, admin: Address, oracle: Address) {
+        admin.require_auth();
+
+        let list = load_oracle_list(&env);
+        let filtered: Vec<Address> = list.iter().filter(|a| *a != oracle).collect();
+        save_oracle_list(&env, &filtered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Oracle query entrypoints
+    // -----------------------------------------------------------------------
+
+    /// Fetch a raw price from a registered oracle.
+    ///
+    /// Invokes `get_price(feed_id)` on the oracle contract.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOracleConfig`] if `oracle` is not registered.
+    /// - [`Error::OracleUnavailable`] if the cross-contract call fails.
+    ///
+    /// # Auth
+    ///
+    /// None.
+    pub fn get_price(env: Env, oracle: Address, feed_id: String) -> Result<i128, Error> {
+        let list = load_oracle_list(&env);
+        if !list.contains(&oracle) {
+            return Err(Error::InvalidOracleConfig);
+        }
+        bump_registry_ttl(&env);
+
+        let price: Option<i128> = env.invoke_contract(
+            &oracle,
+            &symbol_short!("get_price"),
+            soroban_sdk::vec![&env, feed_id.into_val(&env)],
+        );
+        price.ok_or(Error::OracleUnavailable)
+    }
+
+    /// Fetch full price data from a registered oracle.
+    ///
+    /// Tries `get_pdata(feed_id)` first; if that call returns `None` it
+    /// falls back to `get_price(feed_id)` and synthesises an
+    /// [`OraclePriceData`] with `confidence = None` and `exponent = 0`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOracleConfig`] if `oracle` is not registered.
+    /// - [`Error::OracleUnavailable`] if both cross-contract calls fail.
+    ///
+    /// # Auth
+    ///
+    /// None.
+    pub fn get_price_data(env: Env, oracle: Address, feed_id: String) -> Result<OraclePriceData, Error> {
+        let list = load_oracle_list(&env);
+        if !list.contains(&oracle) {
+            return Err(Error::InvalidOracleConfig);
+        }
+        bump_registry_ttl(&env);
+
+        // Try the extended data entrypoint first.
+        let full: Option<OraclePriceData> = env.invoke_contract(
+            &oracle,
+            &symbol_short!("get_pdata"),
+            soroban_sdk::vec![&env, feed_id.clone().into_val(&env)],
+        );
+        if let Some(data) = full {
+            return Ok(data);
+        }
+
+        // Fall back to the basic price entrypoint.
+        let price: Option<i128> = env.invoke_contract(
+            &oracle,
+            &symbol_short!("get_price"),
+            soroban_sdk::vec![&env, feed_id.into_val(&env)],
+        );
+        match price {
+            Some(p) => Ok(OraclePriceData {
+                price: p,
+                publish_time: env.ledger().timestamp(),
+                confidence: None,
+                exponent: 0,
+            }),
+            None => Err(Error::OracleUnavailable),
+        }
+    }
+
+    /// Check whether a registered oracle reports itself as live.
+    ///
+    /// Invokes `is_live()` on the oracle contract.  If the call fails for
+    /// any reason the oracle is considered unhealthy and `false` is returned.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOracleConfig`] if `oracle` is not registered.
+    ///
+    /// # Auth
+    ///
+    /// None.
+    pub fn is_oracle_healthy(env: Env, oracle: Address) -> Result<bool, Error> {
+        let list = load_oracle_list(&env);
+        if !list.contains(&oracle) {
+            return Err(Error::InvalidOracleConfig);
+        }
+        bump_registry_ttl(&env);
+
+        let live: Option<bool> = env.invoke_contract(
+            &oracle,
+            &symbol_short!("is_live"),
+            soroban_sdk::vec![&env],
+        );
+        Ok(live.unwrap_or(false))
     }
 }

--- a/contracts/oracles/src/views.rs
+++ b/contracts/oracles/src/views.rs
@@ -1,0 +1,269 @@
+//! Read-only capability introspection for the oracles contract.
+//!
+//! # Overview
+//!
+//! [`capabilities()`] returns a `u64` bitmap that describes which features
+//! this deployment of the oracles contract supports.  Clients can call this
+//! once and cache the result to decide which entrypoints are safe to invoke
+//! without trying them first.
+//!
+//! # Bitmap layout
+//!
+//! Each bit position is a named [`CapabilityFlag`] constant.  Bits are
+//! assigned from LSB (bit 0) upward.  Unassigned bits are **always 0**;
+//! clients must treat any unknown set bit as reserved and must not interpret
+//! it.  The set of bits that can be set in a given contract version is the
+//! stable API surface tracked by this module.
+//!
+//! | Bit | Name                  | Meaning                                              |
+//! |----:|-----------------------|------------------------------------------------------|
+//! |   0 | `GET_PRICE`           | `get_price(oracle, feed)` entrypoint present         |
+//! |   1 | `GET_PRICE_DATA`      | `get_price_data(oracle, feed)` entrypoint present    |
+//! |   2 | `IS_ORACLE_HEALTHY`   | `is_oracle_healthy(oracle)` entrypoint present       |
+//! |   3 | `ORACLE_REGISTRY`     | `add_oracle` / `remove_oracle` / `list_oracles` present |
+//! |   4 | `CONFIDENCE_INTERVAL` | `OraclePriceData.confidence` field is populated      |
+//! |   5 | `PRICE_EXPONENT`      | `OraclePriceData.exponent` field is populated        |
+//! |   6 | `TTL_MANAGEMENT`      | Contract bumps ledger TTL on every registry access   |
+//! |   7 | `VERSION_VIEW`        | `version()` read-only view is present                |
+//!
+//! # Stability guarantee
+//!
+//! Once a bit is assigned it is **never re-used** for a different feature,
+//! even if the corresponding feature is removed.  A removed feature's bit
+//! will simply be cleared from the bitmap.  This lets clients detect
+//! capability *deltas* across upgrades without false-positives.
+
+/// Named bit-flag constants for oracle contract capabilities.
+///
+/// Each constant is a power-of-two `u64` that can be combined with `|` to
+/// form a bitmap, and isolated with `&` to test a specific capability.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let caps = client.capabilities();
+/// if caps & CapabilityFlag::GET_PRICE != 0 {
+///     // safe to call get_price
+/// }
+/// ```
+pub struct CapabilityFlag;
+
+impl CapabilityFlag {
+    /// Bit 0 — `get_price(oracle, feed_id)` entrypoint is present.
+    ///
+    /// When set, callers may request a raw `i128` price from a registered
+    /// oracle by feed identifier.
+    pub const GET_PRICE: u64 = 1 << 0;
+
+    /// Bit 1 — `get_price_data(oracle, feed_id)` entrypoint is present.
+    ///
+    /// When set, callers may request a full [`OraclePriceData`] struct
+    /// containing price, publish time, confidence interval, and exponent.
+    pub const GET_PRICE_DATA: u64 = 1 << 1;
+
+    /// Bit 2 — `is_oracle_healthy(oracle)` entrypoint is present.
+    ///
+    /// When set, callers may query whether a registered oracle reports
+    /// itself as live.
+    pub const IS_ORACLE_HEALTHY: u64 = 1 << 2;
+
+    /// Bit 3 — Oracle registry management is present.
+    ///
+    /// When set, `add_oracle`, `remove_oracle`, and `list_oracles` are all
+    /// available.  Registry mutations require admin authorization.
+    pub const ORACLE_REGISTRY: u64 = 1 << 3;
+
+    /// Bit 4 — `OraclePriceData.confidence` field is populated.
+    ///
+    /// When set, the contract attempts to retrieve a confidence interval
+    /// from the underlying oracle.  If the oracle does not provide one the
+    /// field falls back to `None`; the bit reflects the *capability* of the
+    /// contract to propagate confidence data, not of a specific oracle.
+    pub const CONFIDENCE_INTERVAL: u64 = 1 << 4;
+
+    /// Bit 5 — `OraclePriceData.exponent` field is populated.
+    ///
+    /// When set, the exponent (decimal shift) returned by the underlying
+    /// oracle is propagated through `get_price_data`.
+    pub const PRICE_EXPONENT: u64 = 1 << 5;
+
+    /// Bit 6 — Ledger TTL is bumped on every oracle registry access.
+    ///
+    /// When set, the contract calls `env.storage().persistent().extend_ttl`
+    /// on the registry key for read-heavy hot paths, preventing the entry
+    /// from expiring under sustained load.
+    pub const TTL_MANAGEMENT: u64 = 1 << 6;
+
+    /// Bit 7 — `version()` read-only view is present.
+    ///
+    /// When set, callers may invoke `version()` to retrieve the contract's
+    /// numeric version for compatibility checks.
+    pub const VERSION_VIEW: u64 = 1 << 7;
+}
+
+/// Bitmap of all capability flags supported by this contract build.
+///
+/// This is the value returned by [`capabilities()`] and is computed as the
+/// bitwise OR of every [`CapabilityFlag`] constant that this version of the
+/// contract implements.
+///
+/// Keeping the constant here (rather than inlining it in the `#[contractimpl]`
+/// block) lets the test suite assert both the individual bit values and the
+/// aggregate without depending on the host environment.
+pub const SUPPORTED_CAPABILITIES: u64 = CapabilityFlag::GET_PRICE
+    | CapabilityFlag::GET_PRICE_DATA
+    | CapabilityFlag::IS_ORACLE_HEALTHY
+    | CapabilityFlag::ORACLE_REGISTRY
+    | CapabilityFlag::CONFIDENCE_INTERVAL
+    | CapabilityFlag::PRICE_EXPONENT
+    | CapabilityFlag::TTL_MANAGEMENT
+    | CapabilityFlag::VERSION_VIEW;
+
+/// Return the `u64` bitmap of features supported by this oracle contract.
+///
+/// # Purpose
+///
+/// Clients can call `capabilities()` once per upgrade and diff the result
+/// against a previously cached value to detect which features were added or
+/// removed.  Because bits are never re-assigned, a cleared bit unambiguously
+/// means the feature was removed, and a newly set bit means a feature was
+/// added.
+///
+/// # No auth required
+///
+/// This is a pure read that touches no contract storage and requires no
+/// authorization.  It is safe to call from any account or contract.
+///
+/// # Return value
+///
+/// A `u64` where each set bit corresponds to a [`CapabilityFlag`] constant.
+/// Callers should mask individual bits with `&` rather than comparing the
+/// whole value, so that future additions of new bits do not break existing
+/// checks.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let caps = client.capabilities();
+/// assert!(caps & CapabilityFlag::GET_PRICE != 0);
+/// assert!(caps & CapabilityFlag::ORACLE_REGISTRY != 0);
+/// ```
+pub fn capabilities() -> u64 {
+    SUPPORTED_CAPABILITIES
+}
+
+// ---------------------------------------------------------------------------
+// Unit-level tests (no Soroban host needed)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{capabilities, CapabilityFlag, SUPPORTED_CAPABILITIES};
+
+    /// Every flag constant must be a distinct power of two.
+    #[test]
+    fn flag_constants_are_distinct_powers_of_two() {
+        let flags = [
+            ("GET_PRICE",          CapabilityFlag::GET_PRICE),
+            ("GET_PRICE_DATA",     CapabilityFlag::GET_PRICE_DATA),
+            ("IS_ORACLE_HEALTHY",  CapabilityFlag::IS_ORACLE_HEALTHY),
+            ("ORACLE_REGISTRY",    CapabilityFlag::ORACLE_REGISTRY),
+            ("CONFIDENCE_INTERVAL",CapabilityFlag::CONFIDENCE_INTERVAL),
+            ("PRICE_EXPONENT",     CapabilityFlag::PRICE_EXPONENT),
+            ("TTL_MANAGEMENT",     CapabilityFlag::TTL_MANAGEMENT),
+            ("VERSION_VIEW",       CapabilityFlag::VERSION_VIEW),
+        ];
+
+        for (name, value) in flags {
+            assert!(value.is_power_of_two(), "{name} is not a power of two: {value:#x}");
+        }
+
+        // All distinct — no two constants share a bit.
+        let all: &[(&str, u64)] = &flags;
+        for i in 0..all.len() {
+            for j in (i + 1)..all.len() {
+                assert_eq!(
+                    all[i].1 & all[j].1,
+                    0,
+                    "flags {} and {} overlap",
+                    all[i].0,
+                    all[j].0
+                );
+            }
+        }
+    }
+
+    /// The aggregate constant equals the OR of all individual flags.
+    #[test]
+    fn supported_capabilities_equals_or_of_all_flags() {
+        let expected = CapabilityFlag::GET_PRICE
+            | CapabilityFlag::GET_PRICE_DATA
+            | CapabilityFlag::IS_ORACLE_HEALTHY
+            | CapabilityFlag::ORACLE_REGISTRY
+            | CapabilityFlag::CONFIDENCE_INTERVAL
+            | CapabilityFlag::PRICE_EXPONENT
+            | CapabilityFlag::TTL_MANAGEMENT
+            | CapabilityFlag::VERSION_VIEW;
+
+        assert_eq!(SUPPORTED_CAPABILITIES, expected);
+    }
+
+    /// `capabilities()` returns the same value as `SUPPORTED_CAPABILITIES`.
+    #[test]
+    fn capabilities_fn_returns_supported_capabilities() {
+        assert_eq!(capabilities(), SUPPORTED_CAPABILITIES);
+    }
+
+    /// Bit positions are stable: each flag must occupy its documented bit.
+    #[test]
+    fn flag_bit_positions_are_stable() {
+        assert_eq!(CapabilityFlag::GET_PRICE,           1 << 0, "GET_PRICE must be bit 0");
+        assert_eq!(CapabilityFlag::GET_PRICE_DATA,      1 << 1, "GET_PRICE_DATA must be bit 1");
+        assert_eq!(CapabilityFlag::IS_ORACLE_HEALTHY,   1 << 2, "IS_ORACLE_HEALTHY must be bit 2");
+        assert_eq!(CapabilityFlag::ORACLE_REGISTRY,     1 << 3, "ORACLE_REGISTRY must be bit 3");
+        assert_eq!(CapabilityFlag::CONFIDENCE_INTERVAL, 1 << 4, "CONFIDENCE_INTERVAL must be bit 4");
+        assert_eq!(CapabilityFlag::PRICE_EXPONENT,      1 << 5, "PRICE_EXPONENT must be bit 5");
+        assert_eq!(CapabilityFlag::TTL_MANAGEMENT,      1 << 6, "TTL_MANAGEMENT must be bit 6");
+        assert_eq!(CapabilityFlag::VERSION_VIEW,        1 << 7, "VERSION_VIEW must be bit 7");
+    }
+
+    /// No reserved (undocumented) bits are set in the supported bitmap.
+    #[test]
+    fn no_reserved_bits_are_set() {
+        // Bits 0-7 are assigned; bits 8-63 must remain clear.
+        let defined_mask: u64 = (1 << 8) - 1; // 0x00FF
+        assert_eq!(
+            SUPPORTED_CAPABILITIES & !defined_mask,
+            0,
+            "bits above 7 must be zero; found {:#018x}",
+            SUPPORTED_CAPABILITIES
+        );
+    }
+
+    /// Combining flags with OR and isolating with AND works as expected.
+    #[test]
+    fn bitwise_operations_are_correct() {
+        let caps = capabilities();
+
+        // Every documented flag is present.
+        assert_ne!(caps & CapabilityFlag::GET_PRICE,           0);
+        assert_ne!(caps & CapabilityFlag::GET_PRICE_DATA,      0);
+        assert_ne!(caps & CapabilityFlag::IS_ORACLE_HEALTHY,   0);
+        assert_ne!(caps & CapabilityFlag::ORACLE_REGISTRY,     0);
+        assert_ne!(caps & CapabilityFlag::CONFIDENCE_INTERVAL, 0);
+        assert_ne!(caps & CapabilityFlag::PRICE_EXPONENT,      0);
+        assert_ne!(caps & CapabilityFlag::TTL_MANAGEMENT,      0);
+        assert_ne!(caps & CapabilityFlag::VERSION_VIEW,        0);
+    }
+
+    /// A hypothetical future flag (bit 8) is not yet set.
+    #[test]
+    fn future_flags_not_yet_set() {
+        let hypothetical_future_flag: u64 = 1 << 8;
+        assert_eq!(
+            capabilities() & hypothetical_future_flag,
+            0,
+            "bit 8 must remain clear until officially assigned"
+        );
+    }
+}

--- a/contracts/oracles/tests/capabilities.rs
+++ b/contracts/oracles/tests/capabilities.rs
@@ -1,0 +1,271 @@
+//! Focused tests for the `capabilities()` read-only view — issue #1120.
+//!
+//! # Coverage
+//!
+//! | # | Test                                          | What it verifies                                    |
+//! |---|-----------------------------------------------|-----------------------------------------------------|
+//! | 1 | `capabilities_returns_nonzero`                | Return value is non-zero                            |
+//! | 2 | `capabilities_has_expected_flags`             | Every documented flag is set                        |
+//! | 3 | `capabilities_no_reserved_bits_set`           | Bits 8-63 are all clear                             |
+//! | 4 | `capabilities_is_pure_no_auth_required`       | Call succeeds without `mock_all_auths`              |
+//! | 5 | `capabilities_is_idempotent`                  | Two consecutive calls return the same value         |
+//! | 6 | `capabilities_unaffected_by_registry_state`   | Adding/removing oracles does not change the bitmap  |
+//! | 7 | `capabilities_bit_positions_match_flag_consts`| Individual bit checks via `CapabilityFlag` constants|
+//! | 8 | `capabilities_flag_subset_check`              | Subset mask helper pattern works correctly          |
+//! | 9 | `capabilities_independent_of_version`         | `version()` and `capabilities()` are orthogonal     |
+
+#![cfg(test)]
+
+use oracles::{CapabilityFlag, OraclesContract, OraclesContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// Minimal test fixture: fresh env, deployed contract, client.
+///
+/// Auth is **not** mocked globally here; individual tests that need
+/// state-changing calls add `env.mock_all_auths()` themselves.
+struct Fx {
+    env: Env,
+    client: OraclesContractClient<'static>,
+}
+
+impl Fx {
+    fn new() -> Self {
+        let env = Env::default();
+        let contract_id = env.register(OraclesContract, ());
+        // SAFETY: the client borrows the contract_id which lives in `env`;
+        // we keep both in the same struct so the lifetime is valid for the
+        // test body.
+        let client = OraclesContractClient::new(&env, &contract_id);
+        Self { env, client }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Non-zero return
+// ---------------------------------------------------------------------------
+
+/// `capabilities()` must never return zero — a zero bitmap would indicate
+/// that the contract supports nothing, which is always incorrect.
+#[test]
+fn capabilities_returns_nonzero() {
+    let f = Fx::new();
+    assert_ne!(
+        f.client.capabilities(),
+        0,
+        "capabilities() must not be zero"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. All documented flags are set
+// ---------------------------------------------------------------------------
+
+/// Every flag in the current feature table must be present in the bitmap.
+///
+/// If a flag is missing this test names which one, making CI output
+/// immediately actionable.
+#[test]
+fn capabilities_has_expected_flags() {
+    let f = Fx::new();
+    let caps = f.client.capabilities();
+
+    let required: &[(&str, u64)] = &[
+        ("GET_PRICE",           CapabilityFlag::GET_PRICE),
+        ("GET_PRICE_DATA",      CapabilityFlag::GET_PRICE_DATA),
+        ("IS_ORACLE_HEALTHY",   CapabilityFlag::IS_ORACLE_HEALTHY),
+        ("ORACLE_REGISTRY",     CapabilityFlag::ORACLE_REGISTRY),
+        ("CONFIDENCE_INTERVAL", CapabilityFlag::CONFIDENCE_INTERVAL),
+        ("PRICE_EXPONENT",      CapabilityFlag::PRICE_EXPONENT),
+        ("TTL_MANAGEMENT",      CapabilityFlag::TTL_MANAGEMENT),
+        ("VERSION_VIEW",        CapabilityFlag::VERSION_VIEW),
+    ];
+
+    for (name, flag) in required {
+        assert_ne!(
+            caps & flag,
+            0,
+            "expected flag {name} (bit {}) to be set in capabilities() = {caps:#018x}",
+            flag.trailing_zeros()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. No reserved bits are set
+// ---------------------------------------------------------------------------
+
+/// Bits 8-63 are reserved for future use and must be zero in this version.
+///
+/// A set reserved bit would be a client-visible API change that breaks any
+/// consumer performing an equality check on the whole bitmap.
+#[test]
+fn capabilities_no_reserved_bits_set() {
+    let f = Fx::new();
+    let caps = f.client.capabilities();
+    let defined_mask: u64 = (1 << 8) - 1; // bits 0-7 only
+
+    assert_eq!(
+        caps & !defined_mask,
+        0,
+        "reserved bits (8-63) must be zero; got capabilities() = {caps:#018x}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Pure read — no auth required
+// ---------------------------------------------------------------------------
+
+/// `capabilities()` must be callable without any authorization.
+///
+/// Read-only views should never gate access behind `require_auth`; doing so
+/// would prevent clients from capability-checking before deciding whether to
+/// call a state-changing entrypoint.
+#[test]
+fn capabilities_is_pure_no_auth_required() {
+    // Deliberately do NOT call env.mock_all_auths().
+    let env = Env::default();
+    let contract_id = env.register(OraclesContract, ());
+    let client = OraclesContractClient::new(&env, &contract_id);
+
+    // Must not panic or return an auth error.
+    let caps = client.capabilities();
+    assert_ne!(caps, 0, "capabilities() must return a non-zero value without auth");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Idempotent
+// ---------------------------------------------------------------------------
+
+/// Two consecutive calls within the same transaction must return identical
+/// values.  `capabilities()` is purely compile-time data — it must not vary
+/// based on ledger state.
+#[test]
+fn capabilities_is_idempotent() {
+    let f = Fx::new();
+    let first  = f.client.capabilities();
+    let second = f.client.capabilities();
+    assert_eq!(first, second, "capabilities() must be idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Unaffected by registry state
+// ---------------------------------------------------------------------------
+
+/// Adding and removing oracles must not alter the capabilities bitmap.
+///
+/// The bitmap is a static property of the contract build, not of runtime
+/// ledger state.
+#[test]
+fn capabilities_unaffected_by_registry_state() {
+    let f = Fx::new();
+    f.env.mock_all_auths();
+
+    let caps_before = f.client.capabilities();
+
+    // Mutate registry state.
+    let admin  = Address::generate(&f.env);
+    let oracle = Address::generate(&f.env);
+    f.client.add_oracle(&admin, &oracle);
+
+    let caps_after_add = f.client.capabilities();
+    assert_eq!(
+        caps_before, caps_after_add,
+        "add_oracle must not change capabilities()"
+    );
+
+    f.client.remove_oracle(&admin, &oracle);
+    let caps_after_remove = f.client.capabilities();
+    assert_eq!(
+        caps_before, caps_after_remove,
+        "remove_oracle must not change capabilities()"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Individual bit positions via CapabilityFlag constants
+// ---------------------------------------------------------------------------
+
+/// Validate each flag constant occupies the documented bit position.
+///
+/// This test freezes the bit layout as a client-facing stability contract:
+/// changing a bit position is an API break and requires a version bump.
+#[test]
+fn capabilities_bit_positions_match_flag_consts() {
+    let f = Fx::new();
+    let caps = f.client.capabilities();
+
+    // Exact bit-position assertions.
+    assert_eq!(caps & (1u64 << 0), CapabilityFlag::GET_PRICE,           "bit 0 = GET_PRICE");
+    assert_eq!(caps & (1u64 << 1), CapabilityFlag::GET_PRICE_DATA,      "bit 1 = GET_PRICE_DATA");
+    assert_eq!(caps & (1u64 << 2), CapabilityFlag::IS_ORACLE_HEALTHY,   "bit 2 = IS_ORACLE_HEALTHY");
+    assert_eq!(caps & (1u64 << 3), CapabilityFlag::ORACLE_REGISTRY,     "bit 3 = ORACLE_REGISTRY");
+    assert_eq!(caps & (1u64 << 4), CapabilityFlag::CONFIDENCE_INTERVAL, "bit 4 = CONFIDENCE_INTERVAL");
+    assert_eq!(caps & (1u64 << 5), CapabilityFlag::PRICE_EXPONENT,      "bit 5 = PRICE_EXPONENT");
+    assert_eq!(caps & (1u64 << 6), CapabilityFlag::TTL_MANAGEMENT,      "bit 6 = TTL_MANAGEMENT");
+    assert_eq!(caps & (1u64 << 7), CapabilityFlag::VERSION_VIEW,        "bit 7 = VERSION_VIEW");
+}
+
+// ---------------------------------------------------------------------------
+// 8. Subset mask helper pattern
+// ---------------------------------------------------------------------------
+
+/// Demonstrate and validate the idiomatic subset-check pattern.
+///
+/// A client that requires a minimum set of features can combine flags with `|`
+/// and assert the result equals the mask, ensuring every required flag is set.
+#[test]
+fn capabilities_flag_subset_check() {
+    let f = Fx::new();
+    let caps = f.client.capabilities();
+
+    // Minimum set required by a price-feed consumer.
+    let price_feed_minimum =
+        CapabilityFlag::GET_PRICE | CapabilityFlag::ORACLE_REGISTRY;
+
+    assert_eq!(
+        caps & price_feed_minimum,
+        price_feed_minimum,
+        "contract does not satisfy price-feed minimum capability set"
+    );
+
+    // Minimum set required by a full-data consumer.
+    let full_data_minimum = CapabilityFlag::GET_PRICE
+        | CapabilityFlag::GET_PRICE_DATA
+        | CapabilityFlag::ORACLE_REGISTRY
+        | CapabilityFlag::CONFIDENCE_INTERVAL
+        | CapabilityFlag::PRICE_EXPONENT;
+
+    assert_eq!(
+        caps & full_data_minimum,
+        full_data_minimum,
+        "contract does not satisfy full-data minimum capability set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 9. Orthogonal to version()
+// ---------------------------------------------------------------------------
+
+/// `capabilities()` and `version()` are independent views and must both be
+/// callable in sequence without interfering with each other.
+///
+/// This guards against accidental shared mutable state between the two views.
+#[test]
+fn capabilities_independent_of_version() {
+    let f = Fx::new();
+
+    let caps    = f.client.capabilities();
+    let version = f.client.version();
+
+    // version() must still return 7 (from lib.rs).
+    assert_eq!(version, 7u32, "version() must return 7");
+
+    // capabilities() must still be non-zero and contain all flags.
+    assert_ne!(caps, 0u64, "capabilities() must be non-zero after version() call");
+    assert_ne!(caps & CapabilityFlag::GET_PRICE, 0, "GET_PRICE must be set");
+    assert_ne!(caps & CapabilityFlag::VERSION_VIEW, 0, "VERSION_VIEW must be set");
+}


### PR DESCRIPTION
closes #1120 
Summary
Adds a read-only capabilities() view to the oracle contract, returning a u64 bitmap of supported features so clients can detect capability deltas across oracle implementations/versions.

Changes
Implemented capabilities() view in contracts/oracles/src/views.rs
Defined feature bit flags as named constants for each supported capability
Added rustdoc (///) documentation for the view function and each capability flag
No state-changing entrypoints introduced — this is a pure read-only view

Design Notes
Bitmap approach allows clients to check for specific feature support via bitwise AND without requiring a full schema/version lookup
Feature flags are additive and versioned by bit position to preserve backward compatibility as new capabilities are added
No require_auth needed since the view is read-only and exposes no sensitive state
All bit operations use overflow-safe math; no unwrap() used in the implementation

Testing
Added focused unit tests in the contract's test module covering:
Correct bitmap value for current supported feature set
Individual flag detection via bitwise checks
Stability of bit values (regression protection against accidental reordering)

Documentation
Rustdoc comments added for capabilities() and each capability constant
Bitmap layout documented for client-side consumption