### PR TITLE
feat(migrate): add error migration script sketch with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "allowlist"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1213,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reporting"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/contracts/migrate/Cargo.toml
+++ b/contracts/migrate/Cargo.toml
@@ -17,3 +17,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 [[test]]
 name = "gas_snap"
 path = "tests/gas_snap.rs"
+
+[[test]]
+name = "err_migrate"
+path = "tests/err_migrate.rs"

--- a/contracts/migrate/src/lib.rs
+++ b/contracts/migrate/src/lib.rs
@@ -7,13 +7,15 @@
 //! this compare-and-set rule prevents stale operators from overwriting a
 //! newer migration.
 
+mod migrate;
+
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Env,
 };
 
 #[contracttype]
 #[derive(Clone)]
-enum DataKey {
+pub enum DataKey {
     Admin,
     Version,
 }
@@ -141,6 +143,25 @@ impl MigrateContract {
             .instance()
             .get(&DataKey::Admin)
             .ok_or(ContractError::NotInitialized)
+    }
+
+    /// Migrate error-related state from one version to the next.
+    ///
+    /// This entrypoint delegates to [`migrate::migrate_error_state`] and
+    /// provides the same pre-condition guarantees — version compare-and-set,
+    /// admin authentication, and an extensible data-reshape hook.
+    ///
+    /// # Errors
+    ///
+    /// See [`migrate::migrate_error_state`].
+    pub fn migrate_error_data(
+        env: Env,
+        admin: Address,
+        expected_version: u32,
+        target_version: u32,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        migrate::migrate_error_state(&env, &admin, expected_version, target_version)
     }
 
     fn load_version(env: &Env) -> Result<u32, ContractError> {

--- a/contracts/migrate/src/migrate.rs
+++ b/contracts/migrate/src/migrate.rs
@@ -1,0 +1,100 @@
+//! Migration script for error types across the Predictify contract ecosystem.
+//!
+//! This module provides a sketch for migrating error data between contract
+//! versions. It is intended to be extended as the error surface of each
+//! contract evolves.
+//!
+//! # Overview
+//!
+//! During a version migration, it may be necessary to re-map or re-encode
+//! stored error-related state (discriminants, error counts, etc.). This module
+//! defines the scaffolding for such a migration—a single entrypoint that
+//! a data-upgrade script can invoke to reshape error data while preserving
+//! backward compatibility.
+//!
+//! # Usage
+//!
+//! Call `migrate_error_state(...)` during a contract upgrade, passing the
+//! previous and target version numbers. The function checks that the stored
+//! version matches `expected_version`, applies the error-data reshape, and
+//! bumps the stored version to `target_version`.
+
+use soroban_sdk::{Address, Env};
+
+use crate::{ContractError, DataKey};
+
+/// Migrate error-related state from one version to the next.
+///
+/// # Arguments
+///
+/// * `env`        - Contract environment.
+/// * `admin`      - Authenticated administrator.
+/// * `expected`   - The version we expect to find stored. Must equal the
+///                  current contract version.
+/// * `target`     - The version to upgrade to. Must be strictly greater than
+///                  `expected`.
+///
+/// # Errors
+///
+/// * [`ContractError::NotInitialized`] if the contract has not been
+///   initialized.
+/// * [`ContractError::Unauthorized`] if `admin` does not match the stored
+///   administrator.
+/// * [`ContractError::VersionMismatch`] if `expected` != stored version.
+/// * [`ContractError::InvalidTargetVersion`] if `target` <= stored version.
+///
+/// # Notes
+///
+/// The current implementation is a no-op for the data-reshape itself —
+/// it validates version pre-conditions and delegates the actual migration
+/// work to a future `reshape_errors` hook.
+pub fn migrate_error_state(
+    env: &Env,
+    admin: &Address,
+    expected: u32,
+    target: u32,
+) -> Result<(), ContractError> {
+    // --- Guard: contract must be initialised ---
+    if !env.storage().instance().has(&DataKey::Admin) {
+        return Err(ContractError::NotInitialized);
+    }
+
+    // --- Guard: caller must match stored admin ---
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::NotInitialized)?;
+    if admin != &stored_admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    // --- Guard: version compare-and-set ---
+    let current: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::Version)
+        .ok_or(ContractError::NotInitialized)?;
+    if expected != current {
+        return Err(ContractError::VersionMismatch);
+    }
+    if target <= current {
+        return Err(ContractError::InvalidTargetVersion);
+    }
+
+    // --- Data reshape (to be extended per-version) ---
+    reshape_errors(env, current, target);
+
+    // --- Bump version ---
+    env.storage().instance().set(&DataKey::Version, &target);
+
+    Ok(())
+}
+
+/// Apply error-data transforms between two versions.
+///
+/// Each version pair that introduces an error-structure change should add a
+/// match arm here. The default arm is a no-op.
+fn reshape_errors(_env: &Env, from: u32, to: u32) {
+    let _ = (from, to);
+}

--- a/contracts/migrate/tests/err_migrate.rs
+++ b/contracts/migrate/tests/err_migrate.rs
@@ -1,0 +1,175 @@
+#![cfg(test)]
+
+//! Tests for the error migration script sketch.
+//!
+//! Validates that `migrate_error_data` correctly guards preconditions,
+//! applies version bumps, and rejects invalid inputs.
+
+use migrate::{ContractError, MigrateContract, MigrateContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+/// Deploy and initialise a fresh migrate contract.
+struct Fixture {
+    env: Env,
+    client: MigrateContractClient<'static>,
+    admin: Address,
+}
+
+impl Fixture {
+    fn new(initial_version: u32) -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(MigrateContract, ());
+        let admin = Address::generate(&env);
+        let client = MigrateContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &initial_version);
+        Self {
+            env,
+            client,
+            admin,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn successful_migration_bumps_version() {
+    let f = Fixture::new(1);
+
+    let result = f.client.try_migrate_error_data(&f.admin, &1, &2);
+    assert_eq!(result, Ok(Ok(())), "migration from 1→2 should succeed");
+
+    assert_eq!(
+        f.client.current_version(),
+        2,
+        "stored version must be 2 after migration"
+    );
+}
+
+#[test]
+fn migration_can_skip_multiple_versions() {
+    let f = Fixture::new(1);
+
+    assert_eq!(f.client.try_migrate_error_data(&f.admin, &1, &5), Ok(Ok(())));
+    assert_eq!(f.client.current_version(), 5);
+}
+
+#[test]
+fn migrate_from_non_default_start() {
+    let f = Fixture::new(10);
+
+    assert_eq!(f.client.try_migrate_error_data(&f.admin, &10, &11), Ok(Ok(())));
+    assert_eq!(f.client.current_version(), 11);
+}
+
+// ---------------------------------------------------------------------------
+// Guard: version compare-and-set
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rejects_expected_version_mismatch() {
+    let f = Fixture::new(3);
+
+    assert_eq!(
+        f.client.try_migrate_error_data(&f.admin, &2, &4),
+        Err(Ok(ContractError::VersionMismatch)),
+        "should reject expected=2 when stored=3"
+    );
+    assert_eq!(
+        f.client.current_version(),
+        3,
+        "state must remain unchanged on error"
+    );
+}
+
+#[test]
+fn rejects_target_equal_to_current() {
+    let f = Fixture::new(5);
+
+    assert_eq!(
+        f.client.try_migrate_error_data(&f.admin, &5, &5),
+        Err(Ok(ContractError::InvalidTargetVersion)),
+        "target==current is not an upgrade"
+    );
+    assert_eq!(f.client.current_version(), 5);
+}
+
+#[test]
+fn rejects_target_lower_than_current() {
+    let f = Fixture::new(5);
+
+    assert_eq!(
+        f.client.try_migrate_error_data(&f.admin, &5, &3),
+        Err(Ok(ContractError::InvalidTargetVersion)),
+        "downgrade must be rejected"
+    );
+    assert_eq!(f.client.current_version(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// Guard: not-initialised
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rejects_uninitialised_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MigrateContract, ());
+    let admin = Address::generate(&env);
+    let client = MigrateContractClient::new(&env, &contract_id);
+
+    assert_eq!(
+        client.try_migrate_error_data(&admin, &1, &2),
+        Err(Ok(ContractError::NotInitialized)),
+        "uninitialised contract must return NotInitialized"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Guard: caller authentication
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rejects_non_admin_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MigrateContract, ());
+    let admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let client = MigrateContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &1);
+
+    assert_eq!(
+        client.try_migrate_error_data(&stranger, &1, &2),
+        Err(Ok(ContractError::Unauthorized)),
+        "non-admin caller must be rejected"
+    );
+    assert_eq!(client.current_version(), 1, "state must remain unchanged");
+}
+
+// ---------------------------------------------------------------------------
+// Integrity: state unchanged on failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn state_not_changed_on_version_mismatch() {
+    let f = Fixture::new(7);
+
+    let _ = f.client.try_migrate_error_data(&f.admin, &6, &8);
+    assert_eq!(f.client.current_version(), 7);
+}
+
+#[test]
+fn state_not_changed_on_invalid_target() {
+    let f = Fixture::new(4);
+
+    let _ = f.client.try_migrate_error_data(&f.admin, &4, &4);
+    assert_eq!(f.client.current_version(), 4);
+
+    let _ = f.client.try_migrate_error_data(&f.admin, &4, &1);
+    assert_eq!(f.client.current_version(), 4);
+}


### PR DESCRIPTION
## Overview

This PR adds a migration script sketch for error types across the Predictify contract ecosystem. It provides a `migrate_error_state` function with version compare-and-set guards, admin authentication, and an extensible data-reshape hook for error-related state migrations during contract upgrades.

## Related Issue

Closes #1110

## Changes

### Migration Script
- **[ADD]** `contracts/migrate/src/migrate.rs`
  - `migrate_error_state()` — validates pre-conditions (initialized, admin auth, version match), applies error-data reshape, and bumps the stored version
  - `reshape_errors()` — extensible hook for per-version error data transforms

- **[ADD]** `contracts/migrate/tests/err_migrate.rs` — 10 tests covering:
  - Happy path: successful bump, multi-version skip, non-default start
  - Guard conditions: version mismatch, invalid target (equal/lower), uninitialized
  - Auth: non-admin caller rejection
  - Integrity: state unchanged on all error paths

- **[MODIFY]** `contracts/migrate/src/lib.rs` — Added `migrate_error_data` contract entrypoint that delegates to the module function

## Verification Results

```
cargo test -p migrate
✅ 17/17 passed (10 new err_migrate tests + 7 existing gas_snap tests)
```

| Acceptance Criteria | Status |
| --- | --- |
| Migration validates version compare-and-set | ✅ Tested: mismatch, equal, downgrade all rejected |
| Admin authentication enforced | ✅ Tested: non-admin rejected |
| State unchanged on error | ✅ Tested: verified on all error paths |
| Error-data reshape hook is extensible | ✅ Placeholder with documented future extension points |

## Timeline

- jaymoneymanxl committed
