### PR TITLE
test: add migrate gas regression snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
+name = "migrate"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/migrate/Cargo.toml
+++ b/contracts/migrate/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "migrate"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[test]]
+name = "gas_snap"
+path = "tests/gas_snap.rs"

--- a/contracts/migrate/src/lib.rs
+++ b/contracts/migrate/src/lib.rs
@@ -1,0 +1,152 @@
+#![no_std]
+
+//! Version migration contract.
+//!
+//! The contract keeps a single administrator and monotonically increasing
+//! version number. A migration must name the version it expects to replace;
+//! this compare-and-set rule prevents stale operators from overwriting a
+//! newer migration.
+
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env,
+};
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Admin,
+    Version,
+}
+
+/// Errors returned by migration entrypoints.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ContractError {
+    /// The contract has already been initialized.
+    AlreadyInitialized = 1,
+    /// The contract has not been initialized.
+    NotInitialized = 2,
+    /// The authenticated caller is not the migration administrator.
+    Unauthorized = 3,
+    /// The target version is not strictly greater than the current version.
+    InvalidTargetVersion = 4,
+    /// The supplied expected version does not match the stored version.
+    VersionMismatch = 5,
+}
+
+/// Emitted after migration state is initialized.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Initialized {
+    /// Administrator authorized to perform migrations.
+    #[topic]
+    pub admin: Address,
+    /// First active version.
+    pub initial_version: u32,
+}
+
+/// Emitted after a version migration succeeds.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Migrated {
+    /// Administrator that authorized the migration.
+    #[topic]
+    pub admin: Address,
+    /// Version replaced by this migration.
+    pub previous_version: u32,
+    /// Version activated by this migration.
+    pub target_version: u32,
+}
+
+#[contract]
+pub struct MigrateContract;
+
+#[contractimpl]
+impl MigrateContract {
+    /// Initializes migration state with an administrator and starting version.
+    ///
+    /// The administrator must authorize the call. Re-initialization returns
+    /// [`ContractError::AlreadyInitialized`] and leaves state unchanged.
+    pub fn initialize(env: Env, admin: Address, initial_version: u32) -> Result<(), ContractError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &initial_version);
+        Initialized {
+            admin,
+            initial_version,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Advances the stored version using an authenticated compare-and-set.
+    ///
+    /// `expected_version` must equal the stored version and `target_version`
+    /// must be strictly greater. These checks prevent stale, duplicate, and
+    /// downgrade migrations. Successful calls emit a `migrated` event whose
+    /// data is `(previous_version, target_version)`.
+    pub fn migrate(
+        env: Env,
+        admin: Address,
+        expected_version: u32,
+        target_version: u32,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+
+        let stored_admin = Self::load_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let current_version = Self::load_version(&env)?;
+        if expected_version != current_version {
+            return Err(ContractError::VersionMismatch);
+        }
+        if target_version <= current_version {
+            return Err(ContractError::InvalidTargetVersion);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &target_version);
+        Migrated {
+            admin,
+            previous_version: current_version,
+            target_version,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Returns the configured migration administrator.
+    pub fn admin(env: Env) -> Result<Address, ContractError> {
+        Self::load_admin(&env)
+    }
+
+    /// Returns the current stored version.
+    pub fn current_version(env: Env) -> Result<u32, ContractError> {
+        Self::load_version(&env)
+    }
+
+    fn load_admin(env: &Env) -> Result<Address, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    fn load_version(env: &Env) -> Result<u32, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Version)
+            .ok_or(ContractError::NotInitialized)
+    }
+}

--- a/contracts/migrate/tests/gas_snap.rs
+++ b/contracts/migrate/tests/gas_snap.rs
@@ -1,0 +1,199 @@
+//! Per-entrypoint Soroban CPU and memory regression snapshots.
+//!
+//! Each snapshot isolates one public call and compares its measured mock-host
+//! budget delta with a checked-in baseline. CI permits at most a 5% increase:
+//! `limit = baseline + ceil(baseline / 20)`. Setup work is deliberately
+//! completed before the budget reset so unrelated fixture costs cannot hide an
+//! entrypoint regression.
+
+use migrate::{ContractError, MigrateContract, MigrateContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[derive(Copy, Clone)]
+struct Baseline {
+    cpu: u64,
+    memory: u64,
+}
+
+// Baselines measured with soroban-sdk 25.3.1 and a reset unlimited budget.
+const INITIALIZE: Baseline = Baseline {
+    cpu: 55_643,
+    memory: 20_337,
+};
+const MIGRATE: Baseline = Baseline {
+    cpu: 69_405,
+    memory: 22_409,
+};
+const ADMIN: Baseline = Baseline {
+    cpu: 31_614,
+    memory: 12_495,
+};
+const CURRENT_VERSION: Baseline = Baseline {
+    cpu: 31_370,
+    memory: 12_495,
+};
+
+fn measured_budget(env: &Env) -> (u64, u64) {
+    let budget = env.cost_estimate().budget();
+    (budget.cpu_instruction_cost(), budget.memory_bytes_cost())
+}
+
+fn reset_budget(env: &Env) {
+    env.cost_estimate().budget().reset_unlimited();
+}
+
+fn five_percent_ceiling(baseline: u64) -> u64 {
+    let rounded_five_percent = baseline.div_ceil(20);
+    baseline
+        .checked_add(rounded_five_percent)
+        .expect("gas baseline must leave room for its 5% regression margin")
+}
+
+fn assert_budget(label: &str, measured: (u64, u64), baseline: Baseline) {
+    let cpu_limit = five_percent_ceiling(baseline.cpu);
+    let memory_limit = five_percent_ceiling(baseline.memory);
+
+    println!(
+        "{label}: cpu={}, memory={}, cpu_limit={cpu_limit}, memory_limit={memory_limit}",
+        measured.0, measured.1
+    );
+    assert!(
+        measured.0 <= cpu_limit,
+        "{label}: CPU regression exceeds 5%: measured {}, baseline {}, limit {}",
+        measured.0,
+        baseline.cpu,
+        cpu_limit
+    );
+    assert!(
+        measured.1 <= memory_limit,
+        "{label}: memory regression exceeds 5%: measured {}, baseline {}, limit {}",
+        measured.1,
+        baseline.memory,
+        memory_limit
+    );
+}
+
+struct Fixture {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(MigrateContract, ());
+        let admin = Address::generate(&env);
+        Self {
+            env,
+            contract_id,
+            admin,
+        }
+    }
+
+    fn client(&self) -> MigrateContractClient<'_> {
+        MigrateContractClient::new(&self.env, &self.contract_id)
+    }
+
+    fn initialize(&self, version: u32) {
+        self.client().initialize(&self.admin, &version);
+    }
+}
+
+#[test]
+fn snapshot_initialize() {
+    let fixture = Fixture::new();
+    let client = fixture.client();
+
+    reset_budget(&fixture.env);
+    client.initialize(&fixture.admin, &1);
+    let measured = measured_budget(&fixture.env);
+
+    assert_budget("initialize", measured, INITIALIZE);
+}
+
+#[test]
+fn snapshot_migrate() {
+    let fixture = Fixture::new();
+    fixture.initialize(1);
+    let client = fixture.client();
+
+    reset_budget(&fixture.env);
+    client.migrate(&fixture.admin, &1, &2);
+    let measured = measured_budget(&fixture.env);
+
+    assert_eq!(client.current_version(), 2);
+    assert_budget("migrate", measured, MIGRATE);
+}
+
+#[test]
+fn snapshot_admin() {
+    let fixture = Fixture::new();
+    fixture.initialize(1);
+    let client = fixture.client();
+
+    reset_budget(&fixture.env);
+    let stored_admin = client.admin();
+    let measured = measured_budget(&fixture.env);
+
+    assert_eq!(stored_admin, fixture.admin);
+    assert_budget("admin", measured, ADMIN);
+}
+
+#[test]
+fn snapshot_current_version() {
+    let fixture = Fixture::new();
+    fixture.initialize(7);
+    let client = fixture.client();
+
+    reset_budget(&fixture.env);
+    let current_version = client.current_version();
+    let measured = measured_budget(&fixture.env);
+
+    assert_eq!(current_version, 7);
+    assert_budget("current_version", measured, CURRENT_VERSION);
+}
+
+#[test]
+fn rejects_stale_and_unsafe_migrations_without_changing_state() {
+    let fixture = Fixture::new();
+    fixture.initialize(3);
+    let client = fixture.client();
+
+    assert_eq!(
+        client.try_migrate(&fixture.admin, &2, &4),
+        Err(Ok(ContractError::VersionMismatch))
+    );
+    assert_eq!(
+        client.try_migrate(&fixture.admin, &3, &3),
+        Err(Ok(ContractError::InvalidTargetVersion))
+    );
+    assert_eq!(
+        client.try_migrate(&fixture.admin, &3, &2),
+        Err(Ok(ContractError::InvalidTargetVersion))
+    );
+    assert_eq!(client.current_version(), 3);
+}
+
+#[test]
+fn rejects_an_authenticated_non_admin() {
+    let fixture = Fixture::new();
+    fixture.initialize(1);
+    let stranger = Address::generate(&fixture.env);
+
+    assert_eq!(
+        fixture.client().try_migrate(&stranger, &1, &2),
+        Err(Ok(ContractError::Unauthorized))
+    );
+    assert_eq!(fixture.client().current_version(), 1);
+}
+
+#[test]
+fn regression_margin_is_exactly_five_percent_rounded_up() {
+    assert_eq!(five_percent_ceiling(0), 0);
+    assert_eq!(five_percent_ceiling(1), 2);
+    assert_eq!(five_percent_ceiling(20), 21);
+    assert_eq!(five_percent_ceiling(21), 23);
+    assert_eq!(five_percent_ceiling(100), 105);
+}


### PR DESCRIPTION
Closes #1138

## Summary

- restores the missing `contracts/migrate` workspace crate at the path specified by the issue
- adds an authenticated, monotonic compare-and-set migration flow that rejects stale, duplicate, downgrade, and non-admin attempts without changing state
- snapshots CPU and memory for every public entrypoint after resetting fixture costs
- calculates the CI ceiling as `baseline + ceil(baseline / 20)`, so regressions above 5% fail with measured/baseline/limit diagnostics
- uses typed contract events and semantic errors; no production `unwrap`, unchecked arithmetic, or generic panic paths

## Gas baselines

| Entrypoint | CPU | Memory | 5% CPU limit | 5% memory limit |
| --- | ---: | ---: | ---: | ---: |
| `initialize` | 55,643 | 20,337 | 58,426 | 21,354 |
| `migrate` | 69,405 | 22,409 | 72,876 | 23,530 |
| `admin` | 31,614 | 12,495 | 33,195 | 13,120 |
| `current_version` | 31,370 | 12,495 | 32,939 | 13,120 |

Baselines were measured with the locked Soroban SDK 25.3.1 mock host. Setup is completed before `Budget::reset_unlimited`, keeping each measurement isolated to one entrypoint.

## Validation

- focused gas/security suite: 7 passed, 0 failed, repeated three times with identical measurements
- `cargo clippy -p migrate --all-targets -- -D warnings`
- `rustfmt --edition 2021 --check contracts/migrate/src/lib.rs contracts/migrate/tests/gas_snap.rs`
- `git diff --check`

## Repository baseline note

The untouched root workspace on current `master` cannot load because `contracts/betting/Cargo.toml` declares a library while `contracts/betting/src/lib.rs` is absent. Current `master` also references a removed `contracts/predictify-hybrid/src/versioning.rs`. To avoid bundling unrelated repairs, the new self-contained crate was isolated for focused test and lint runs; this PR does not modify those pre-existing failures.

## API impact

This adds the previously missing standalone migration contract API: `initialize`, `migrate`, `admin`, and `current_version`. State-changing calls require authorization, and successful initialization/migration emits typed `initialized`/`migrated` events.
