### PR TITLE
Fix: Add ContractError stability test for disputes [b#004] (Auto-Generated)

### DIFF
--- a/contracts/disputes/tests/err_stab.rs
+++ b/contracts/disputes/tests/err_stab.rs
@@ -1,60 +1,62 @@
 //! Stability snapshot for client-facing dispute error codes.
 //!
-//! This test freezes the `#[repr(u32)]` discriminant of every dispute-related
-//! variant in `predictify_hybrid::Error`.  Renumbering, reordering, removing,
-//! or splitting these variants is a **client-facing API breaking change**
-//! and the snapshot below will fail CI to surface it explicitly.
+//! Dispute errors are serialized into contract failures and consumed by client
+//! SDKs, indexers, and frontends. Their numeric discriminants are therefore a
+//! visible API. Renumbering, reordering, removing, or splitting one of these
+//! variants requires an API review and a client migration plan.
 //!
-//! The source of truth for each numeric code is the `Error` enum in
-//! `predictify-hybrid/src/err.rs`.  Values here must match one-for-one.
-//!
-//! ## Coverage
-//!
-//! | Variant name                     | Frozen discriminant |
-//! |----------------------------------|---------------------|
-//! | `AlreadyDisputed`                | 404                 |
-//! | `DisputeVoteExpired`             | 405                 |
-//! | `DisputeVoteDenied`              | 406                 |
-//! | `DisputeAlreadyVoted`            | 407                 |
-//! | `DisputeCondNotMet`              | 408                 |
-//! | `DisputeFeeFailed`               | 409                 |
-//! | `DisputeError`                   | 410                 |
-//! | `DisputerCannotVote`             | 438                 |
-//! | `DisputeStakeCapExceeded`        | 522                 |
-//! | `NoDisputesFound`                | 496                 |
+//! The values below are the frozen GrantFox FWC26 dispute-error snapshot. New
+//! dispute errors must use a previously unused explicit discriminant and be
+//! reviewed into this snapshot deliberately.
+
+use std::collections::BTreeSet;
 
 use predictify_hybrid::Error;
 
-/// Asserts that every dispute-related `Error` variant still maps to its
-/// long-stable client-facing numeric discriminant.
+/// Frozen numeric codes for every dispute-related client-facing error.
 ///
-/// Failures on this test must be treated as API-review required, not as
-/// "fix the test" mechanical changes — downstream clients and event
-/// dashboards match on these codes directly.
+/// The authoritative definitions are in `predictify_hybrid::Error`. Keep this
+/// snapshot synchronized only through an intentional API change review.
+const DISPUTE_ERROR_SNAPSHOT: &[(Error, u32)] = &[
+    (Error::AlreadyDisputed, 404),
+    (Error::DisputeVoteExpired, 405),
+    (Error::DisputeVoteDenied, 406),
+    (Error::DisputeAlreadyVoted, 407),
+    (Error::DisputeCondNotMet, 408),
+    (Error::DisputeFeeFailed, 409),
+    (Error::DisputeError, 410),
+    (Error::DisputerCannotVote, 438),
+    (Error::NoDisputesFound, 496),
+    (Error::DisputeStakeCapExceeded, 522),
+];
+
+/// Asserts that every frozen dispute error retains its client-facing code.
 #[test]
 fn dispute_error_discriminants_stable() {
-    let snapshot: &[(Error, u32)] = &[
-        (Error::AlreadyDisputed, 404),
-        (Error::DisputeVoteExpired, 405),
-        (Error::DisputeVoteDenied, 406),
-        (Error::DisputeAlreadyVoted, 407),
-        (Error::DisputeCondNotMet, 408),
-        (Error::DisputeFeeFailed, 409),
-        (Error::DisputeError, 410),
-        (Error::DisputerCannotVote, 438),
-        (Error::DisputeStakeCapExceeded, 522),
-        (Error::NoDisputesFound, 496),
-    ];
+    assert_eq!(
+        DISPUTE_ERROR_SNAPSHOT.len(),
+        10,
+        "the dispute error snapshot must cover every frozen dispute error"
+    );
 
-    for (err, expected) in snapshot {
+    for &(error, expected) in DISPUTE_ERROR_SNAPSHOT {
         assert_eq!(
-            *err as u32,
-            *expected,
-            "client-facing API break: discriminant for {:?} changed from {} to {}; \
-             downstream clients rely on the stable numeric codes documented above",
-            err,
+            error as u32,
             expected,
-            *err as u32,
+            "client-facing dispute error code changed for {error:?}; this requires an API migration"
+        );
+    }
+}
+
+/// Ensures that no two dispute errors expose the same numeric code.
+#[test]
+fn dispute_error_discriminants_are_unique() {
+    let mut codes = BTreeSet::new();
+
+    for &(error, code) in DISPUTE_ERROR_SNAPSHOT {
+        assert!(
+            codes.insert(code),
+            "client-facing dispute error code {code} is reused by {error:?}"
         );
     }
 }


### PR DESCRIPTION
Closes #1094

This PR was generated by the DripTide AI coder and scoped strictly to issue #1094.

### Changes
Added a focused dispute ContractError stability snapshot covering all ten dispute-related error variants, asserting their frozen numeric discriminants and uniqueness.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #1094` so the Drips Wave bot resolves the issue on merge._