### PR TITLE
fix: Add TTL bump on markets storage reads (#916)

### DIFF
--- a/contracts/markets/src/lib.rs
+++ b/contracts/markets/src/lib.rs
@@ -10,4 +10,15 @@ impl MarketsContract {
     pub fn version(_env: Env) -> u32 {
         7
     }
+
+    /// Read a market from persistent storage and bump its TTL.
+    pub fn get_market(env: Env, market_id: soroban_sdk::Symbol) -> Option<soroban_sdk::Val> {
+        let market: Option<soroban_sdk::Val> = env.storage().persistent().get(&market_id);
+        if market.is_some() {
+            // Bump TTL: 365 days * 17280 ledgers per day = 6307200
+            env.storage().persistent().extend_ttl(&market_id, 6307200, 6307200);
+        }
+        market
+    }
+
 }


### PR DESCRIPTION
**Description:**
This PR adds TTL bumps on hot read paths in the markets contract per the v7 requirements for the GrantFox FWC26 campaign.

**Changes:**
- Implemented `get_market` in `contracts/markets/src/lib.rs` to read market data from persistent storage.
- Added a TTL bump extending persistent storage TTL to 365 days (6,307,200 ledgers) when a market is read to prevent frequently-accessed markets from expiring.

Closes #916
