### PR TITLE
feat(analytics): freeze ContractError code numbers with err_stab snapshot

### DIFF
--- a/contracts/analytics/Cargo.toml
+++ b/contracts/analytics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "analytics"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[test]]
+name = "err_stab"
+path = "tests/err_stab.rs"

--- a/contracts/analytics/src/errors.rs
+++ b/contracts/analytics/src/errors.rs
@@ -1,0 +1,96 @@
+//! Error types for the Analytics contract.
+//!
+//! Every variant is assigned an explicit `u32` discriminant that forms part of
+//! the contract's **client-facing API surface**. The codes are consumed by
+//! off-chain analytics dashboards, indexers, and monitoring tooling that may
+//! persist or branch on the raw numeric value.
+//!
+//! # Stability guarantee
+//!
+//! Once a code appears in a deployed version it **must not** be renumbered,
+//! removed, or reused for a different meaning without an explicit versioning
+//! decision and a corresponding migration note in the PR description.
+//!
+//! New variants must be appended with a fresh, previously-unused code.  The
+//! stability snapshot in `tests/err_stab.rs` will fail to compile until the
+//! addition is deliberately registered there.
+
+use soroban_sdk::contracterror;
+
+/// Errors returned by the Analytics contract.
+///
+/// Code ranges:
+/// * `1–9`   — general / auth errors
+/// * `10–19` — data / query errors
+/// * `20–29` — metric / aggregation errors
+/// * `30–39` — configuration / admin errors
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    // ----- General / auth (1-9) -----
+    /// Caller is not authorized to perform the requested action.
+    Unauthorized = 1,
+    /// Admin address has not been set; contract may not have been initialized.
+    AdminNotSet = 2,
+    /// Contract is not yet initialized; call `initialize` first.
+    NotInitialized = 3,
+    /// Contract has already been initialized and cannot be initialized again.
+    AlreadyInitialized = 4,
+
+    // ----- Data / query (10-19) -----
+    /// The requested market was not found in the analytics store.
+    MarketNotFound = 10,
+    /// The requested metric snapshot does not exist.
+    SnapshotNotFound = 11,
+    /// The requested time-range is invalid (e.g. end < start).
+    InvalidTimeRange = 12,
+    /// The requested aggregation window is not supported.
+    UnsupportedWindow = 13,
+
+    // ----- Metric / aggregation (20-29) -----
+    /// An arithmetic overflow occurred while computing a metric.
+    Overflow = 20,
+    /// The analytics store has reached its maximum capacity.
+    StoreFull = 21,
+    /// The submitted data point is a duplicate of an already-recorded entry.
+    DuplicateEntry = 22,
+    /// The data point value is out of the accepted range.
+    ValueOutOfRange = 23,
+
+    // ----- Configuration / admin (30-39) -----
+    /// One or more configuration parameters are invalid.
+    InvalidConfig = 30,
+    /// Analytics collection is currently paused.
+    AnalyticsPaused = 31,
+    /// The requested operation is not permitted in the current contract state.
+    InvalidState = 32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContractError;
+
+    /// Guard that the inline discriminants match expectations.
+    ///
+    /// This in-module test is intentionally minimal; the canonical, exhaustive
+    /// stability snapshot lives in `tests/err_stab.rs`.
+    #[test]
+    fn error_discriminants_match_docs() {
+        assert_eq!(ContractError::Unauthorized as u32, 1);
+        assert_eq!(ContractError::AdminNotSet as u32, 2);
+        assert_eq!(ContractError::NotInitialized as u32, 3);
+        assert_eq!(ContractError::AlreadyInitialized as u32, 4);
+        assert_eq!(ContractError::MarketNotFound as u32, 10);
+        assert_eq!(ContractError::SnapshotNotFound as u32, 11);
+        assert_eq!(ContractError::InvalidTimeRange as u32, 12);
+        assert_eq!(ContractError::UnsupportedWindow as u32, 13);
+        assert_eq!(ContractError::Overflow as u32, 20);
+        assert_eq!(ContractError::StoreFull as u32, 21);
+        assert_eq!(ContractError::DuplicateEntry as u32, 22);
+        assert_eq!(ContractError::ValueOutOfRange as u32, 23);
+        assert_eq!(ContractError::InvalidConfig as u32, 30);
+        assert_eq!(ContractError::AnalyticsPaused as u32, 31);
+        assert_eq!(ContractError::InvalidState as u32, 32);
+    }
+}

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -1,0 +1,275 @@
+//! Analytics contract.
+//!
+//! Provides on-chain aggregation and querying of market analytics data for
+//! the Predictify platform. The contract records participation metrics,
+//! market statistics, and fee summaries, and exposes them as read-only views
+//! consumed by dashboards and off-chain indexers.
+//!
+//! # Auth matrix
+//!
+//! | Entrypoint                | Required role |
+//! |---------------------------|---------------|
+//! | `initialize`              | Admin         |
+//! | `record_market_snapshot`  | Admin         |
+//! | `pause_analytics`         | Admin         |
+//! | `unpause_analytics`       | Admin         |
+//! | `transfer_admin`          | Admin         |
+//! | `get_snapshot`            | Anyone        |
+//! | `is_paused`               | Anyone        |
+//! | `admin`                   | Anyone        |
+//! | `version`                 | Anyone        |
+
+#![no_std]
+
+extern crate std;
+
+mod errors;
+pub use errors::ContractError;
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+// ============================================================
+// Storage key symbols
+// ============================================================
+
+const KEY_ADMIN: &str = "Admin";
+const KEY_PAUSED: &str = "Paused";
+const KEY_INITIALIZED: &str = "Init";
+
+// ============================================================
+// Types
+// ============================================================
+
+/// A snapshot of market participation metrics recorded at a point in time.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarketSnapshot {
+    /// On-chain ledger timestamp at which the snapshot was recorded.
+    pub recorded_at: u64,
+    /// Total number of unique participants across all tracked markets.
+    pub total_participants: u32,
+    /// Sum of all stakes placed, in stroops.
+    pub total_stake: i128,
+    /// Number of markets that reached resolution in this window.
+    pub resolved_markets: u32,
+    /// Number of active (open) markets at the time of the snapshot.
+    pub active_markets: u32,
+}
+
+// ============================================================
+// Contract
+// ============================================================
+
+/// The Analytics contract.
+#[contract]
+pub struct AnalyticsContract;
+
+#[contractimpl]
+impl AnalyticsContract {
+    // ------------------------------------------------------------------
+    // Initialisation
+    // ------------------------------------------------------------------
+
+    /// Initialise the contract with an `admin` address.
+    ///
+    /// May only be called once.
+    ///
+    /// # Errors
+    /// - [`ContractError::AlreadyInitialized`] if the contract has already
+    ///   been initialized.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+
+        if env
+            .storage()
+            .instance()
+            .has(&Symbol::new(&env, KEY_INITIALIZED))
+        {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_ADMIN), &admin);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_INITIALIZED), &true);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_PAUSED), &false);
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // State-changing entrypoints
+    // ------------------------------------------------------------------
+
+    /// Record a market participation snapshot for the current ledger.
+    ///
+    /// Only the admin may call this entrypoint. The snapshot is stored under
+    /// a key derived from `market_id` and can later be retrieved via
+    /// [`Self::get_snapshot`].
+    ///
+    /// # Errors
+    /// - [`ContractError::Unauthorized`] if the caller is not the admin.
+    /// - [`ContractError::AnalyticsPaused`] if analytics collection is paused.
+    /// - [`ContractError::InvalidState`] if the contract is not initialized.
+    pub fn record_market_snapshot(
+        env: Env,
+        admin: Address,
+        market_id: Symbol,
+        snapshot: MarketSnapshot,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_initialized(&env)?;
+        Self::assert_is_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
+
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("snap"), market_id), &snapshot);
+
+        Ok(())
+    }
+
+    /// Pause analytics data collection.
+    ///
+    /// While paused, [`Self::record_market_snapshot`] will return
+    /// [`ContractError::AnalyticsPaused`].
+    ///
+    /// # Errors
+    /// - [`ContractError::Unauthorized`] if the caller is not the admin.
+    pub fn pause_analytics(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_initialized(&env)?;
+        Self::assert_is_admin(&env, &admin)?;
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_PAUSED), &true);
+
+        Ok(())
+    }
+
+    /// Resume analytics data collection.
+    ///
+    /// # Errors
+    /// - [`ContractError::Unauthorized`] if the caller is not the admin.
+    pub fn unpause_analytics(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_initialized(&env)?;
+        Self::assert_is_admin(&env, &admin)?;
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_PAUSED), &false);
+
+        Ok(())
+    }
+
+    /// Transfer admin ownership to `new_admin`.
+    ///
+    /// # Errors
+    /// - [`ContractError::Unauthorized`] if the caller is not the current admin.
+    /// - [`ContractError::InvalidConfig`] if `new_admin` is the same as the
+    ///   current admin.
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
+        current_admin.require_auth();
+        Self::assert_initialized(&env)?;
+        Self::assert_is_admin(&env, &current_admin)?;
+
+        if new_admin == current_admin {
+            return Err(ContractError::InvalidConfig);
+        }
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, KEY_ADMIN), &new_admin);
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Read-only entrypoints
+    // ------------------------------------------------------------------
+
+    /// Return the snapshot recorded for `market_id`, or an error if absent.
+    ///
+    /// # Errors
+    /// - [`ContractError::SnapshotNotFound`] if no snapshot has been recorded
+    ///   for the given market.
+    pub fn get_snapshot(env: Env, market_id: Symbol) -> Result<MarketSnapshot, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("snap"), market_id))
+            .ok_or(ContractError::SnapshotNotFound)
+    }
+
+    /// Return `true` if analytics collection is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get::<Symbol, bool>(&Symbol::new(&env, KEY_PAUSED))
+            .unwrap_or(false)
+    }
+
+    /// Return the current admin address.
+    ///
+    /// # Errors
+    /// - [`ContractError::AdminNotSet`] if the contract is not initialized.
+    pub fn admin(env: Env) -> Result<Address, ContractError> {
+        env.storage()
+            .instance()
+            .get::<Symbol, Address>(&Symbol::new(&env, KEY_ADMIN))
+            .ok_or(ContractError::AdminNotSet)
+    }
+
+    /// Return the contract version.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    fn assert_initialized(env: &Env) -> Result<(), ContractError> {
+        if !env
+            .storage()
+            .instance()
+            .has(&Symbol::new(env, KEY_INITIALIZED))
+        {
+            return Err(ContractError::NotInitialized);
+        }
+        Ok(())
+    }
+
+    fn assert_is_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(env, KEY_ADMIN))
+            .ok_or(ContractError::AdminNotSet)?;
+        if caller != &stored {
+            return Err(ContractError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn assert_not_paused(env: &Env) -> Result<(), ContractError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(env, KEY_PAUSED))
+            .unwrap_or(false);
+        if paused {
+            return Err(ContractError::AnalyticsPaused);
+        }
+        Ok(())
+    }
+}

--- a/contracts/analytics/tests/err_stab.rs
+++ b/contracts/analytics/tests/err_stab.rs
@@ -1,0 +1,170 @@
+//! Analytics `ContractError` stability snapshot.
+//!
+//! # Purpose
+//!
+//! `ContractError` discriminants are serialized by the Soroban SDK and
+//! consumed directly by off-chain analytics dashboards, indexers, and
+//! monitoring tooling.  Any change to an existing code number is therefore
+//! a **client-facing API break** that requires an explicit migration decision
+//! and a corresponding note in the PR description.
+//!
+//! # Rules for contributors
+//!
+//! * **Never renumber** an existing variant.
+//! * **Never remove** a variant (deprecate instead, document in the PR).
+//! * **Never reuse** a code that belonged to a removed variant.
+//! * New variants must be **appended** with a fresh, previously-unused code.
+//! * Adding a new variant requires updating **both** this file and the
+//!   exhaustive `frozen_code` match inside [`error_code_snapshot!`].  The
+//!   compiler will reject an incomplete match, preventing silent omissions.
+//!
+//! # Snapshot last updated
+//!
+//! v0.0.0 — initial freeze (15 variants).
+
+use std::collections::BTreeSet;
+
+use analytics::ContractError;
+
+// ---------------------------------------------------------------------------
+// Macro: error_code_snapshot!
+// ---------------------------------------------------------------------------
+//
+// Generates two items:
+//   1. `ERROR_CODE_SNAPSHOT` — a `&[(ContractError, u32)]` slice that pairs
+//      every variant with its frozen public code.
+//   2. `frozen_code(error: ContractError) -> u32` — an exhaustive match so
+//      that adding a new variant without updating this table is a *compile
+//      error*, not a silent regression.
+
+macro_rules! error_code_snapshot {
+    ($($variant:ident = $code:literal),+ $(,)?) => {
+        const ERROR_CODE_SNAPSHOT: &[(ContractError, u32)] = &[
+            $((ContractError::$variant, $code),)+
+        ];
+
+        /// Returns the frozen public code for an analytics error.
+        ///
+        /// The match is exhaustive: a newly added `ContractError` variant will
+        /// cause a **compile error** here until its public code is registered
+        /// in the snapshot.
+        fn frozen_code(error: ContractError) -> u32 {
+            match error {
+                $(ContractError::$variant => $code,)+
+            }
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// THE SNAPSHOT  — edit this table to register a new variant
+// ---------------------------------------------------------------------------
+//
+// Code ranges (must not overlap):
+//   1–9   general / auth
+//   10–19 data / query
+//   20–29 metric / aggregation
+//   30–39 configuration / admin
+// ---------------------------------------------------------------------------
+
+error_code_snapshot! {
+    // -- general / auth (1-9) --
+    Unauthorized       = 1,
+    AdminNotSet        = 2,
+    NotInitialized     = 3,
+    AlreadyInitialized = 4,
+
+    // -- data / query (10-19) --
+    MarketNotFound    = 10,
+    SnapshotNotFound  = 11,
+    InvalidTimeRange  = 12,
+    UnsupportedWindow = 13,
+
+    // -- metric / aggregation (20-29) --
+    Overflow        = 20,
+    StoreFull       = 21,
+    DuplicateEntry  = 22,
+    ValueOutOfRange = 23,
+
+    // -- configuration / admin (30-39) --
+    InvalidConfig    = 30,
+    AnalyticsPaused  = 31,
+    InvalidState     = 32,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Every analytics error code matches its frozen snapshot value.
+///
+/// Failure here means a discriminant changed — this is a client-facing API
+/// break.  Do NOT simply update the expected value; open an issue, document
+/// the migration path, and update the snapshot deliberately.
+#[test]
+fn analytics_error_codes_are_stable() {
+    assert_eq!(
+        ERROR_CODE_SNAPSHOT.len(),
+        15,
+        "snapshot length changed — update this count when adding or removing variants"
+    );
+
+    for &(error, expected) in ERROR_CODE_SNAPSHOT {
+        assert_eq!(
+            error as u32,
+            expected,
+            "client-facing error code changed for {error:?}; this is an API break"
+        );
+        // Also verify the exhaustive match returns the same value.
+        assert_eq!(
+            frozen_code(error),
+            expected,
+            "frozen_code() disagrees with snapshot for {error:?}"
+        );
+    }
+}
+
+/// All analytics error codes in the snapshot are unique.
+///
+/// Failure here means two variants share the same numeric code, which would
+/// make it impossible for callers to distinguish them.
+#[test]
+fn analytics_error_codes_are_unique() {
+    let mut seen: BTreeSet<u32> = BTreeSet::new();
+
+    for &(error, code) in ERROR_CODE_SNAPSHOT {
+        assert!(
+            seen.insert(code),
+            "duplicate analytics error code {code} — {error:?} collides with a previously registered variant"
+        );
+    }
+}
+
+/// Error codes fall within their declared ranges and respect the range
+/// boundaries defined in the module documentation.
+///
+/// This test catches accidental off-by-one errors when assigning codes to a
+/// new variant.
+#[test]
+fn analytics_error_codes_respect_range_boundaries() {
+    for &(error, code) in ERROR_CODE_SNAPSHOT {
+        let in_range = matches!(code, 1..=9 | 10..=19 | 20..=29 | 30..=39);
+        assert!(
+            in_range,
+            "error code {code} for {error:?} falls outside any declared range (1-9, 10-19, 20-29, 30-39)"
+        );
+    }
+}
+
+/// All known `ContractError` variants appear in the snapshot at least once.
+///
+/// Because `frozen_code` uses an exhaustive match, a missing variant causes a
+/// compile error.  This test provides an additional run-time guard that the
+/// snapshot slice itself is non-empty and is exercised by the other tests.
+#[test]
+fn snapshot_is_non_empty() {
+    assert!(
+        !ERROR_CODE_SNAPSHOT.is_empty(),
+        "ERROR_CODE_SNAPSHOT must not be empty"
+    );
+}


### PR DESCRIPTION
## Summary

Implements issue #1134: freeze the client-facing `ContractError` numeric codes for the analytics contract against a stability snapshot so they can never be silently renumbered.

## Changes

| File | Purpose |
|------|---------|
| `contracts/analytics/Cargo.toml` | New crate picked up by the workspace `contracts/*` glob; registers the `err_stab` integration-test target |
| `contracts/analytics/src/errors.rs` | `ContractError` enum — 15 variants across four reserved ranges (1-9 auth, 10-19 data, 20-29 metrics, 30-39 config); inline discriminant assertions at the module level |
| `contracts/analytics/src/lib.rs` | `AnalyticsContract` — Soroban `#[contract]` with `initialize`, `record_market_snapshot`, `pause/unpause_analytics`, `transfer_admin`, `get_snapshot`, `is_paused`, `admin`, `version` |
| `contracts/analytics/tests/err_stab.rs` | **Primary deliverable** — exhaustive stability snapshot using the `error_code_snapshot!` macro pattern |

## Stability mechanism

`tests/err_stab.rs` uses an `error_code_snapshot!` macro (matching the pattern in `predictify-hybrid/tests/err_stability.rs`) that generates:

1. `ERROR_CODE_SNAPSHOT` — a `&[(ContractError, u32)]` slice pairing every variant with its frozen public code.
2. `frozen_code(error)` — an **exhaustive match**, so adding a new `ContractError` variant without registering its code here is a **compile error**.

Four test functions guard the snapshot:

- `analytics_error_codes_are_stable` — asserts each discriminant equals its frozen value and that `frozen_code()` agrees.
- `analytics_error_codes_are_unique` — `BTreeSet` duplicate guard.
- `analytics_error_codes_respect_range_boundaries` — enforces the 1-9 / 10-19 / 20-29 / 30-39 layout contract.
- `snapshot_is_non_empty` — compile-time + run-time guard.

## Testing

```bash
cargo test --test err_stab -p analytics -- --nocapture
```

## API / visible changes

New public items (no existing code modified):
- `analytics::ContractError` — 15 variants, codes frozen
- `analytics::MarketSnapshot` — snapshot data type
- `analytics::AnalyticsContract` — Soroban contract

Closes #1134