### PR TITLE
test: markets proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
 name = "markets"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1206,7 +1207,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reporting"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/contracts/markets/Cargo.toml
+++ b/contracts/markets/Cargo.toml
@@ -13,3 +13,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1.2.0"

--- a/contracts/markets/tests/proptest.rs
+++ b/contracts/markets/tests/proptest.rs
@@ -1,0 +1,73 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{contract, contractimpl, testutils::{Address as _, Ledger}, Address, Env, Symbol};
+use markets::admin::AdminManager;
+use markets::errors::ContractError;
+
+#[contract]
+pub struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {
+    pub fn set_cd(env: Env, admin: Address, secs: u64) -> Result<(), ContractError> {
+        AdminManager::set_admin_cooldown(&env, &admin, secs)
+    }
+    
+    pub fn get_cd(env: Env) -> u64 {
+        AdminManager::get_admin_cooldown(&env)
+    }
+    
+    pub fn check_cd(env: Env, admin: Address, func: Symbol) -> Result<(), ContractError> {
+        AdminManager::check_admin_cooldown(&env, &admin, &func)
+    }
+}
+
+proptest! {
+    #[test]
+    fn test_admin_cooldown_invariants(
+        cooldown in 1u64..1_000_000_000,
+        initial_timestamp in 100u64..1_000_000_000_000,
+        time_advance in 0u64..2_000_000_000
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(DummyContract, ());
+        let client = DummyContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let func_name = Symbol::new(&env, "action");
+        
+        // Initial cooldown should be 0
+        prop_assert_eq!(client.get_cd(), 0);
+        
+        // Set cooldown
+        client.set_cd(&admin, &cooldown);
+        prop_assert_eq!(client.get_cd(), cooldown);
+        
+        // Set initial timestamp
+        env.ledger().with_mut(|l| {
+            l.timestamp = initial_timestamp;
+        });
+        
+        // First action should succeed
+        let res = client.try_check_cd(&admin, &func_name);
+        prop_assert!(res.is_ok());
+        
+        // Advance time
+        env.ledger().with_mut(|l| {
+            l.timestamp = initial_timestamp.saturating_add(time_advance);
+        });
+        
+        // Second action
+        let res2 = client.try_check_cd(&admin, &func_name);
+        
+        if time_advance < cooldown {
+            // Should fail due to cooldown
+            prop_assert_eq!(res2.unwrap_err().unwrap(), ContractError::AdminActionTimelocked);
+        } else {
+            // Should succeed
+            prop_assert!(res2.is_ok());
+        }
+    }
+}


### PR DESCRIPTION
Closes #913 

This is a smart-contract issue for the GrantFox FWC26 campaign (Stellar Wave). Property test for markets state invariants.

### Requirements and Context
- Add invariant proptest for markets (v7).
- Implement focused property tests for state invariants.
- Adhere to repo's lint and code style.
- Secure, tested, and documented.
- Efficient and easy to review.
- Minimum 95% test coverage.
- Overflow-safe math; no `unwrap()` in production paths.

### Changes Included
- Added `proptest = "1.2.0"` to the `[dev-dependencies]` in `contracts/markets/Cargo.toml`.
- Implemented `contracts/markets/tests/proptest.rs` to enforce the `AdminManager` cooldown logic with various generated parameters (timestamp, cooldown length, time advancement).