### PR TITLE
docs(recovery): add storage-tier documentation with tier, TTL, and rationale

### DIFF
--- a/contracts/predictify-hybrid/docs/storage.md
+++ b/contracts/predictify-hybrid/docs/storage.md
@@ -1,0 +1,68 @@
+# Recovery Module — Storage Keys
+
+## Overview
+
+All recovery storage keys use the **Persistent** tier. The recovery
+module does not use Instance or Temporary storage; every key must outlive
+individual contract calls and survive across ledger upgrades.
+
+---
+
+## Admin Key (shared)
+
+| Key | Type | Tier | TTL | Rationale |
+|-----|------|------|-----|-----------|
+| `Symbol("Admin")` | `Address` | Persistent | `MARKET_TTL_LEDGERS` | Single admin address governs all privileged recovery actions. Must persist across contract upgrades and be readable in every call. |
+
+---
+
+## Per-Market Recovery Timelock
+
+| Key | Type | Tier | TTL | Rationale |
+|-----|------|------|-----|-----------|
+| `Symbol("rcv_pending")` | `Map<Symbol, PendingMarketRecovery>` | Persistent | `RECOVERY_TTL_LEDGERS` | Tracks pending recovery requests per market while they await timelock expiry. Must survive between the `initiate` and `execute` calls (up to 7 days). |
+| `Symbol("rcv_timelock_cfg")` | `RecoveryTimelockConfig` | Persistent | `RECOVERY_TTL_LEDGERS` | Stores the global timelock delay for recoveries. Read on every recovery flow so the value must always be available. |
+
+---
+
+## Recovery Records & History
+
+| Key | Type | Tier | TTL | Rationale |
+|-----|------|------|-----|-----------|
+| `Symbol("recovery_records")` | `Map<Symbol, MarketRecovery>` | Persistent | `RECOVERY_TTL_LEDGERS` | Active (unresolved) recovery records per market. Split from history during the v2 migration so that queries for current state are cheap. |
+| `Symbol("recovery_status_map")` | `Map<Symbol, String>` | Persistent | `RECOVERY_TTL_LEDGERS` | Quick-lookup status endpoint (`"pending"` / `"recovered"`) without deserialising the full `MarketRecovery` struct. |
+| `Symbol("recovery_v2_migrated")` | `bool` | Persistent | `RECOVERY_TTL_LEDGERS` | One-shot migration flag. After the first read that triggers `ensure_migrated()` the legacy map is split and this flag is set to `true` to skip re-migration on every subsequent call. |
+| `(Symbol("rcv_hist"), Symbol)` | `Vec<RecoveryHistoryEntry>` | Persistent | `RECOVERY_TTL_LEDGERS` | Per-market completed recovery history, capped at `MAX_RECOVERY_HISTORY_PER_MARKET` (10) entries. Stored separately from active records so that appending history never interferes with the active-map write. |
+| `Symbol("recovery_history")` | `Map<Symbol, Vec<RecoveryHistoryEntry>>` | Persistent | `RECOVERY_TTL_LEDGERS` | **Legacy — migration-only.** Holds the combined active-and-completed history before the v2 migration splits it into `recovery_records` (active) and `rcv_hist` (completed). After migration this key is removed and no longer written. Documented for completeness; existing entries from before the upgrade are migrated on first read. |
+
+---
+
+## Unclaimed Winnings Claim Periods
+
+| Key | Type | Tier | TTL | Rationale |
+|-----|------|------|-----|-----------|
+| `Symbol("claim_period_global")` | `u64` | Persistent | `RECOVERY_TTL_LEDGERS` | Default claim window in seconds (fallback when no per-market override is set). Must outlive individual markets because it applies to all future markets. |
+| `Symbol("claim_period_market")` | `Map<Symbol, u64>` | Persistent | `RECOVERY_TTL_LEDGERS` | Per-market claim-period overrides. Markets with a custom claim window get an entry here. |
+| `Symbol("claim_window_start")` | `Map<Symbol, u64>` | Persistent | `RECOVERY_TTL_LEDGERS` | Records when each market's claim window started (set once on first resolution). Needed to compute the deadline: `start + effective_claim_period`. |
+| `Symbol("treasury_addr")` | `Address` | Persistent | `RECOVERY_TTL_LEDGERS` | Treasury address where swept unclaimed winnings are deposited. Rarely written but must be available on every sweep call. |
+
+---
+
+## TTL Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `RECOVERY_TTL_LEDGERS` | 365 × 17 280 ≈ 1 year | Maximum TTL assigned to every recovery persistent key. |
+| `RECOVERY_LIFETIME_THRESHOLD` | 31 × 17 280 ≈ 31 days | Minimum remaining ledgers before a hot read bumps the key back to `RECOVERY_TTL_LEDGERS`. |
+
+All recovery keys are extended (TTL-bumped) on every hot read path via
+`RecoveryStorage::bump_recovery_ttl`, ensuring they stay alive as long
+as the contract is actively used.
+
+---
+
+## API Impact
+
+This documentation describes storage internals only. It does not change
+the contract's public API. All storage keys are internal implementation
+details of the recovery module.

--- a/contracts/predictify-hybrid/tests/storage_docs.rs
+++ b/contracts/predictify-hybrid/tests/storage_docs.rs
@@ -1,0 +1,111 @@
+const STORAGE_DOCUMENTATION: &str = include_str!("../docs/storage.md");
+
+#[test]
+fn storage_documentation_covers_all_storage_tiers_and_recovery_keys() {
+    for required_section in ["Instance", "Persistent", "Temporary"] {
+        assert!(
+            STORAGE_DOCUMENTATION.contains(required_section),
+            "storage documentation must describe the {required_section} tier"
+        );
+    }
+
+    // Verify recovery-specific storage keys are documented.
+    assert!(
+        STORAGE_DOCUMENTATION.contains("recovery_records"),
+        "storage documentation must identify the recovery_records key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("rcv_pending"),
+        "storage documentation must identify the rcv_pending key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("rcv_timelock_cfg"),
+        "storage documentation must identify the rcv_timelock_cfg key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("recovery_status_map"),
+        "storage documentation must identify the recovery_status_map key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("recovery_v2_migrated"),
+        "storage documentation must identify the recovery_v2_migrated key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("rcv_hist"),
+        "storage documentation must identify the rcv_hist key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("recovery_history"),
+        "storage documentation must identify the recovery_history legacy key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("claim_period_global"),
+        "storage documentation must identify the claim_period_global key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("claim_period_market"),
+        "storage documentation must identify the claim_period_market key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("claim_window_start"),
+        "storage documentation must identify the claim_window_start key"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("treasury_addr"),
+        "storage documentation must identify the treasury_addr key"
+    );
+
+    // Verify value types are documented.
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Address"),
+        "storage documentation must describe the Address value type"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Map<Symbol, PendingMarketRecovery>"),
+        "storage documentation must describe the PendingMarketRecovery map type"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Map<Symbol, String>"),
+        "storage documentation must describe the status map type"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Map<Symbol, u64>"),
+        "storage documentation must describe the claim period map types"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("MarketRecovery"),
+        "storage documentation must reference the MarketRecovery struct"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Vec<RecoveryHistoryEntry>"),
+        "storage documentation must describe the recovery history value type"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("Map<Symbol, Vec<RecoveryHistoryEntry>>"),
+        "storage documentation must describe the legacy recovery_history map type"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("PendingMarketRecovery"),
+        "storage documentation must reference the PendingMarketRecovery struct"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("RecoveryTimelockConfig"),
+        "storage documentation must reference the RecoveryTimelockConfig struct"
+    );
+
+    // Verify TTL constants are documented.
+    assert!(
+        STORAGE_DOCUMENTATION.contains("RECOVERY_TTL_LEDGERS"),
+        "storage documentation must describe the recovery TTL constant"
+    );
+    assert!(
+        STORAGE_DOCUMENTATION.contains("RECOVERY_LIFETIME_THRESHOLD"),
+        "storage documentation must describe the recovery lifetime threshold"
+    );
+
+    // Verify API impact statement.
+    assert!(
+        STORAGE_DOCUMENTATION.contains("does not change the contract's public API"),
+        "storage documentation must state the API impact"
+    );
+}


### PR DESCRIPTION
## Description

Documents all 12 recovery module storage keys used by `contracts/predictify-hybrid/src/recovery.rs` with explicit storage tier, TTL values, and design rationale per key.

The recovery module (within `predictify-hybrid`) manages per-market recovery timelocks, recovery records & history, unclaimed winnings claim periods, and shared admin state. Every key uses the **Persistent** tier — no Instance or Temporary keys exist in this module.

## Changes

### `contracts/predictify-hybrid/docs/storage.md`
- Full documentation of all 12 recovery storage keys organized into 4 logical groups:
  - **Admin Key** — shared `Admin` address key
  - **Per-Market Recovery Timelock** — `rcv_pending`, `rcv_timelock_cfg`
  - **Recovery Records & History** — `recovery_records`, `recovery_status_map`, `recovery_v2_migrated`, `rcv_hist`, `recovery_history`
  - **Unclaimed Winnings Claim Periods** — `claim_period_global`, `claim_period_market`, `claim_window_start`, `treasury_addr`
- Each key documents: XDR key name, Rust type, storage tier (Persistent), TTL constant, and design rationale
- Added the legacy `recovery_history` key — a migration-only key used in `ensure_migrated()` that was previously undocumented
- Documents TTL constants: `RECOVERY_TTL_LEDGERS` (~1 year) and `RECOVERY_LIFETIME_THRESHOLD` (~31 days)
- API impact statement noting no public API changes

### `contracts/predictify-hybrid/tests/storage_docs.rs`
- Added assertion verifying the `recovery_history` legacy key appears in the docs
- Added assertion verifying the `Map<Symbol, Vec<RecoveryHistoryEntry>>` type is documented

The test verifies:
- All three Soroban storage tiers are mentioned (Instance, Persistent, Temporary)
- Every storage key name is present
- Every Rust value type is documented
- TTL constants are documented
- API impact statement is present

## Rationale

The recovery module uses only Persistent storage because every key must outlive individual contract calls and survive across ledger upgrades:
- Timelock configs must be available between `initiate` and `execute` calls (up to 7 days)
- Recovery records track active (unresolved) recoveries that can span multiple ledger entries
- History entries accumulate per-market and must be queryable long after recovery completes
- Claim period configs apply to all future markets, not just the current contract invocation

## Verification

- [ ] All documentation aligns with actual storage keys in `contracts/predictify-hybrid/src/recovery.rs`
- [ ] The existing `storage_documentation_covers_all_storage_tiers_and_recovery_keys` test passes with the new assertions
- [ ] No API changes — storage keys remain internal implementation details
- [ ] No lint warnings or formatting issues

Closes #1125