### PR TITLE
fix(markets): expand error enum with admin-specific variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "allowlist"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1213,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reporting"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/contracts/markets/src/admin.rs
+++ b/contracts/markets/src/admin.rs
@@ -63,7 +63,7 @@ impl AdminManager {
         };
         
         if last_action > 0 && now < last_action.saturating_add(cooldown) {
-            return Err(ContractError::AdminActionTimelocked);
+            return Err(ContractError::AdminCooldownActive);
         }
         
         env.storage().persistent().set(&last_key, &now);

--- a/contracts/markets/src/errors.rs
+++ b/contracts/markets/src/errors.rs
@@ -27,6 +27,13 @@ pub enum ContractError {
     InvalidState = 10,
     /// Admin action timelocked; thrown when an admin action is invoked before the cooldown has elapsed.
     AdminActionTimelocked = 11,
+    // ===== ADMIN-SPECIFIC ERROR VARIANTS (12-19) =====
+    /// Admin cooldown period is still active; the action cannot be executed yet.
+    AdminCooldownActive = 12,
+    /// The provided admin address is invalid (e.g., zero address or self-referential).
+    AdminAddressInvalid = 13,
+    /// The requested admin operation is not permitted in the current contract state.
+    AdminOperationNotPermitted = 14,
 }
 
 #[cfg(test)]
@@ -46,5 +53,8 @@ mod tests {
         assert_eq!(ContractError::StakeTooSmall as u32, 9);
         assert_eq!(ContractError::InvalidState as u32, 10);
         assert_eq!(ContractError::AdminActionTimelocked as u32, 11);
+        assert_eq!(ContractError::AdminCooldownActive as u32, 12);
+        assert_eq!(ContractError::AdminAddressInvalid as u32, 13);
+        assert_eq!(ContractError::AdminOperationNotPermitted as u32, 14);
     }
 }

--- a/contracts/markets/src/lib.rs
+++ b/contracts/markets/src/lib.rs
@@ -23,7 +23,7 @@
 //! | `transfer_ownership`   | Admin                      |
 //! | `version`              | Anyone (read-only)         |
 
-mod errors;
+pub mod errors;
 
 use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env, String, Vec};
 
@@ -90,7 +90,6 @@ pub struct LiquidityData {
     pub total_amount: i128,
 }
 
-pub mod errors;
 pub mod admin;
 
 #[contract]

--- a/contracts/markets/tests/admin_cooldown.rs
+++ b/contracts/markets/tests/admin_cooldown.rs
@@ -54,7 +54,7 @@ fn test_admin_cooldown() {
     
     // Second invocation immediately should fail due to cooldown
     let res_err = client.try_check_cd(&admin, &func_name);
-    assert_eq!(res_err.unwrap_err().unwrap(), ContractError::AdminActionTimelocked);
+    assert_eq!(res_err.unwrap_err().unwrap(), ContractError::AdminCooldownActive);
     
     // Advance ledger timestamp beyond cooldown
     env.ledger().with_mut(|l| {


### PR DESCRIPTION
## Overview

This PR expands the markets contract error enum with three admin-specific error variants, migrates the cooldown enforcement to the more precise `AdminCooldownActive` error, and fixes a duplicate module declaration in lib.rs.

## Related Issue

Closes #1123

## Changes

- **[ADD]** `contracts/markets/src/errors.rs` — Three new ContractError variants:
  - `AdminCooldownActive = 12` — cooldown period still active
  - `AdminAddressInvalid = 13` — invalid admin address
  - `AdminOperationNotPermitted = 14` — operation not permitted in current state

- **[MODIFY]** `contracts/markets/src/admin.rs` — Changed cooldown enforcement to return `AdminCooldownActive` instead of the generic `AdminActionTimelocked`

- **[FIX]** `contracts/markets/src/lib.rs` — Removed duplicate `mod errors;` / `pub mod errors;` declarations

- **[MODIFY]** `contracts/markets/tests/admin_cooldown.rs` — Updated test assertion to expect `AdminCooldownActive`

## Verification Results

```
cargo test -p markets
✅ 3/3 passed (1 error variant test + 2 admin cooldown tests)

cargo check -p markets
✅ Compiles cleanly
```

| Acceptance Criteria | Status |
| --- | --- |
| AdminCooldownActive code is 12 | ✅ Tested |
| AdminAddressInvalid code is 13 | ✅ Tested |
| AdminOperationNotPermitted code is 14 | ✅ Tested |
| Cooldown enforcement uses specific error | ✅ Changed to AdminCooldownActive |
| No duplicate module declarations | ✅ Fixed lib.rs |
| Library compiles without errors | ✅ Verified |

## Timeline

- jaymoneymanxl committed
