### PR TITLE
Fix: Add rustdoc for public entrypoints in markets [b#001] (Auto-Generated)

### DIFF
--- a/contracts/markets/src/lib.rs
+++ b/contracts/markets/src/lib.rs
@@ -7,7 +7,32 @@ pub struct MarketsContract;
 
 #[contractimpl]
 impl MarketsContract {
+    /// Returns the deployed markets contract API version.
+    ///
+    /// This read-only entrypoint exposes the contract version so clients can
+    /// verify that they are communicating with the expected markets contract
+    /// interface before invoking other operations. It returns the compile-time
+    /// version identifier and does not modify contract state.
+    ///
+    /// # Returns
+    ///
+    /// The markets contract version, currently `7`.
+    ///
+    /// # Errors
+    ///
+    /// This function does not emit or return contract errors.
     pub fn version(_env: Env) -> u32 {
         7
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MarketsContract;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn version_returns_current_contract_version() {
+        assert_eq!(MarketsContract::version(Env::default()), 7);
     }
 }


### PR DESCRIPTION
Closes #1091

This PR was generated by the DripTide AI coder and scoped strictly to issue #1091.

### Changes
Added comprehensive rustdoc to the public version entrypoint, documenting its purpose, behavior, return value, and error behavior. Added a focused unit test confirming the current contract version.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #1091` so the Drips Wave bot resolves the issue on merge._