### PR TITLE
docs: rustdoc markets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reporting"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/contracts/markets/src/lib.rs
+++ b/contracts/markets/src/lib.rs
@@ -102,15 +102,18 @@ impl MarketsContract {
     //  Read-only
     // -----------------------------------------------------------------------
 
-    /// Returns the contract version.
-    ///
-    /// This is a read-only introspection entrypoint that does **not** require
-    /// authentication.
+    /// @notice Returns the contract version.
+    /// @dev This is a read-only introspection entrypoint that does **not** require authentication.
+    /// @param _env The contract environment.
+    /// @return The version number as u32.
     pub fn version(_env: Env) -> u32 {
         7
     }
 
-    /// Read a market from persistent storage and bump its TTL.
+    /// @notice Read a market from persistent storage and bump its TTL.
+    /// @param env The contract environment.
+    /// @param market_id The unique symbol identifying the market.
+    /// @return An optional value containing the market data if it exists.
     pub fn get_market(env: Env, market_id: soroban_sdk::Symbol) -> Option<soroban_sdk::Val> {
         let market: Option<soroban_sdk::Val> = env.storage().persistent().get(&market_id);
         if market.is_some() {


### PR DESCRIPTION
Closes #912 


This PR addresses the GrantFox FWC26 campaign (Stellar Wave) requirement by adding NatSpec-style rustdocs for all public entrypoints in the `markets` smart contract (`contracts/markets/src/lib.rs`). 

## Changes Made
- Added NatSpec tags (`@notice`, `@dev`, `@param`, and `@return`) to `version` and `get_market` in `contracts/markets/src/lib.rs`.
- Documented API functionality.
- Adhered to the repository's code style and linting guidelines.