### PR TITLE
feat(governance): add structured lifecycle events [b#007]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "admin"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +24,13 @@ dependencies = [
 [[package]]
 name = "allowlist"
 version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "analytics"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]
@@ -172,6 +186,13 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "auction"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -706,6 +727,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "governance"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1006,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "monitor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1259,6 @@ dependencies = [
 name = "resolution"
 version = "0.0.0"
 dependencies = [
- "predictify-hybrid",
  "soroban-sdk",
 ]
 
@@ -1806,6 +1840,13 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "validators"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,3 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
-
-
-[workspace.members]
-"contracts/auction"
-
-[workspace.members]
-"contracts/analytics"

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "governance"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[test]]
+name = "governance_lifecycle"
+path = "tests/governance_lifecycle.rs"
+
+[[test]]
+name = "events"
+path = "tests/events.rs"
+
+[[test]]
+name = "auth_boundary"
+path = "tests/auth_boundary.rs"

--- a/contracts/governance/README.md
+++ b/contracts/governance/README.md
@@ -1,0 +1,84 @@
+# Governance Contract
+
+A minimal, self-contained on-chain governance module for Predictify with
+**structured lifecycle events** for off-chain indexers.
+
+Accounts create proposals, cast weighted votes during a bounded voting window,
+and proposals are finalized (executed or rejected) once voting closes. Every
+lifecycle transition emits a typed event with a **stable topic symbol** so that
+indexers can filter, decode, and replay governance state deterministically.
+
+## Lifecycle
+
+```text
+                      cast_vote (many)
+                     ┌──────────────┐
+                     ▼              │
+create_proposal → Active ──────────┘
+                     │
+       ┌─────────────┼──────────────┐
+       ▼ execute     ▼ execute       ▼ cancel
+   Executed       Rejected        Canceled
+```
+
+A proposal starts `Active` and moves to exactly one terminal state:
+`Executed`, `Rejected`, or `Canceled`.
+
+## Structured lifecycle events
+
+The first topic of every event is a stable `Symbol`. Identifying fields (actor
+address, proposal id) are placed in **topics** so indexers can subscribe by key
+without decoding the payload; quantitative fields go in the **data** payload.
+In addition to each action-specific event, **every** status transition also
+emits a generic `gov_status` event carrying `(old_status, new_status)`, so an
+indexer that only tracks lifecycle state can rely on that single stream.
+
+| Topic          | Topics tuple                          | Data payload                                          | Emitted when                        |
+|----------------|---------------------------------------|-------------------------------------------------------|-------------------------------------|
+| `gov_init`     | `(gov_init, admin)`                   | `(voting_period, timestamp)`                          | Contract initialized                |
+| `gov_created`  | `(gov_created, proposer, proposal_id)`| `(title, voting_ends_at, timestamp)`                  | Proposal created                    |
+| `gov_voted`    | `(gov_voted, voter, proposal_id)`     | `(choice, weight, votes_for, votes_against, timestamp)`| Vote cast                          |
+| `gov_executed` | `(gov_executed, executor, proposal_id)`| `(votes_for, votes_against, timestamp)`              | Passing proposal executed           |
+| `gov_rejected` | `(gov_rejected, proposal_id)`         | `(votes_for, votes_against, timestamp)`               | Proposal finalized as rejected      |
+| `gov_canceled` | `(gov_canceled, caller, proposal_id)` | `timestamp`                                           | Proposal canceled                   |
+| `gov_status`   | `(gov_status, proposal_id)`           | `(old_status, new_status, timestamp)`                 | Any proposal status change (generic)|
+| `gov_admin_xf` | `(gov_admin_xf, previous_admin, new_admin)`| `timestamp`                                      | Admin transferred                   |
+
+These topic strings are part of the contract's public API and never change.
+
+## Entrypoints
+
+| Function            | Auth                          | Description                                              |
+|---------------------|-------------------------------|----------------------------------------------------------|
+| `initialize`        | admin                         | One-time init with admin + default voting period (secs). |
+| `create_proposal`   | proposer                      | Create a proposal; returns its id.                       |
+| `cast_vote`         | voter                         | Cast a weighted `For`/`Against` vote (once per account). |
+| `execute_proposal`  | any (permissionless)          | Finalize after voting closes → `Executed` or `Rejected`. |
+| `cancel_proposal`   | proposer **or** admin         | Cancel an active proposal.                               |
+| `transfer_admin`    | current admin                 | Transfer admin role.                                     |
+| `version`           | none (read-only)              | Contract version (`u32`).                                |
+| `get_admin`         | none (read-only)              | Current admin address.                                   |
+| `get_proposal`      | none (read-only)              | Fetch a proposal by id.                                  |
+| `has_voted`         | none (read-only)              | Whether an address has voted on a proposal.              |
+
+Every state-changing entrypoint calls `require_auth()` on its acting principal.
+Arithmetic on ids, deadlines, and vote tallies is overflow-safe (`checked_add`),
+and production paths contain no `unwrap()`.
+
+## Errors
+
+Typed `#[contracterror]` codes (stable, never reassigned): `Unauthorized (1)`,
+`NotInitialized (2)`, `AlreadyInitialized (3)`, `ProposalNotFound (4)`,
+`InvalidStateTransition (5)`, `AlreadyVoted (6)`, `VotingOpen (7)`,
+`VotingClosed (8)`, `InvalidVotingPeriod (9)`, `Overflow (10)`.
+
+## Tests
+
+- `tests/governance_lifecycle.rs` — creation, voting, execution/rejection,
+  cancellation, admin transfer, and every guard rail.
+- `tests/events.rs` — asserts each lifecycle event's stable topic and decodes
+  event payloads to verify their fields.
+- `tests/auth_boundary.rs` — asserts `require_auth()` is enforced on the correct
+  principal and that role-gated entrypoints reject the wrong caller.
+
+Run with `cargo test -p governance`.

--- a/contracts/governance/src/err.rs
+++ b/contracts/governance/src/err.rs
@@ -1,0 +1,36 @@
+//! Error types for the Governance contract.
+//!
+//! All state-changing entrypoints return typed errors via `#[contracterror]`.
+//! Each variant carries a stable integer code that forms part of the
+//! contract's public API surface and must not be reused or reordered.
+
+use soroban_sdk::contracterror;
+
+/// Errors returned by the Governance contract.
+///
+/// Each variant is assigned a stable integer code. Off-chain consumers may
+/// rely on these codes; existing codes must never be reassigned.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum GovernanceError {
+    /// Caller is not authorized for the action.
+    Unauthorized = 1,
+    /// Contract has not been initialized.
+    NotInitialized = 2,
+    /// Contract has already been initialized.
+    AlreadyInitialized = 3,
+    /// The referenced proposal does not exist.
+    ProposalNotFound = 4,
+    /// The proposal is not in a state that permits this transition.
+    InvalidStateTransition = 5,
+    /// The account has already voted on this proposal.
+    AlreadyVoted = 6,
+    /// The voting window for the proposal is still open.
+    VotingOpen = 7,
+    /// The voting window for the proposal has closed.
+    VotingClosed = 8,
+    /// The provided voting period is invalid (e.g. zero).
+    InvalidVotingPeriod = 9,
+    /// Arithmetic overflow occurred.
+    Overflow = 10,
+}

--- a/contracts/governance/src/events.rs
+++ b/contracts/governance/src/events.rs
@@ -1,0 +1,180 @@
+//! Structured lifecycle events for the Governance contract.
+//!
+//! Every governance lifecycle transition emits a typed event with a **stable
+//! topic symbol** so that off-chain indexers can filter, decode, and replay
+//! governance state transitions deterministically.
+//!
+//! # Design
+//!
+//! - The first topic of every event is a stable [`Symbol`]; these strings are
+//!   part of the contract's public API and must never change.
+//! - Identifying fields (actor [`Address`], proposal id) are placed in
+//!   **topics** so indexers can subscribe by key without decoding the payload.
+//! - Quantitative fields (vote tallies, timestamps) are placed in the **data**
+//!   payload.
+//! - In addition to the action-specific event, every change to a proposal's
+//!   [`ProposalStatus`] also emits a generic [`emit_status_changed`] event
+//!   carrying `(old, new)`. Indexers that only track lifecycle state can rely
+//!   on this single event stream regardless of which entrypoint caused the
+//!   transition.
+//!
+//! # Event Summary
+//!
+//! | Topic Symbol    | Emitted When                          |
+//! |-----------------|---------------------------------------|
+//! | `gov_init`      | Contract is initialized               |
+//! | `gov_created`   | A new proposal is created             |
+//! | `gov_voted`     | A vote is cast on a proposal          |
+//! | `gov_executed`  | A passing proposal is executed        |
+//! | `gov_rejected`  | A proposal is finalized as rejected   |
+//! | `gov_canceled`  | A proposal is canceled                |
+//! | `gov_status`    | A proposal's status changes (generic) |
+//! | `gov_admin_xf`  | Admin/ownership is transferred        |
+
+use soroban_sdk::{Address, Env, String, Symbol};
+
+use crate::types::{ProposalStatus, VoteChoice};
+
+/// Emit a `GovernanceInitialized` event.
+///
+/// Published once when the contract is initialized via
+/// [`crate::GovernanceContract::initialize`].
+///
+/// * Topics: `(gov_init, admin)`
+/// * Data: `(voting_period, timestamp)`
+pub fn emit_initialized(env: &Env, admin: &Address, voting_period: u64) {
+    let topics = (Symbol::new(env, "gov_init"), admin);
+    env.events()
+        .publish(topics, (voting_period, env.ledger().timestamp()));
+}
+
+/// Emit a `ProposalCreated` event.
+///
+/// Published when a new proposal is created via
+/// [`crate::GovernanceContract::create_proposal`].
+///
+/// * Topics: `(gov_created, proposer, proposal_id)`
+/// * Data: `(title, voting_ends_at, timestamp)`
+pub fn emit_proposal_created(
+    env: &Env,
+    proposer: &Address,
+    proposal_id: u64,
+    title: &String,
+    voting_ends_at: u64,
+) {
+    let topics = (Symbol::new(env, "gov_created"), proposer, proposal_id);
+    env.events().publish(
+        topics,
+        (title.clone(), voting_ends_at, env.ledger().timestamp()),
+    );
+}
+
+/// Emit a `VoteCast` event.
+///
+/// Published when a vote is recorded via
+/// [`crate::GovernanceContract::cast_vote`]. The running tallies are included
+/// so indexers can track the vote outcome without additional reads.
+///
+/// * Topics: `(gov_voted, voter, proposal_id)`
+/// * Data: `(choice, weight, votes_for, votes_against, timestamp)`
+pub fn emit_vote_cast(
+    env: &Env,
+    voter: &Address,
+    proposal_id: u64,
+    choice: VoteChoice,
+    weight: u64,
+    votes_for: u64,
+    votes_against: u64,
+) {
+    let topics = (Symbol::new(env, "gov_voted"), voter, proposal_id);
+    env.events().publish(
+        topics,
+        (
+            choice,
+            weight,
+            votes_for,
+            votes_against,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+/// Emit a `ProposalExecuted` event.
+///
+/// Published when a passing proposal is executed via
+/// [`crate::GovernanceContract::execute_proposal`].
+///
+/// * Topics: `(gov_executed, executor, proposal_id)`
+/// * Data: `(votes_for, votes_against, timestamp)`
+pub fn emit_proposal_executed(
+    env: &Env,
+    executor: &Address,
+    proposal_id: u64,
+    votes_for: u64,
+    votes_against: u64,
+) {
+    let topics = (Symbol::new(env, "gov_executed"), executor, proposal_id);
+    env.events()
+        .publish(topics, (votes_for, votes_against, env.ledger().timestamp()));
+}
+
+/// Emit a `ProposalRejected` event.
+///
+/// Published when a proposal is finalized without a passing majority via
+/// [`crate::GovernanceContract::execute_proposal`].
+///
+/// * Topics: `(gov_rejected, proposal_id)`
+/// * Data: `(votes_for, votes_against, timestamp)`
+pub fn emit_proposal_rejected(
+    env: &Env,
+    proposal_id: u64,
+    votes_for: u64,
+    votes_against: u64,
+) {
+    let topics = (Symbol::new(env, "gov_rejected"), proposal_id);
+    env.events()
+        .publish(topics, (votes_for, votes_against, env.ledger().timestamp()));
+}
+
+/// Emit a `ProposalCanceled` event.
+///
+/// Published when a proposal is canceled via
+/// [`crate::GovernanceContract::cancel_proposal`].
+///
+/// * Topics: `(gov_canceled, caller, proposal_id)`
+/// * Data: `timestamp`
+pub fn emit_proposal_canceled(env: &Env, caller: &Address, proposal_id: u64) {
+    let topics = (Symbol::new(env, "gov_canceled"), caller, proposal_id);
+    env.events().publish(topics, env.ledger().timestamp());
+}
+
+/// Emit a generic `ProposalStatusChanged` event.
+///
+/// Emitted on **every** transition of a proposal's [`ProposalStatus`], in
+/// addition to the action-specific event. Indexers that only need to track
+/// lifecycle state can subscribe to this single topic.
+///
+/// * Topics: `(gov_status, proposal_id)`
+/// * Data: `(old_status, new_status, timestamp)`
+pub fn emit_status_changed(
+    env: &Env,
+    proposal_id: u64,
+    old_status: ProposalStatus,
+    new_status: ProposalStatus,
+) {
+    let topics = (Symbol::new(env, "gov_status"), proposal_id);
+    env.events()
+        .publish(topics, (old_status, new_status, env.ledger().timestamp()));
+}
+
+/// Emit an `AdminTransferred` event.
+///
+/// Published when governance ownership is transferred via
+/// [`crate::GovernanceContract::transfer_admin`].
+///
+/// * Topics: `(gov_admin_xf, previous_admin, new_admin)`
+/// * Data: `timestamp`
+pub fn emit_admin_transferred(env: &Env, previous_admin: &Address, new_admin: &Address) {
+    let topics = (Symbol::new(env, "gov_admin_xf"), previous_admin, new_admin);
+    env.events().publish(topics, env.ledger().timestamp());
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,0 +1,497 @@
+//! Governance smart contract with structured lifecycle events.
+//!
+//! Implements a minimal, self-contained on-chain governance module: accounts
+//! create proposals, cast weighted votes during a bounded voting window, and
+//! proposals are finalized (executed or rejected) once voting closes. Every
+//! lifecycle transition emits a typed, structured event with a stable topic
+//! symbol for off-chain indexers — see [`events`].
+//!
+//! # Lifecycle
+//!
+//! ```text
+//!                       cast_vote (many)
+//!                      ┌──────────────┐
+//!                      ▼              │
+//! create_proposal → Active ──────────┘
+//!                      │
+//!        ┌─────────────┼──────────────┐
+//!        ▼ execute     ▼ execute       ▼ cancel
+//!    Executed       Rejected        Canceled
+//! ```
+//!
+//! A proposal starts [`Active`](types::ProposalStatus::Active) and moves to
+//! exactly one terminal state: `Executed`, `Rejected`, or `Canceled`.
+//!
+//! # Authorization
+//!
+//! - `initialize` — the initial admin must `require_auth()`.
+//! - `create_proposal` — the proposer must `require_auth()`.
+//! - `cast_vote` — the voter must `require_auth()`.
+//! - `cancel_proposal` — the original proposer **or** the admin.
+//! - `execute_proposal` — any authenticated caller (permissionless
+//!   finalization), but only after the voting window has closed.
+//! - `transfer_admin` — the current admin must `require_auth()`.
+//! - Read-only entrypoints require no authentication.
+//!
+//! # Event Topics
+//!
+//! | Topic          | Description                          |
+//! |----------------|--------------------------------------|
+//! | `gov_init`     | Contract initialized                 |
+//! | `gov_created`  | Proposal created                     |
+//! | `gov_voted`    | Vote cast                            |
+//! | `gov_executed` | Proposal executed                    |
+//! | `gov_rejected` | Proposal rejected                    |
+//! | `gov_canceled` | Proposal canceled                    |
+//! | `gov_status`   | Proposal status changed (generic)    |
+//! | `gov_admin_xf` | Admin transferred                    |
+
+#![no_std]
+
+mod err;
+mod events;
+mod types;
+
+pub use err::GovernanceError;
+pub use types::{Proposal, ProposalStatus, VoteChoice};
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Minimum remaining ledgers before a proposal entry is bumped on write.
+const PROPOSAL_TTL_THRESHOLD: u32 = 100_000;
+/// Extended TTL ledgers for proposal entries.
+const PROPOSAL_TTL_TO: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+/// Persistent / instance storage keys used by the Governance contract.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Whether the contract has been initialized (`bool`).
+    Initialized,
+    /// The current admin address (`Address`).
+    Admin,
+    /// Default voting period in seconds applied to new proposals (`u64`).
+    VotingPeriod,
+    /// Monotonic counter for the next proposal id (`u64`).
+    NextId,
+    /// A stored proposal, keyed by id (`Proposal`).
+    Proposal(u64),
+    /// Whether `(proposal_id, voter)` has already voted (`bool`).
+    HasVoted(u64, Address),
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct GovernanceContract;
+
+#[contractimpl]
+impl GovernanceContract {
+    // =======================================================================
+    // Initialization
+    // =======================================================================
+
+    /// Initialize the contract with an `admin` and a default `voting_period`
+    /// (in seconds) applied to newly created proposals.
+    ///
+    /// May only be called once. Emits a `gov_init` event.
+    ///
+    /// # Authorization
+    /// The `admin` must authenticate via `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::AlreadyInitialized`] if already initialized.
+    /// - [`GovernanceError::InvalidVotingPeriod`] if `voting_period` is zero.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        voting_period: u64,
+    ) -> Result<(), GovernanceError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(GovernanceError::AlreadyInitialized);
+        }
+        if voting_period == 0 {
+            return Err(GovernanceError::InvalidVotingPeriod);
+        }
+
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::VotingPeriod, &voting_period);
+        env.storage().instance().set(&DataKey::NextId, &0u64);
+
+        events::emit_initialized(&env, &admin, voting_period);
+
+        Ok(())
+    }
+
+    // =======================================================================
+    // State-changing entrypoints
+    // =======================================================================
+
+    /// Create a new proposal with the given `title`.
+    ///
+    /// The proposal starts in [`ProposalStatus::Active`] and its voting window
+    /// closes `voting_period` seconds after creation. Returns the new proposal
+    /// id. Emits `gov_created` and a `gov_status` event.
+    ///
+    /// # Authorization
+    /// The `proposer` must authenticate via `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    /// - [`GovernanceError::Overflow`] if the id counter or voting deadline
+    ///   would overflow.
+    pub fn create_proposal(
+        env: Env,
+        proposer: Address,
+        title: String,
+    ) -> Result<u64, GovernanceError> {
+        proposer.require_auth();
+        Self::require_initialized(&env)?;
+
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .unwrap_or(0u64);
+        let next = id.checked_add(1).ok_or(GovernanceError::Overflow)?;
+
+        let voting_period: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VotingPeriod)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        let created_at = env.ledger().timestamp();
+        let voting_ends_at = created_at
+            .checked_add(voting_period)
+            .ok_or(GovernanceError::Overflow)?;
+
+        let proposal = Proposal {
+            id,
+            proposer: proposer.clone(),
+            title: title.clone(),
+            status: ProposalStatus::Active,
+            votes_for: 0,
+            votes_against: 0,
+            created_at,
+            voting_ends_at,
+        };
+
+        Self::save_proposal(&env, &proposal);
+        env.storage().instance().set(&DataKey::NextId, &next);
+
+        events::emit_proposal_created(&env, &proposer, id, &title, voting_ends_at);
+        // A creation is, semantically, a transition into the Active state.
+        events::emit_status_changed(&env, id, ProposalStatus::Active, ProposalStatus::Active);
+
+        Ok(id)
+    }
+
+    /// Cast a weighted vote on an active proposal.
+    ///
+    /// Each account may vote at most once per proposal. Voting is only allowed
+    /// while the proposal is [`Active`](ProposalStatus::Active) and before its
+    /// `voting_ends_at` deadline. Emits a `gov_voted` event.
+    ///
+    /// # Authorization
+    /// The `voter` must authenticate via `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    /// - [`GovernanceError::ProposalNotFound`] if the proposal does not exist.
+    /// - [`GovernanceError::InvalidStateTransition`] if the proposal is not active.
+    /// - [`GovernanceError::VotingClosed`] if the voting window has closed.
+    /// - [`GovernanceError::AlreadyVoted`] if the account already voted.
+    /// - [`GovernanceError::Overflow`] if a vote tally would overflow.
+    pub fn cast_vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        choice: VoteChoice,
+        weight: u64,
+    ) -> Result<(), GovernanceError> {
+        voter.require_auth();
+        Self::require_initialized(&env)?;
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(GovernanceError::InvalidStateTransition);
+        }
+        if env.ledger().timestamp() >= proposal.voting_ends_at {
+            return Err(GovernanceError::VotingClosed);
+        }
+
+        let vote_key = DataKey::HasVoted(proposal_id, voter.clone());
+        if env.storage().persistent().has(&vote_key) {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+
+        match choice {
+            VoteChoice::For => {
+                proposal.votes_for = proposal
+                    .votes_for
+                    .checked_add(weight)
+                    .ok_or(GovernanceError::Overflow)?;
+            }
+            VoteChoice::Against => {
+                proposal.votes_against = proposal
+                    .votes_against
+                    .checked_add(weight)
+                    .ok_or(GovernanceError::Overflow)?;
+            }
+        }
+
+        env.storage().persistent().set(&vote_key, &true);
+        Self::save_proposal(&env, &proposal);
+
+        events::emit_vote_cast(
+            &env,
+            &voter,
+            proposal_id,
+            choice,
+            weight,
+            proposal.votes_for,
+            proposal.votes_against,
+        );
+
+        Ok(())
+    }
+
+    /// Finalize an active proposal after its voting window has closed.
+    ///
+    /// The proposal transitions to [`Executed`](ProposalStatus::Executed) if
+    /// `votes_for > votes_against`, otherwise to
+    /// [`Rejected`](ProposalStatus::Rejected). Permissionless: any
+    /// authenticated caller may finalize once voting has ended. Emits either a
+    /// `gov_executed` or `gov_rejected` event plus a `gov_status` event.
+    ///
+    /// # Authorization
+    /// The `caller` must authenticate via `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    /// - [`GovernanceError::ProposalNotFound`] if the proposal does not exist.
+    /// - [`GovernanceError::InvalidStateTransition`] if not active.
+    /// - [`GovernanceError::VotingOpen`] if the voting window is still open.
+    pub fn execute_proposal(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<ProposalStatus, GovernanceError> {
+        caller.require_auth();
+        Self::require_initialized(&env)?;
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(GovernanceError::InvalidStateTransition);
+        }
+        if env.ledger().timestamp() < proposal.voting_ends_at {
+            return Err(GovernanceError::VotingOpen);
+        }
+
+        let old_status = proposal.status;
+        let new_status = if proposal.votes_for > proposal.votes_against {
+            ProposalStatus::Executed
+        } else {
+            ProposalStatus::Rejected
+        };
+        proposal.status = new_status;
+        Self::save_proposal(&env, &proposal);
+
+        match new_status {
+            ProposalStatus::Executed => events::emit_proposal_executed(
+                &env,
+                &caller,
+                proposal_id,
+                proposal.votes_for,
+                proposal.votes_against,
+            ),
+            _ => events::emit_proposal_rejected(
+                &env,
+                proposal_id,
+                proposal.votes_for,
+                proposal.votes_against,
+            ),
+        }
+        events::emit_status_changed(&env, proposal_id, old_status, new_status);
+
+        Ok(new_status)
+    }
+
+    /// Cancel an active proposal before it is finalized.
+    ///
+    /// Only the original proposer or the admin may cancel. The proposal
+    /// transitions to [`Canceled`](ProposalStatus::Canceled). Emits a
+    /// `gov_canceled` event plus a `gov_status` event.
+    ///
+    /// # Authorization
+    /// The `caller` must authenticate via `require_auth()` and be either the
+    /// proposer or the admin.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    /// - [`GovernanceError::ProposalNotFound`] if the proposal does not exist.
+    /// - [`GovernanceError::InvalidStateTransition`] if not active.
+    /// - [`GovernanceError::Unauthorized`] if caller is neither proposer nor admin.
+    pub fn cancel_proposal(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        Self::require_initialized(&env)?;
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(GovernanceError::InvalidStateTransition);
+        }
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(GovernanceError::NotInitialized)?;
+        if caller != proposal.proposer && caller != admin {
+            return Err(GovernanceError::Unauthorized);
+        }
+
+        let old_status = proposal.status;
+        proposal.status = ProposalStatus::Canceled;
+        Self::save_proposal(&env, &proposal);
+
+        events::emit_proposal_canceled(&env, &caller, proposal_id);
+        events::emit_status_changed(
+            &env,
+            proposal_id,
+            old_status,
+            ProposalStatus::Canceled,
+        );
+
+        Ok(())
+    }
+
+    /// Transfer contract administration to a `new_admin`.
+    ///
+    /// Emits a `gov_admin_xf` event.
+    ///
+    /// # Authorization
+    /// The `current_admin` must authenticate via `require_auth()` and be the
+    /// registered admin.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    /// - [`GovernanceError::Unauthorized`] if caller is not the admin.
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), GovernanceError> {
+        current_admin.require_auth();
+        Self::require_initialized(&env)?;
+        Self::require_admin(&env, &current_admin)?;
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        events::emit_admin_transferred(&env, &current_admin, &new_admin);
+
+        Ok(())
+    }
+
+    // =======================================================================
+    // Read-only entrypoints (no auth required)
+    // =======================================================================
+
+    /// Return the contract's numeric version.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
+
+    /// Return the current admin address.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] if contract not initialized.
+    pub fn get_admin(env: Env) -> Result<Address, GovernanceError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(GovernanceError::NotInitialized)
+    }
+
+    /// Return a stored proposal by `proposal_id`.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::ProposalNotFound`] if the proposal does not exist.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, GovernanceError> {
+        Self::load_proposal(&env, proposal_id)
+    }
+
+    /// Return whether `voter` has already voted on `proposal_id`.
+    pub fn has_voted(env: Env, proposal_id: u64, voter: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::HasVoted(proposal_id, voter))
+    }
+
+    // =======================================================================
+    // Internal helpers
+    // =======================================================================
+
+    /// Assert the contract is initialized.
+    fn require_initialized(env: &Env) -> Result<(), GovernanceError> {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return Err(GovernanceError::NotInitialized);
+        }
+        Ok(())
+    }
+
+    /// Assert that `caller` is the registered admin.
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), GovernanceError> {
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(GovernanceError::NotInitialized)?;
+        if caller != &stored {
+            return Err(GovernanceError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    /// Load a proposal from persistent storage.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::ProposalNotFound`] if the proposal does not exist.
+    fn load_proposal(env: &Env, proposal_id: u64) -> Result<Proposal, GovernanceError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(GovernanceError::ProposalNotFound)
+    }
+
+    /// Persist a proposal and extend its TTL.
+    fn save_proposal(env: &Env, proposal: &Proposal) {
+        let key = DataKey::Proposal(proposal.id);
+        env.storage().persistent().set(&key, proposal);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PROPOSAL_TTL_THRESHOLD, PROPOSAL_TTL_TO);
+    }
+}

--- a/contracts/governance/src/types.rs
+++ b/contracts/governance/src/types.rs
@@ -1,0 +1,62 @@
+//! Shared data types for the Governance contract.
+//!
+//! These types are part of the contract's public API and are exported so that
+//! clients and off-chain indexers can decode stored state and event payloads.
+
+use soroban_sdk::{contracttype, Address, String};
+
+/// Lifecycle state of a governance proposal.
+///
+/// A proposal always begins in [`ProposalStatus::Active`] and transitions to
+/// exactly one terminal state. The numeric discriminants are stable and form
+/// part of the contract's public API — they must not be reordered.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProposalStatus {
+    /// The proposal is open for voting.
+    Active = 0,
+    /// Voting closed with more `for` than `against` votes and the proposal
+    /// was executed.
+    Executed = 1,
+    /// Voting closed without a passing majority.
+    Rejected = 2,
+    /// The proposer (or admin) withdrew the proposal before finalization.
+    Canceled = 3,
+}
+
+/// Direction of a cast vote.
+///
+/// The numeric discriminants are stable and part of the public API.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VoteChoice {
+    /// A vote against the proposal.
+    Against = 0,
+    /// A vote in favor of the proposal.
+    For = 1,
+}
+
+/// A governance proposal record persisted in contract storage.
+///
+/// The full proposal is emitted as part of lifecycle events so that indexers
+/// can reconstruct proposal state without additional reads.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    /// Monotonic identifier, unique per contract instance.
+    pub id: u64,
+    /// Account that created the proposal.
+    pub proposer: Address,
+    /// Human-readable title / summary of the proposal.
+    pub title: String,
+    /// Current lifecycle state.
+    pub status: ProposalStatus,
+    /// Cumulative weight of `for` votes.
+    pub votes_for: u64,
+    /// Cumulative weight of `against` votes.
+    pub votes_against: u64,
+    /// Ledger timestamp (seconds) at which the proposal was created.
+    pub created_at: u64,
+    /// Ledger timestamp (seconds) after which voting is closed (exclusive).
+    pub voting_ends_at: u64,
+}

--- a/contracts/governance/tests/auth_boundary.rs
+++ b/contracts/governance/tests/auth_boundary.rs
@@ -1,0 +1,174 @@
+#![cfg(test)]
+
+//! Authorization-boundary tests for the Governance contract.
+//!
+//! Every state-changing entrypoint must call `require_auth()` on its acting
+//! principal. These tests use `mock_auths` (rather than `mock_all_auths`) so
+//! that the host records exactly which address each entrypoint required, then
+//! assert that the recorded principal is the expected one. They also assert
+//! that role-gated entrypoints reject the wrong caller with a typed error.
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String,
+};
+
+use governance::{GovernanceContract, GovernanceContractClient, GovernanceError, VoteChoice};
+
+const VOTING_PERIOD: u64 = 3_600;
+const START_TS: u64 = 1_735_689_600;
+
+fn base_env() -> Env {
+    let env = Env::default();
+    env.ledger().set(LedgerInfo {
+        timestamp: START_TS,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 518_400,
+    });
+    env
+}
+
+/// `initialize` must require the admin's authorization.
+#[test]
+fn test_initialize_requires_admin_auth() {
+    let env = base_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (admin.clone(), VOTING_PERIOD).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&admin, &VOTING_PERIOD);
+
+    // The recorded auth must be attributed to `admin`.
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1);
+    assert_eq!(auths[0].0, admin);
+}
+
+/// `create_proposal` must require the proposer's auth, not anyone else's.
+#[test]
+fn test_create_proposal_requires_proposer_auth() {
+    let env = base_env();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    let proposer = Address::generate(&env);
+    client
+        .mock_auths(&[MockAuth {
+            address: &proposer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "create_proposal",
+                args: (proposer.clone(), String::from_str(&env, "P")).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .create_proposal(&proposer, &String::from_str(&env, "P"));
+
+    assert_eq!(env.auths()[0].0, proposer);
+}
+
+/// `cast_vote` must require the voter's auth.
+#[test]
+fn test_cast_vote_requires_voter_auth() {
+    let env = base_env();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+
+    let voter = Address::generate(&env);
+    client
+        .mock_auths(&[MockAuth {
+            address: &voter,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "cast_vote",
+                args: (voter.clone(), id, VoteChoice::For, 3u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .cast_vote(&voter, &id, &VoteChoice::For, &3);
+
+    assert_eq!(env.auths()[0].0, voter);
+}
+
+/// `transfer_admin` must require the current admin's auth.
+#[test]
+fn test_transfer_admin_requires_current_admin_auth() {
+    let env = base_env();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    let new_admin = Address::generate(&env);
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "transfer_admin",
+                args: (admin.clone(), new_admin.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .transfer_admin(&admin, &new_admin);
+
+    assert_eq!(env.auths()[0].0, admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+/// A non-admin, non-proposer caller cannot cancel a proposal even with a
+/// valid signature: the contract rejects it with `Unauthorized`.
+#[test]
+fn test_cancel_by_stranger_rejected_even_with_auth() {
+    let env = base_env();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    let proposer = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let id = client.create_proposal(&proposer, &String::from_str(&env, "P"));
+
+    let res = client.try_cancel_proposal(&stranger, &id);
+    assert_eq!(res, Ok(Err(GovernanceError::Unauthorized)));
+}
+
+/// A non-admin caller cannot transfer admin even with a valid signature.
+#[test]
+fn test_transfer_admin_by_non_admin_rejected() {
+    let env = base_env();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    let stranger = Address::generate(&env);
+    let res = client.try_transfer_admin(&stranger, &stranger);
+    assert_eq!(res, Ok(Err(GovernanceError::Unauthorized)));
+}

--- a/contracts/governance/tests/events.rs
+++ b/contracts/governance/tests/events.rs
@@ -1,0 +1,175 @@
+#![cfg(test)]
+
+//! Event-emission tests for the Governance contract. Verifies that every
+//! lifecycle transition publishes a structured event with the expected stable
+//! topic symbol and payload, so off-chain indexers can rely on the schema.
+
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger, LedgerInfo},
+    Address, Env, String, Symbol, TryIntoVal, Val,
+};
+
+use governance::{GovernanceContract, GovernanceContractClient, ProposalStatus, VoteChoice};
+
+const VOTING_PERIOD: u64 = 3_600;
+const START_TS: u64 = 1_735_689_600;
+
+fn ledger(env: &Env, ts: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: ts,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 518_400,
+    });
+}
+
+/// Returns true if any published event has `symbol` as its first topic.
+fn has_event_topic(env: &Env, contract: &Address, symbol: &str) -> bool {
+    let target = Symbol::new(env, symbol);
+    env.events().all().iter().any(|(cid, topics, _data)| {
+        if &cid != contract || topics.is_empty() {
+            return false;
+        }
+        let first: Val = topics.get(0).unwrap();
+        let first_sym: Result<Symbol, _> = first.try_into_val(env);
+        matches!(first_sym, Ok(sym) if sym == target)
+    })
+}
+
+fn setup() -> (Env, Address, GovernanceContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    ledger(&env, START_TS);
+
+    let admin = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    (env, contract_id, client, admin, voter)
+}
+
+#[test]
+fn test_initialize_emits_event() {
+    let (env, cid, _client, _admin, _voter) = setup();
+    assert!(has_event_topic(&env, &cid, "gov_init"));
+}
+
+#[test]
+fn test_create_proposal_emits_created_and_status() {
+    let (env, cid, client, _admin, _voter) = setup();
+    client.create_proposal(&_admin, &String::from_str(&env, "P"));
+    assert!(has_event_topic(&env, &cid, "gov_created"));
+    assert!(has_event_topic(&env, &cid, "gov_status"));
+}
+
+#[test]
+fn test_cast_vote_emits_voted() {
+    let (env, cid, client, _admin, voter) = setup();
+    let id = client.create_proposal(&_admin, &String::from_str(&env, "P"));
+    client.cast_vote(&voter, &id, &VoteChoice::For, &7);
+    assert!(has_event_topic(&env, &cid, "gov_voted"));
+}
+
+#[test]
+fn test_execute_emits_executed() {
+    let (env, cid, client, admin, voter) = setup();
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+    client.cast_vote(&voter, &id, &VoteChoice::For, &1);
+    ledger(&env, START_TS + VOTING_PERIOD);
+    client.execute_proposal(&admin, &id);
+    assert!(has_event_topic(&env, &cid, "gov_executed"));
+}
+
+#[test]
+fn test_reject_emits_rejected() {
+    let (env, cid, client, admin, _voter) = setup();
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+    ledger(&env, START_TS + VOTING_PERIOD);
+    client.execute_proposal(&admin, &id);
+    assert!(has_event_topic(&env, &cid, "gov_rejected"));
+}
+
+#[test]
+fn test_cancel_emits_canceled() {
+    let (env, cid, client, admin, _voter) = setup();
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+    client.cancel_proposal(&admin, &id);
+    assert!(has_event_topic(&env, &cid, "gov_canceled"));
+}
+
+#[test]
+fn test_transfer_admin_emits_event() {
+    let (env, cid, client, admin, voter) = setup();
+    client.transfer_admin(&admin, &voter);
+    assert!(has_event_topic(&env, &cid, "gov_admin_xf"));
+}
+
+#[test]
+fn test_vote_event_payload_carries_tallies() {
+    let (env, _cid, client, admin, voter) = setup();
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+    client.cast_vote(&voter, &id, &VoteChoice::For, &9);
+
+    // Locate the gov_voted event and assert its data payload matches
+    // (choice, weight, votes_for, votes_against, timestamp).
+    let target = Symbol::new(&env, "gov_voted");
+    let found = env.events().all().iter().find_map(|(_cid, topics, data)| {
+        let first: Val = topics.get(0)?;
+        let sym: Symbol = first.try_into_val(&env).ok()?;
+        if sym == target {
+            Some(data)
+        } else {
+            None
+        }
+    });
+    let data = found.expect("gov_voted event present");
+    // Decode the payload into a Rust tuple and compare by value. Comparing
+    // `Val == Val` directly is wrong for object-typed payloads: the tuple is
+    // stored behind a host object handle, so two structurally-equal tuples
+    // carry different handles and never compare equal.
+    let decoded: (VoteChoice, u64, u64, u64, u64) = data.try_into_val(&env).unwrap();
+    assert_eq!(decoded, (VoteChoice::For, 9u64, 9u64, 0u64, START_TS));
+}
+
+#[test]
+fn test_status_event_payload_on_execution() {
+    let (env, _cid, client, admin, voter) = setup();
+    let id = client.create_proposal(&admin, &String::from_str(&env, "P"));
+    client.cast_vote(&voter, &id, &VoteChoice::For, &1);
+    ledger(&env, START_TS + VOTING_PERIOD);
+    client.execute_proposal(&admin, &id);
+
+    // The final gov_status event should carry (Active, Executed, timestamp).
+    let target = Symbol::new(&env, "gov_status");
+    let last = env
+        .events()
+        .all()
+        .iter()
+        .filter_map(|(_cid, topics, data)| {
+            let first: Val = topics.get(0)?;
+            let sym: Symbol = first.try_into_val(&env).ok()?;
+            if sym == target {
+                Some(data)
+            } else {
+                None
+            }
+        })
+        .last()
+        .expect("gov_status event present");
+    // Decode into a Rust tuple and compare by value (see note above).
+    let decoded: (ProposalStatus, ProposalStatus, u64) = last.try_into_val(&env).unwrap();
+    assert_eq!(
+        decoded,
+        (
+            ProposalStatus::Active,
+            ProposalStatus::Executed,
+            START_TS + VOTING_PERIOD,
+        )
+    );
+}

--- a/contracts/governance/tests/governance_lifecycle.rs
+++ b/contracts/governance/tests/governance_lifecycle.rs
@@ -1,0 +1,265 @@
+#![cfg(test)]
+
+//! Lifecycle tests for the Governance contract: creation, voting, execution,
+//! rejection, cancellation, and admin transfer, plus the guard rails on each
+//! transition.
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env, String,
+};
+
+use governance::{
+    GovernanceContract, GovernanceContractClient, GovernanceError, ProposalStatus, VoteChoice,
+};
+
+const VOTING_PERIOD: u64 = 3_600;
+const START_TS: u64 = 1_735_689_600;
+
+struct TestSetup {
+    admin: Address,
+    alice: Address,
+    bob: Address,
+    carol: Address,
+    client: GovernanceContractClient<'static>,
+}
+
+fn setup() -> (Env, TestSetup) {    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: START_TS,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 518_400,
+    });
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &VOTING_PERIOD);
+
+    (
+        env,
+        TestSetup {
+            admin,
+            alice,
+            bob,
+            carol,
+            client,
+        },
+    )
+}
+
+fn advance_to(env: &Env, ts: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: ts,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 518_400,
+    });
+}
+
+#[test]
+fn test_initialize_sets_admin_and_version() {
+    let (_env, s) = setup();
+    assert_eq!(s.client.get_admin(), s.admin);
+    assert_eq!(s.client.version(), 1);
+}
+
+#[test]
+fn test_initialize_rejects_double_init() {
+    let (_env, s) = setup();
+    let res = s.client.try_initialize(&s.admin, &VOTING_PERIOD);
+    assert_eq!(res, Ok(Err(GovernanceError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_initialize_rejects_zero_voting_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    let res = client.try_initialize(&admin, &0u64);
+    assert_eq!(res, Ok(Err(GovernanceError::InvalidVotingPeriod)));
+}
+
+#[test]
+fn test_create_proposal_increments_ids() {
+    let (env, s) = setup();
+    let id0 = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "First"));
+    let id1 = s
+        .client
+        .create_proposal(&s.bob, &String::from_str(&env, "Second"));
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+
+    let p = s.client.get_proposal(&id0);
+    assert_eq!(p.proposer, s.alice);
+    assert_eq!(p.status, ProposalStatus::Active);
+    assert_eq!(p.votes_for, 0);
+    assert_eq!(p.votes_against, 0);
+    assert_eq!(p.created_at, START_TS);
+    assert_eq!(p.voting_ends_at, START_TS + VOTING_PERIOD);
+}
+
+#[test]
+fn test_get_missing_proposal_errors() {
+    let (_env, s) = setup();
+    let res = s.client.try_get_proposal(&99);
+    assert_eq!(res, Ok(Err(GovernanceError::ProposalNotFound)));
+}
+
+#[test]
+fn test_vote_tallies_and_execution_pass() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "Fund grant"));
+
+    s.client.cast_vote(&s.alice, &id, &VoteChoice::For, &10);
+    s.client.cast_vote(&s.bob, &id, &VoteChoice::For, &5);
+    s.client.cast_vote(&s.carol, &id, &VoteChoice::Against, &4);
+
+    let p = s.client.get_proposal(&id);
+    assert_eq!(p.votes_for, 15);
+    assert_eq!(p.votes_against, 4);
+    assert!(s.client.has_voted(&id, &s.alice));
+
+    advance_to(&env, START_TS + VOTING_PERIOD);
+    let outcome = s.client.execute_proposal(&s.admin, &id);
+    assert_eq!(outcome, ProposalStatus::Executed);
+    assert_eq!(s.client.get_proposal(&id).status, ProposalStatus::Executed);
+}
+
+#[test]
+fn test_execution_rejects_when_not_passing() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "Tie proposal"));
+    s.client.cast_vote(&s.alice, &id, &VoteChoice::For, &3);
+    s.client.cast_vote(&s.bob, &id, &VoteChoice::Against, &3);
+
+    advance_to(&env, START_TS + VOTING_PERIOD);
+    // A tie does not pass (requires strict majority for).
+    let outcome = s.client.execute_proposal(&s.carol, &id);
+    assert_eq!(outcome, ProposalStatus::Rejected);
+}
+
+#[test]
+fn test_double_vote_rejected() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    s.client.cast_vote(&s.alice, &id, &VoteChoice::For, &1);
+    let res = s
+        .client
+        .try_cast_vote(&s.alice, &id, &VoteChoice::For, &1);
+    assert_eq!(res, Ok(Err(GovernanceError::AlreadyVoted)));
+}
+
+#[test]
+fn test_vote_after_close_rejected() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    advance_to(&env, START_TS + VOTING_PERIOD);
+    let res = s
+        .client
+        .try_cast_vote(&s.bob, &id, &VoteChoice::For, &1);
+    assert_eq!(res, Ok(Err(GovernanceError::VotingClosed)));
+}
+
+#[test]
+fn test_execute_before_close_rejected() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    let res = s.client.try_execute_proposal(&s.admin, &id);
+    assert_eq!(res, Ok(Err(GovernanceError::VotingOpen)));
+}
+
+#[test]
+fn test_cancel_by_proposer_and_blocks_votes() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    s.client.cancel_proposal(&s.alice, &id);
+    assert_eq!(s.client.get_proposal(&id).status, ProposalStatus::Canceled);
+
+    let res = s
+        .client
+        .try_cast_vote(&s.bob, &id, &VoteChoice::For, &1);
+    assert_eq!(res, Ok(Err(GovernanceError::InvalidStateTransition)));
+}
+
+#[test]
+fn test_cancel_by_admin() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    s.client.cancel_proposal(&s.admin, &id);
+    assert_eq!(s.client.get_proposal(&id).status, ProposalStatus::Canceled);
+}
+
+#[test]
+fn test_cancel_by_stranger_rejected() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    let res = s.client.try_cancel_proposal(&s.bob, &id);
+    assert_eq!(res, Ok(Err(GovernanceError::Unauthorized)));
+}
+
+#[test]
+fn test_double_execute_rejected() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    s.client.cast_vote(&s.alice, &id, &VoteChoice::For, &1);
+    advance_to(&env, START_TS + VOTING_PERIOD);
+    s.client.execute_proposal(&s.admin, &id);
+    let res = s.client.try_execute_proposal(&s.admin, &id);
+    assert_eq!(res, Ok(Err(GovernanceError::InvalidStateTransition)));
+}
+
+#[test]
+fn test_vote_overflow_guarded() {
+    let (env, s) = setup();
+    let id = s
+        .client
+        .create_proposal(&s.alice, &String::from_str(&env, "P"));
+    s.client
+        .cast_vote(&s.alice, &id, &VoteChoice::For, &u64::MAX);
+    let res = s.client.try_cast_vote(&s.bob, &id, &VoteChoice::For, &1);
+    assert_eq!(res, Ok(Err(GovernanceError::Overflow)));
+}
+
+#[test]
+fn test_transfer_admin() {
+    let (_env, s) = setup();
+    s.client.transfer_admin(&s.admin, &s.bob);
+    assert_eq!(s.client.get_admin(), s.bob);
+}


### PR DESCRIPTION
## Summary

Closes #1097.

Adds a self-contained **governance** contract that emits **stable, structured lifecycle events** on every governance state transition, so off-chain indexers can filter, decode, and replay governance state deterministically.

## Events

The first topic of every event is a stable `Symbol` (part of the public API, never changed). Identifying fields (actor address, proposal id) are **topics** so indexers can subscribe by key without decoding; tallies/timestamps are in the **data** payload. In addition to each action-specific event, **every** status transition also emits a generic `gov_status` event carrying `(old_status, new_status)`.

| Topic | Topics tuple | Data payload |
|---|---|---|
| `gov_init` | `(gov_init, admin)` | `(voting_period, timestamp)` |
| `gov_created` | `(gov_created, proposer, proposal_id)` | `(title, voting_ends_at, timestamp)` |
| `gov_voted` | `(gov_voted, voter, proposal_id)` | `(choice, weight, votes_for, votes_against, timestamp)` |
| `gov_executed` | `(gov_executed, executor, proposal_id)` | `(votes_for, votes_against, timestamp)` |
| `gov_rejected` | `(gov_rejected, proposal_id)` | `(votes_for, votes_against, timestamp)` |
| `gov_canceled` | `(gov_canceled, caller, proposal_id)` | `timestamp` |
| `gov_status` | `(gov_status, proposal_id)` | `(old_status, new_status, timestamp)` |
| `gov_admin_xf` | `(gov_admin_xf, previous_admin, new_admin)` | `timestamp` |

## Contract surface

`initialize`, `create_proposal`, `cast_vote`, `execute_proposal`, `cancel_proposal`, `transfer_admin`, plus read-only `version` / `get_admin` / `get_proposal` / `has_voted`.

## Security & correctness

- `require_auth()` on **every** state-changing entrypoint.
- Overflow-safe math (`checked_add`) for ids, voting deadlines, and vote tallies.
- No `unwrap()` in production paths; all fallible paths return typed `#[contracterror]` codes (stable, never reassigned).
- One-vote-per-account enforcement; voting-window and state-transition guards.

## Tests

- `tests/governance_lifecycle.rs` — creation, voting, execution/rejection, cancellation, admin transfer, and every guard rail.
- `tests/events.rs` — asserts each lifecycle event's stable topic and **decodes payloads** to verify their fields (avoids handle-based `Val` comparison).
- `tests/auth_boundary.rs` — asserts `require_auth()` is enforced on the correct principal and that role-gated entrypoints reject the wrong caller.

## Docs

`contracts/governance/README.md` documents the event schema, entrypoints, and error codes.

## Note

Also removes an invalid `[workspace.members]` block from the root `Cargo.toml` that made the workspace manifest fail to parse (this was present at the branch base; upstream has since fixed it, so this merges cleanly).