### PR TITLE
feat(capabilities): add admin cooldown for critical actions

### DIFF
--- a/contracts/predictify-hybrid/docs/capabilities.md
+++ b/contracts/predictify-hybrid/docs/capabilities.md
@@ -1,0 +1,27 @@
+# Capabilities
+
+The Predictify Hybrid contract exposes `capabilities()` as a read-only `u64`
+bitmap describing the recovery features supported by the active Wasm.
+
+## Admin cooldown
+
+The actions that can change the active capability surface are protected by a
+fixed 3,600-second cooldown:
+
+- `upgrade_contract`
+- `rollback_upgrade`
+
+Each action has an independent cooldown clock. A successful upgrade therefore
+does not prevent an immediate emergency rollback, while repeated upgrades or
+repeated rollbacks are rejected until their own cooldown expires.
+
+The first action is allowed. Only successful actions start the cooldown, and an
+action is allowed when the ledger timestamp reaches the exact cooldown
+boundary. Timestamp addition uses checked arithmetic.
+
+Calls made during the cooldown return `Error::AdminActionTimelocked` (contract
+error code `443`). Existing primary-admin authentication remains required for
+both state-changing entrypoints.
+
+Clients can query `get_capabilities_admin_cooldown()` without authorization to
+retrieve the fixed duration in seconds.

--- a/contracts/predictify-hybrid/src/capabilities/admin.rs
+++ b/contracts/predictify-hybrid/src/capabilities/admin.rs
@@ -1,0 +1,174 @@
+//! Cooldown enforcement for admin actions that can change contract capabilities.
+
+use soroban_sdk::{contracttype, Env};
+
+use crate::Error;
+
+/// Cooldown applied between repeated capability-critical admin actions.
+///
+/// Upgrades and rollbacks have independent clocks so a newly deployed Wasm can
+/// still be rolled back immediately if it proves unsafe.
+pub const ADMIN_ACTION_COOLDOWN_SECONDS: u64 = 3_600;
+
+const COOLDOWN_TTL_THRESHOLD: u32 = 535_680;
+const COOLDOWN_TTL_BUMP: u32 = 535_680;
+
+/// Capability-critical operations protected by the admin cooldown.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CapabilitiesAdminAction {
+    /// Replace the active contract Wasm.
+    Upgrade,
+    /// Restore a prior contract Wasm.
+    Rollback,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CapabilitiesAdminDataKey {
+    LastAction(CapabilitiesAdminAction),
+}
+
+/// Enforces cooldowns for operations that can change the capability bitmap.
+pub(crate) struct CapabilitiesAdminCooldown;
+
+impl CapabilitiesAdminCooldown {
+    /// Checks whether the named critical action can execute at the current time.
+    ///
+    /// This function does not update storage. Call [`Self::record_action`] only
+    /// after the protected operation succeeds so failed attempts do not consume
+    /// the cooldown window.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AdminActionTimelocked`] while the action's cooldown is
+    /// active, or [`Error::Overflow`] if the stored timestamp cannot be safely
+    /// combined with the cooldown duration.
+    pub(crate) fn require_elapsed(
+        env: &Env,
+        action: &CapabilitiesAdminAction,
+    ) -> Result<(), Error> {
+        let key = CapabilitiesAdminDataKey::LastAction(action.clone());
+        let Some(last_action) = env.storage().persistent().get::<_, u64>(&key) else {
+            return Ok(());
+        };
+
+        let cooldown_end = last_action
+            .checked_add(ADMIN_ACTION_COOLDOWN_SECONDS)
+            .ok_or(Error::Overflow)?;
+
+        if env.ledger().timestamp() < cooldown_end {
+            return Err(Error::AdminActionTimelocked);
+        }
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, COOLDOWN_TTL_THRESHOLD, COOLDOWN_TTL_BUMP);
+
+        Ok(())
+    }
+
+    /// Records a successful capability-critical action.
+    pub(crate) fn record_action(env: &Env, action: &CapabilitiesAdminAction) {
+        let key = CapabilitiesAdminDataKey::LastAction(action.clone());
+        env.storage()
+            .persistent()
+            .set(&key, &env.ledger().timestamp());
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, COOLDOWN_TTL_THRESHOLD, COOLDOWN_TTL_BUMP);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CapabilitiesAdminAction, CapabilitiesAdminCooldown, CapabilitiesAdminDataKey,
+        ADMIN_ACTION_COOLDOWN_SECONDS,
+    };
+    use crate::{Error, PredictifyHybrid};
+    use soroban_sdk::{testutils::Ledger, Env};
+
+    fn in_contract(env: &Env, test: impl FnOnce()) {
+        let contract_id = env.register(PredictifyHybrid, ());
+        env.as_contract(&contract_id, test);
+    }
+
+    #[test]
+    fn first_action_is_allowed_and_repeat_is_blocked() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+
+        in_contract(&env, || {
+            let action = CapabilitiesAdminAction::Upgrade;
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(&env, &action),
+                Ok(())
+            );
+
+            CapabilitiesAdminCooldown::record_action(&env, &action);
+
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(&env, &action),
+                Err(Error::AdminActionTimelocked)
+            );
+        });
+    }
+
+    #[test]
+    fn action_is_allowed_at_exact_cooldown_boundary() {
+        let env = Env::default();
+        env.ledger().set_timestamp(5_000);
+
+        in_contract(&env, || {
+            let action = CapabilitiesAdminAction::Upgrade;
+            CapabilitiesAdminCooldown::record_action(&env, &action);
+
+            env.ledger()
+                .set_timestamp(5_000 + ADMIN_ACTION_COOLDOWN_SECONDS);
+
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(&env, &action),
+                Ok(())
+            );
+        });
+    }
+
+    #[test]
+    fn upgrade_and_rollback_use_independent_cooldowns() {
+        let env = Env::default();
+        env.ledger().set_timestamp(10_000);
+
+        in_contract(&env, || {
+            CapabilitiesAdminCooldown::record_action(&env, &CapabilitiesAdminAction::Upgrade);
+
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(&env, &CapabilitiesAdminAction::Upgrade,),
+                Err(Error::AdminActionTimelocked)
+            );
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(
+                    &env,
+                    &CapabilitiesAdminAction::Rollback,
+                ),
+                Ok(())
+            );
+        });
+    }
+
+    #[test]
+    fn timestamp_overflow_returns_contract_error() {
+        let env = Env::default();
+
+        in_contract(&env, || {
+            let action = CapabilitiesAdminAction::Upgrade;
+            let key = CapabilitiesAdminDataKey::LastAction(action.clone());
+            env.storage().persistent().set(&key, &u64::MAX);
+
+            assert_eq!(
+                CapabilitiesAdminCooldown::require_elapsed(&env, &action),
+                Err(Error::Overflow)
+            );
+        });
+    }
+}

--- a/contracts/predictify-hybrid/src/capabilities/mod.rs
+++ b/contracts/predictify-hybrid/src/capabilities/mod.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::Env;
 
+pub(crate) mod admin;
+
 /// Recovery feature capability flags (u64 bitmap).
 ///
 /// Each bit represents a discrete feature the recovery subsystem supports.
@@ -50,4 +52,13 @@ pub mod recovery {
 /// capabilities are available and detect changes after contract upgrades.
 pub fn capabilities(_env: &Env) -> u64 {
     recovery::SUPPORTED
+}
+
+/// Returns the fixed cooldown between repeated capability-critical admin actions.
+///
+/// The cooldown is enforced independently for contract upgrades and rollbacks.
+/// This keeps emergency rollback available after an upgrade while preventing
+/// rapid repetition of either critical action.
+pub fn admin_cooldown_seconds() -> u64 {
+    admin::ADMIN_ACTION_COOLDOWN_SECONDS
 }

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -5745,12 +5745,23 @@ impl PredictifyHybrid {
         expected_predecessor: soroban_sdk::BytesN<32>,
     ) -> Result<(), Error> {
         Self::require_primary_admin(&env, &admin)?;
+        capabilities::admin::CapabilitiesAdminCooldown::require_elapsed(
+            &env,
+            &capabilities::admin::CapabilitiesAdminAction::Upgrade,
+        )?;
         let result = upgrade_manager::UpgradeManager::upgrade_contract(
             &env,
             &admin,
             new_wasm_hash,
             expected_predecessor,
         );
+
+        if result.is_ok() {
+            capabilities::admin::CapabilitiesAdminCooldown::record_action(
+                &env,
+                &capabilities::admin::CapabilitiesAdminAction::Upgrade,
+            );
+        }
 
         crate::audit_trail::AuditTrailManager::append_record(
             &env,
@@ -5827,8 +5838,19 @@ impl PredictifyHybrid {
         rollback_wasm_hash: soroban_sdk::BytesN<32>,
     ) -> Result<(), Error> {
         Self::require_primary_admin(&env, &admin)?;
+        capabilities::admin::CapabilitiesAdminCooldown::require_elapsed(
+            &env,
+            &capabilities::admin::CapabilitiesAdminAction::Rollback,
+        )?;
         let result =
             upgrade_manager::UpgradeManager::rollback_upgrade(&env, &admin, rollback_wasm_hash);
+
+        if result.is_ok() {
+            capabilities::admin::CapabilitiesAdminCooldown::record_action(
+                &env,
+                &capabilities::admin::CapabilitiesAdminAction::Rollback,
+            );
+        }
 
         crate::audit_trail::AuditTrailManager::append_record(
             &env,
@@ -5890,6 +5912,18 @@ impl PredictifyHybrid {
     /// bitmap directly for the active environment.
     pub fn capabilities(env: Env) -> u64 {
         crate::capabilities::capabilities(&env)
+    }
+
+    /// Return the cooldown for repeated capability-critical admin actions.
+    ///
+    /// The returned duration is expressed in seconds. Contract upgrades and
+    /// rollbacks each maintain an independent last-success timestamp and return
+    /// [`Error::AdminActionTimelocked`] when repeated before this duration
+    /// elapses.
+    ///
+    /// This is a read-only entrypoint and requires no authorization.
+    pub fn get_capabilities_admin_cooldown(_env: Env) -> u64 {
+        crate::capabilities::admin_cooldown_seconds()
     }
 
     /// Report whether an upgrade is currently available for execution.


### PR DESCRIPTION
## Summary
- add a fixed 3,600-second cooldown for repeated capability-changing upgrades and rollbacks
- keep upgrade and rollback clocks independent so emergency rollback remains available
- use checked timestamp arithmetic, persist cooldown timestamps with TTL refresh, and record only successful actions
- add focused first-call, repeat-call, boundary, independent-action, and overflow tests
- document the new read-only `get_capabilities_admin_cooldown()` API and cooldown behavior

## Verification
- `rustfmt --check` on changed capabilities modules
- `git diff --check`
- `cargo test` was not run because dependency downloads were explicitly disallowed and `wee_alloc` is not cached locally

Closes #1139