### PR TITLE
feat(migrate): add auth-boundary snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "admin"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +24,13 @@ dependencies = [
 [[package]]
 name = "allowlist"
 version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "analytics"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]
@@ -172,6 +186,13 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "auction"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -978,6 +999,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "monitor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1252,6 @@ dependencies = [
 name = "resolution"
 version = "0.0.0"
 dependencies = [
- "predictify-hybrid",
  "soroban-sdk",
 ]
 
@@ -1806,6 +1833,13 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "validators"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,4 @@ inherits = "release"
 debug-assertions = true
 
 
-[workspace.members]
-"contracts/auction"
 
-[workspace.members]
-"contracts/analytics"

--- a/contracts/migrate/Cargo.toml
+++ b/contracts/migrate/Cargo.toml
@@ -21,3 +21,7 @@ path = "tests/gas_snap.rs"
 [[test]]
 name = "err_migrate"
 path = "tests/err_migrate.rs"
+
+[[test]]
+name = "auth_snap"
+path = "tests/auth_snap.rs"

--- a/contracts/migrate/src/lib.rs
+++ b/contracts/migrate/src/lib.rs
@@ -1,136 +1,195 @@
-#![no_std]
+//! Migrate contract — version-gated state migration for the Predictify ecosystem.
+//!
+//! # Overview
+//!
+//! This contract provides a minimal, admin-gated facility for advancing the
+//! on-chain storage schema across numbered versions.  It tracks a single
+//! `admin` address and a `version` counter; all state-changing entrypoints
+//! require the caller to authenticate as the stored admin.
+//!
+//! # Versioning model
+//!
+//! The compiled-in [`CURRENT_VERSION`] constant represents the highest version
+//! this build understands.  `initialize` rejects any `version` argument that
+//! is `0` or exceeds `CURRENT_VERSION`.  `migrate_error_data` enforces a
+//! compare-and-set on the stored version: the caller must supply the exact
+//! current version as `expected_version` and a strictly higher `target_version`.
+//!
+//! # Security
+//!
+//! Every entrypoint that mutates storage calls `admin.require_auth()` before
+//! touching any state.  Read-only entrypoints (`admin`, `current_version`)
+//! do not require auth.
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, Vec, Map, BytesN};
+#![no_std]
 
 mod migrate;
 
-use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+/// Discriminated storage keys used by instance storage.
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Stores the administrator [`Address`].
     Admin,
+    /// Stores the current schema version as `u32`.
     Version,
 }
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
 
 /// Errors returned by migration entrypoints.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
-    /// Caller is not authorized
+    /// The caller is not the stored administrator.
     Unauthorized = 1,
-    /// Contract not initialized
+    /// The contract has not been initialised yet.
     NotInitialized = 2,
-    /// Contract already initialized
+    /// The contract has already been initialised.
     AlreadyInitialized = 3,
-    /// Version mismatch - current version doesn't match expected
+    /// The supplied `expected_version` does not match the stored version.
     VersionMismatch = 4,
-    /// Target version is invalid (same as current or lower)
+    /// The supplied `target_version` is not strictly greater than the current
+    /// version, or `version` was `0` during `initialize`.
     InvalidTargetVersion = 5,
-    /// Migration data validation failed
+    /// Migration data failed validation.
     InvalidMigrationData = 6,
-    /// Storage migration failed
+    /// A storage migration step failed.
     MigrationFailed = 7,
 }
 
-/// Storage version key
-const VERSION_KEY: Symbol = Symbol::new("VERSION");
-/// Admin key
-const ADMIN_KEY: Symbol = Symbol::new("ADMIN");
-/// Migration data prefix
-const MIGRATION_PREFIX: Symbol = Symbol::new("MIGRATION_");
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
-/// Migration metadata stored per version upgrade
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MigrationRecord {
-    pub from_version: u32,
-    pub to_version: u32,
-    pub timestamp: u64,
-    pub migrated_by: Address,
-    pub data_checksum: BytesN<32>,
-}
-
-/// Storage layout version 1 - initial schema
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StorageV1 {
-    pub admin: Address,
-    pub version: u32,
-    pub data: Map<Symbol, Vec<u8>>,
-}
-
-/// Storage layout version 2 - added migration history
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StorageV2 {
-    pub admin: Address,
-    pub version: u32,
-    pub data: Map<Symbol, Vec<u8>>,
-    pub migration_history: Vec<MigrationRecord>,
-}
-
-/// Current storage version
+/// The highest schema version this contract build understands.
+///
+/// `initialize` and future migration steps use this as an upper bound so that
+/// a mis-configured deployment cannot advance beyond what the wasm handles.
 const CURRENT_VERSION: u32 = 2;
 
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+/// The Migrate contract.
 #[contract]
 pub struct MigrateContract;
 
 #[contractimpl]
 impl MigrateContract {
-    /// Initialize the contract with admin and version
-    /// Requires auth from admin
+    /// Initialise the contract, recording `admin` and `version` in storage.
+    ///
+    /// # Auth
+    ///
+    /// Requires `admin.require_auth()`.  The call is rejected if the signer
+    /// does not match `admin`.
+    ///
+    /// # Arguments
+    ///
+    /// * `admin`   — Address that will own subsequent migration calls.
+    /// * `version` — Starting schema version; must be in `1..=CURRENT_VERSION`.
+    ///
+    /// # Errors
+    ///
+    /// * [`ContractError::InvalidTargetVersion`] — `version` is `0` or above
+    ///   [`CURRENT_VERSION`].
+    /// * [`ContractError::AlreadyInitialized`] — the contract was already
+    ///   initialised.
     pub fn initialize(env: Env, admin: Address, version: u32) -> Result<(), ContractError> {
         admin.require_auth();
-        
+
         if version == 0 || version > CURRENT_VERSION {
             return Err(ContractError::InvalidTargetVersion);
         }
-        
-        if env.storage().instance().has(&VERSION_KEY) {
+
+        if env.storage().instance().has(&DataKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
         }
-        .publish(&env);
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Version, &version);
+
         Ok(())
     }
 
-    /// Returns the configured migration administrator.
+    /// Return the stored administrator address.
+    ///
+    /// # Errors
+    ///
+    /// * [`ContractError::NotInitialized`] — the contract has not been
+    ///   initialised.
     pub fn admin(env: Env) -> Result<Address, ContractError> {
         Self::load_admin(&env)
     }
 
-    /// Returns the current stored version.
+    /// Return the current stored schema version.
+    ///
+    /// # Errors
+    ///
+    /// * [`ContractError::NotInitialized`] — the contract has not been
+    ///   initialised.
     pub fn current_version(env: Env) -> Result<u32, ContractError> {
         Self::load_version(&env)
     }
 
-    fn load_admin(env: &Env) -> Result<Address, ContractError> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::NotInitialized)
-    }
-
-    /// Migrate error-related state from one version to the next.
+    /// Migrate error-related state from `expected_version` to `target_version`.
     ///
-    /// This entrypoint delegates to [`migrate::migrate_error_state`] and
-    /// provides the same pre-condition guarantees — version compare-and-set,
-    /// admin authentication, and an extensible data-reshape hook.
+    /// This is the primary migration entrypoint.  It delegates to
+    /// [`migrate::migrate_error_state`], which enforces the following
+    /// preconditions before advancing the stored version:
+    ///
+    /// 1. The contract must be initialised.
+    /// 2. `admin` must match the stored administrator.
+    /// 3. `expected_version` must equal the currently stored version.
+    /// 4. `target_version` must be strictly greater than the stored version.
+    ///
+    /// # Auth
+    ///
+    /// Requires `admin.require_auth()`.  The gate fires before any storage
+    /// read so that an unauthenticated call never touches contract state.
+    ///
+    /// # Arguments
+    ///
+    /// * `admin`            — Must be the stored administrator.
+    /// * `expected_version` — Compare-and-set guard: must equal stored version.
+    /// * `target_version`   — Destination version; must be `> expected_version`.
     ///
     /// # Errors
     ///
-    /// See [`migrate::migrate_error_state`].
+    /// * [`ContractError::NotInitialized`]     — contract not initialised.
+    /// * [`ContractError::Unauthorized`]       — `admin` != stored admin.
+    /// * [`ContractError::VersionMismatch`]    — `expected_version` != stored.
+    /// * [`ContractError::InvalidTargetVersion`] — `target_version` <= stored.
     pub fn migrate_error_data(
         env: Env,
         admin: Address,
         expected_version: u32,
         target_version: u32,
     ) -> Result<(), ContractError> {
+        // Auth gate fires before any storage access.
         admin.require_auth();
         migrate::migrate_error_state(&env, &admin, expected_version, target_version)
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    fn load_admin(env: &Env) -> Result<Address, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)
     }
 
     fn load_version(env: &Env) -> Result<u32, ContractError> {

--- a/contracts/migrate/src/migrate.rs
+++ b/contracts/migrate/src/migrate.rs
@@ -30,9 +30,9 @@ use crate::{ContractError, DataKey};
 /// * `env`        - Contract environment.
 /// * `admin`      - Authenticated administrator.
 /// * `expected`   - The version we expect to find stored. Must equal the
-///                  current contract version.
+///   current contract version.
 /// * `target`     - The version to upgrade to. Must be strictly greater than
-///                  `expected`.
+///   `expected`.
 ///
 /// # Errors
 ///

--- a/contracts/migrate/tests/auth_snap.rs
+++ b/contracts/migrate/tests/auth_snap.rs
@@ -1,0 +1,444 @@
+//! Auth-boundary snapshot tests for the Migrate contract.
+//!
+//! # Purpose
+//!
+//! Every state-changing entrypoint is covered by two complementary cases that
+//! together act as a ratchet: if `require_auth` is ever removed or called on
+//! the wrong address the corresponding test fails, making the regression
+//! visible in CI without needing to read the source.
+//!
+//! # Strategy
+//!
+//! 1. **Reject without auth** — a bare [`Env::default()`] with *no*
+//!    [`mock_all_auths()`] call is used.  Because `require_auth()` panics in
+//!    the test environment when no auth is mocked, `try_*` returns `Err`.
+//!    This proves the auth gate is present and is not accidentally bypassed.
+//!
+//! 2. **Accept with auth** — [`mock_all_auths()`] is enabled and
+//!    [`env.auths()`] is inspected immediately after the call.  We assert that
+//!    `auths()[0].0` equals the expected signer.  This proves the *correct*
+//!    address is being authorised, not an unrelated or empty one.
+//!
+//! Read-only views ([`admin`], [`current_version`]) have a dedicated section
+//! confirming they require no auth and never panic on an initialised contract.
+//!
+//! # Additional coverage
+//!
+//! * `initialize` — [`ContractError::AlreadyInitialized`] on double-init.
+//! * `initialize` — [`ContractError::InvalidTargetVersion`] on version 0 and
+//!   versions above the compiled-in [`CURRENT_VERSION`] (2).
+//! * `migrate_error_data` — a stranger (non-stored-admin address that still
+//!   has its auth mocked) is rejected with [`ContractError::Unauthorized`].
+//! * `migrate_error_data` — stale expected version yields
+//!   [`ContractError::VersionMismatch`]; downgrade yields
+//!   [`ContractError::InvalidTargetVersion`].
+//! * State invariant — version remains unchanged after every rejected call.
+
+#![cfg(test)]
+
+use migrate::{ContractError, MigrateContract, MigrateContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Register the contract **without** initialising it or enabling auth mocks.
+///
+/// Use this in tests that need to prove auth is required — a call on the
+/// returned client will invoke `require_auth()` against an unmocked env and
+/// must therefore fail.
+fn register(env: &Env) -> (MigrateContractClient<'_>, Address) {
+    let contract_id = env.register(MigrateContract, ());
+    let client = MigrateContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    (client, admin)
+}
+
+/// Register the contract, enable auth mocks, initialise it, and drain the
+/// `initialize` auth snapshot.
+///
+/// Use this in tests that verify the *signer* recorded by a subsequent call.
+/// Draining the init snapshot ensures `env.auths()` after the call under test
+/// reflects only that one call, not the setup call.
+fn register_and_init(env: &Env, initial_version: u32) -> (MigrateContractClient<'_>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(MigrateContract, ());
+    let client = MigrateContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin, &initial_version);
+    // Drain the initialize auth snapshot so it does not pollute later
+    // env.auths() assertions in the calling test.
+    let _ = env.auths();
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// initialize — auth gate
+// ---------------------------------------------------------------------------
+
+/// `initialize` must invoke `require_auth` on the admin address.
+///
+/// A bare [`Env::default()`] with no mocking makes `require_auth` panic,
+/// which bubbles up as an `Err` from `try_initialize`.
+#[test]
+fn initialize_rejected_without_auth() {
+    let env = Env::default();
+    let (client, admin) = register(&env);
+
+    let result = client.try_initialize(&admin, &1);
+    assert!(
+        result.is_err(),
+        "initialize must require auth; succeeded without it"
+    );
+}
+
+/// With auth mocked, `initialize` records the admin as the sole signer.
+#[test]
+fn initialize_accepted_with_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = register(&env);
+
+    client.initialize(&admin, &1);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "exactly one auth entry expected");
+    assert_eq!(
+        auths[0].0, admin,
+        "admin must be the authorised address for initialize"
+    );
+}
+
+/// A second `initialize` call must return [`ContractError::AlreadyInitialized`].
+#[test]
+fn initialize_already_initialized_returns_typed_error() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+
+    let result = client.try_initialize(&admin, &1);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::AlreadyInitialized,
+            "double-init must return AlreadyInitialized"
+        ),
+        other => panic!("expected AlreadyInitialized contract error, got {other:?}"),
+    }
+}
+
+/// Version `0` is not a valid initial version.
+#[test]
+fn initialize_rejects_version_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = register(&env);
+
+    let result = client.try_initialize(&admin, &0);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::InvalidTargetVersion,
+            "version 0 must be rejected"
+        ),
+        other => panic!("expected InvalidTargetVersion, got {other:?}"),
+    }
+}
+
+/// A version above the compiled-in `CURRENT_VERSION` (2) must be rejected.
+#[test]
+fn initialize_rejects_version_above_current() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = register(&env);
+
+    let result = client.try_initialize(&admin, &99);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::InvalidTargetVersion,
+            "version above CURRENT_VERSION must be rejected"
+        ),
+        other => panic!("expected InvalidTargetVersion, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// migrate_error_data — auth gate
+// ---------------------------------------------------------------------------
+
+/// `migrate_error_data` must invoke `require_auth` on the admin argument.
+///
+/// A bare env with no mocking causes `require_auth` to panic, which surfaces
+/// as `Err` from `try_migrate_error_data`.
+#[test]
+fn migrate_error_data_rejected_without_auth() {
+    let env = Env::default();
+    // Register + initialise without mocking (we drain init ourselves after
+    // enabling mocking, then disable so the actual call under test is bare).
+    env.mock_all_auths();
+    let contract_id = env.register(MigrateContract, ());
+    let client = MigrateContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &1);
+
+    // Switch to a fresh env without auth mocks for the call under test.
+    // We rebuild the client on the same env but cancel auth mocking by using
+    // a new Env entirely — the registered contract state does not carry over,
+    // so we use a different approach: call on the env with no further mocking
+    // after the init drain.  Soroban's auth mock is per-call, so once
+    // mock_all_auths() was used in the init call above, subsequent calls on
+    // the SAME env still require their own auth to be satisfied.
+    //
+    // The simplest correct approach: use a fresh env with the contract
+    // re-registered but NOT mock_all_auths'd.
+    let env2 = Env::default();
+    let contract_id2 = env2.register(MigrateContract, ());
+    let client2 = MigrateContractClient::new(&env2, &contract_id2);
+    let admin2 = Address::generate(&env2);
+
+    // `initialize` itself requires auth — we can't call it here without
+    // mocking.  Instead test the un-initialised path: the call still fires
+    // require_auth before any storage check, so it must fail.
+    let result = client2.try_migrate_error_data(&admin2, &1, &2);
+    assert!(
+        result.is_err(),
+        "migrate_error_data must require auth; succeeded without it"
+    );
+}
+
+/// With auth mocked, `migrate_error_data` records the admin as the sole
+/// signer and bumps the stored version.
+#[test]
+fn migrate_error_data_accepted_with_admin_auth() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+
+    client.migrate_error_data(&admin, &1, &2);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "exactly one auth entry expected");
+    assert_eq!(
+        auths[0].0, admin,
+        "admin must be the authorised address for migrate_error_data"
+    );
+}
+
+/// After a successful `migrate_error_data` the stored version reflects the
+/// `target_version` argument.
+#[test]
+fn migrate_error_data_bumps_version() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+
+    client.migrate_error_data(&admin, &1, &2);
+
+    assert_eq!(
+        client.current_version(),
+        2,
+        "version must be 2 after migrate_error_data(1 → 2)"
+    );
+}
+
+/// A stranger whose auth is mocked but who is not the stored admin must be
+/// rejected with [`ContractError::Unauthorized`].
+#[test]
+fn migrate_error_data_stranger_rejected_with_unauthorized() {
+    let env = Env::default();
+    let (client, _admin) = register_and_init(&env, 1);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_migrate_error_data(&stranger, &1, &2);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::Unauthorized,
+            "non-admin caller must receive Unauthorized"
+        ),
+        other => panic!("expected Unauthorized, got {other:?}"),
+    }
+}
+
+/// A stale `expected_version` must return [`ContractError::VersionMismatch`]
+/// and must not alter the stored version.
+#[test]
+fn migrate_error_data_version_mismatch_returns_typed_error() {
+    let env = Env::default();
+    // Start at version 1; pass expected=2 (wrong) so we get VersionMismatch.
+    let (client, admin) = register_and_init(&env, 1);
+
+    let result = client.try_migrate_error_data(&admin, &2, &3);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::VersionMismatch,
+            "stale expected_version must return VersionMismatch"
+        ),
+        other => panic!("expected VersionMismatch, got {other:?}"),
+    }
+    assert_eq!(
+        client.current_version(),
+        1,
+        "version must remain 1 after VersionMismatch"
+    );
+}
+
+/// A `target_version` equal to the current version must return
+/// [`ContractError::InvalidTargetVersion`].
+#[test]
+fn migrate_error_data_target_equal_to_current_rejected() {
+    let env = Env::default();
+    // Use version 2 (CURRENT_VERSION); pass target=2 which equals current.
+    let (client, admin) = register_and_init(&env, 2);
+
+    let result = client.try_migrate_error_data(&admin, &2, &2);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::InvalidTargetVersion,
+            "target == current must return InvalidTargetVersion"
+        ),
+        other => panic!("expected InvalidTargetVersion, got {other:?}"),
+    }
+    assert_eq!(client.current_version(), 2);
+}
+
+/// A `target_version` lower than the current version (downgrade) must return
+/// [`ContractError::InvalidTargetVersion`] and must not alter state.
+#[test]
+fn migrate_error_data_downgrade_rejected() {
+    let env = Env::default();
+    // Start at version 2 (CURRENT_VERSION); attempt to downgrade to 1.
+    let (client, admin) = register_and_init(&env, 2);
+
+    let result = client.try_migrate_error_data(&admin, &2, &1);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::InvalidTargetVersion,
+            "downgrade must return InvalidTargetVersion"
+        ),
+        other => panic!("expected InvalidTargetVersion, got {other:?}"),
+    }
+    assert_eq!(
+        client.current_version(),
+        2,
+        "version must remain 2 after rejected downgrade"
+    );
+}
+
+/// Calling `migrate_error_data` on an uninitialised contract must return
+/// [`ContractError::NotInitialized`] (require_auth fires before storage
+/// checks, so this indirectly confirms the auth gate is also present).
+#[test]
+fn migrate_error_data_on_uninitialised_contract_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MigrateContract, ());
+    let client = MigrateContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    let result = client.try_migrate_error_data(&admin, &1, &2);
+    match result {
+        Err(Ok(e)) => assert_eq!(
+            e,
+            ContractError::NotInitialized,
+            "uninitialised contract must return NotInitialized"
+        ),
+        other => panic!("expected NotInitialized, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read-only views — no auth required
+// ---------------------------------------------------------------------------
+
+/// `admin()` must return the stored admin without requiring any auth.
+#[test]
+fn admin_view_requires_no_auth() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+    // Deliberately no mock_all_auths / additional mocking from here.
+    assert_eq!(
+        client.admin(),
+        admin,
+        "admin() must return the stored admin address"
+    );
+}
+
+/// `current_version()` must return the stored version without requiring auth.
+#[test]
+fn current_version_view_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin) = register_and_init(&env, 1);
+    assert_eq!(
+        client.current_version(),
+        1,
+        "current_version() must return the version set during initialize"
+    );
+}
+
+/// After a successful migration `current_version()` returns the target.
+#[test]
+fn current_version_reflects_latest_migration() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+
+    client.migrate_error_data(&admin, &1, &7);
+    let _ = env.auths();
+
+    assert_eq!(
+        client.current_version(),
+        7,
+        "current_version() must reflect the target version after migration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Signer identity invariant
+// ---------------------------------------------------------------------------
+
+/// The authorised signer recorded by `initialize` must equal the address
+/// passed as the `admin` argument, not some other in-scope address.
+#[test]
+fn initialize_auth_snapshot_signer_is_the_admin_argument() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = register(&env);
+    let bystander = Address::generate(&env);
+
+    client.initialize(&admin, &1);
+
+    let auths = env.auths();
+    // The bystander must NOT appear as a signer.
+    assert!(
+        auths.iter().all(|(signer, _)| *signer != bystander),
+        "bystander address must not appear in the auth snapshot"
+    );
+    // The admin MUST appear as a signer.
+    assert!(
+        auths.iter().any(|(signer, _)| *signer == admin),
+        "admin address must appear in the auth snapshot"
+    );
+}
+
+/// The authorised signer recorded by `migrate_error_data` must equal the
+/// address passed as the `admin` argument.
+#[test]
+fn migrate_error_data_auth_snapshot_signer_is_the_admin_argument() {
+    let env = Env::default();
+    let (client, admin) = register_and_init(&env, 1);
+    let bystander = Address::generate(&env);
+
+    client.migrate_error_data(&admin, &1, &2);
+
+    let auths = env.auths();
+    assert!(
+        auths.iter().all(|(signer, _)| *signer != bystander),
+        "bystander must not appear in the auth snapshot for migrate_error_data"
+    );
+    assert!(
+        auths.iter().any(|(signer, _)| *signer == admin),
+        "admin must appear in the auth snapshot for migrate_error_data"
+    );
+}

--- a/contracts/migrate/tests/err_migrate.rs
+++ b/contracts/migrate/tests/err_migrate.rs
@@ -10,6 +10,7 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 
 /// Deploy and initialise a fresh migrate contract.
 struct Fixture {
+    #[allow(dead_code)]
     env: Env,
     client: MigrateContractClient<'static>,
     admin: Address,
@@ -59,10 +60,12 @@ fn migration_can_skip_multiple_versions() {
 
 #[test]
 fn migrate_from_non_default_start() {
-    let f = Fixture::new(10);
+    // Start at version 2 (the maximum allowed by CURRENT_VERSION) and
+    // migrate forward — demonstrating non-default starting points work.
+    let f = Fixture::new(2);
 
-    assert_eq!(f.client.try_migrate_error_data(&f.admin, &10, &11), Ok(Ok(())));
-    assert_eq!(f.client.current_version(), 11);
+    assert_eq!(f.client.try_migrate_error_data(&f.admin, &2, &3), Ok(Ok(())));
+    assert_eq!(f.client.current_version(), 3);
 }
 
 // ---------------------------------------------------------------------------
@@ -71,42 +74,43 @@ fn migrate_from_non_default_start() {
 
 #[test]
 fn rejects_expected_version_mismatch() {
-    let f = Fixture::new(3);
+    // Start at version 1; pass expected=2 (wrong) — should get VersionMismatch.
+    let f = Fixture::new(1);
 
     assert_eq!(
         f.client.try_migrate_error_data(&f.admin, &2, &4),
         Err(Ok(ContractError::VersionMismatch)),
-        "should reject expected=2 when stored=3"
+        "should reject expected=2 when stored=1"
     );
     assert_eq!(
         f.client.current_version(),
-        3,
+        1,
         "state must remain unchanged on error"
     );
 }
 
 #[test]
 fn rejects_target_equal_to_current() {
-    let f = Fixture::new(5);
+    let f = Fixture::new(2);
 
     assert_eq!(
-        f.client.try_migrate_error_data(&f.admin, &5, &5),
+        f.client.try_migrate_error_data(&f.admin, &2, &2),
         Err(Ok(ContractError::InvalidTargetVersion)),
         "target==current is not an upgrade"
     );
-    assert_eq!(f.client.current_version(), 5);
+    assert_eq!(f.client.current_version(), 2);
 }
 
 #[test]
 fn rejects_target_lower_than_current() {
-    let f = Fixture::new(5);
+    let f = Fixture::new(2);
 
     assert_eq!(
-        f.client.try_migrate_error_data(&f.admin, &5, &3),
+        f.client.try_migrate_error_data(&f.admin, &2, &1),
         Err(Ok(ContractError::InvalidTargetVersion)),
         "downgrade must be rejected"
     );
-    assert_eq!(f.client.current_version(), 5);
+    assert_eq!(f.client.current_version(), 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,19 +161,19 @@ fn rejects_non_admin_caller() {
 
 #[test]
 fn state_not_changed_on_version_mismatch() {
-    let f = Fixture::new(7);
+    let f = Fixture::new(1);
 
-    let _ = f.client.try_migrate_error_data(&f.admin, &6, &8);
-    assert_eq!(f.client.current_version(), 7);
+    let _ = f.client.try_migrate_error_data(&f.admin, &2, &3);
+    assert_eq!(f.client.current_version(), 1);
 }
 
 #[test]
 fn state_not_changed_on_invalid_target() {
-    let f = Fixture::new(4);
+    let f = Fixture::new(2);
 
-    let _ = f.client.try_migrate_error_data(&f.admin, &4, &4);
-    assert_eq!(f.client.current_version(), 4);
+    let _ = f.client.try_migrate_error_data(&f.admin, &2, &2);
+    assert_eq!(f.client.current_version(), 2);
 
-    let _ = f.client.try_migrate_error_data(&f.admin, &4, &1);
-    assert_eq!(f.client.current_version(), 4);
+    let _ = f.client.try_migrate_error_data(&f.admin, &2, &1);
+    assert_eq!(f.client.current_version(), 2);
 }

--- a/contracts/migrate/tests/gas_snap.rs
+++ b/contracts/migrate/tests/gas_snap.rs
@@ -120,7 +120,7 @@ fn snapshot_migrate() {
     let client = fixture.client();
 
     reset_budget(&fixture.env);
-    client.migrate(&fixture.admin, &1, &2);
+    client.migrate_error_data(&fixture.admin, &1, &2);
     let measured = measured_budget(&fixture.env);
 
     assert_eq!(client.current_version(), 2);
@@ -144,36 +144,36 @@ fn snapshot_admin() {
 #[test]
 fn snapshot_current_version() {
     let fixture = Fixture::new();
-    fixture.initialize(7);
+    fixture.initialize(2);
     let client = fixture.client();
 
     reset_budget(&fixture.env);
     let current_version = client.current_version();
     let measured = measured_budget(&fixture.env);
 
-    assert_eq!(current_version, 7);
+    assert_eq!(current_version, 2);
     assert_budget("current_version", measured, CURRENT_VERSION);
 }
 
 #[test]
 fn rejects_stale_and_unsafe_migrations_without_changing_state() {
     let fixture = Fixture::new();
-    fixture.initialize(3);
+    fixture.initialize(1);
     let client = fixture.client();
 
     assert_eq!(
-        client.try_migrate(&fixture.admin, &2, &4),
+        client.try_migrate_error_data(&fixture.admin, &2, &4),
         Err(Ok(ContractError::VersionMismatch))
     );
     assert_eq!(
-        client.try_migrate(&fixture.admin, &3, &3),
+        client.try_migrate_error_data(&fixture.admin, &1, &1),
         Err(Ok(ContractError::InvalidTargetVersion))
     );
     assert_eq!(
-        client.try_migrate(&fixture.admin, &3, &2),
+        client.try_migrate_error_data(&fixture.admin, &1, &0),
         Err(Ok(ContractError::InvalidTargetVersion))
     );
-    assert_eq!(client.current_version(), 3);
+    assert_eq!(client.current_version(), 1);
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn rejects_an_authenticated_non_admin() {
     let stranger = Address::generate(&fixture.env);
 
     assert_eq!(
-        fixture.client().try_migrate(&stranger, &1, &2),
+        fixture.client().try_migrate_error_data(&stranger, &1, &2),
         Err(Ok(ContractError::Unauthorized))
     );
     assert_eq!(fixture.client().current_version(), 1);


### PR DESCRIPTION
feat(migrate): auth-boundary snapshot tests for migrate contract
  
  Closes #
  
  Summary
  
  Snapshots the required require_auth per entrypoint on the migrate contract so that any future
  removal or misdirection of an auth gate produces an immediate CI failure — visible as a diff
  against the checked-in test expectations.
  
  Changes
  
  New: contracts/migrate/tests/auth_snap.rs (18 tests)
  
  Each state-changing entrypoint gets two complementary cases:
  
  1. Reject without auth — bare Env::default() with no mock_all_auths(); proves the gate is
  present
  2. Accept with auth — mock_all_auths() enabled, env.auths()[0].0 asserted to equal the expected
  signer; proves the correct address is authorised
  
  ┌────────────┬───────────────┬───────┐
  │ Entrypoint │ Auth required │ Tests                                                        │
  ├────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
  │ initialize         │ admin         │ rejected without auth, accepted, double-init error,  │
  │                    │               │ version 0 error, version > CURRENT_VERSION error     │
  ├────────────────────┼───────────────┼──────────────────────────────────────────────────────┤
  │ migrate_error_data │ admin         │ rejected without auth, accepted, version bumped,     │
  │                    │               │ Unauthorized for stranger, VersionMismatch,          │
  │                    │               │ InvalidTargetVersion (equal/downgrade),              │
  │                    │               │ NotInitialized on uninit                             │
  ├────────────────────┼───────────────┼──────────────────────────────────────────────────────┤
  │ admin              │ none          │ confirmed no auth needed                             │
  ├────────────────────┼───────────────┼──────────────────────────────────────────────────────┤
  │ current_version    │ none          │ confirmed no auth needed                             │
  ├────────────────────┼───────────────┼──────────────────────────────────────────────────────┤
  │ signer identity    │ —             │ bystander absent, admin present in snapshot for both │
  │                    │               │ mutating entrypoints                                 │
  └────────────────────┴───────────────┴──────────────────────────────────────────────────────┘
  
  Fixed: contracts/migrate/src/lib.rs
  
  - Removed duplicate use soroban_sdk blocks and orphan .publish(&env) syntax error
  - initialize now correctly writes DataKey::Admin and DataKey::Version to storage
  - Full /// rustdoc on all four public entrypoints
  
  Fixed: pre-existing breakage in gas_snap.rs, err_migrate.rs, src/migrate.rs
  
  - gas_snap.rs: client.migrate() → client.migrate_error_data(); invalid init versions corrected
  - err_migrate.rs: invalid init versions (> CURRENT_VERSION 2) corrected; #[allow(dead_code)] on
  unused Fixture.env
  - src/migrate.rs: overindented doc list items fixed
  
  Test results
  
  cargo test -p migrate       →  35/35 pass (18 auth_snap + 10 err_migrate + 7 gas_snap)
  cargo clippy --tests -D warnings  →  clean

closes #1113 