### PR TITLE
feat(betting): add per-account limits enforcement [b#077]

### DIFF
--- a/contracts/betting/Cargo.toml
+++ b/contracts/betting/Cargo.toml
@@ -35,3 +35,11 @@ path = "tests/auth_snap.rs"
 [[test]]
 name = "overflow_safety"
 path = "tests/overflow_safety.rs"
+
+[[test]]
+name = "limits_tests"
+path = "tests/limits_tests.rs"
+
+[[test]]
+name = "limits_err_stab"
+path = "tests/limits_err_stab.rs"

--- a/contracts/betting/src/lib.rs
+++ b/contracts/betting/src/lib.rs
@@ -25,6 +25,7 @@
 extern crate alloc;
 
 pub mod events;
+pub mod limits;
 
 /// Default instance storage TTL bump in ledgers (~30 days).
 pub const INSTANCE_TTL_LEDGERS: u32 = 535_680;

--- a/contracts/betting/src/limits.rs
+++ b/contracts/betting/src/limits.rs
@@ -1,0 +1,273 @@
+//! # Per-account betting limits
+//!
+//! This module enforces a configurable, admin-managed cap on how much a single
+//! account may stake (cumulatively) across all markets tracked by the betting
+//! subsystem.  The cap is **global** — it applies across every market, not
+//! per-market — and is enforced before any funds are transferred.
+//!
+//! ## Design
+//!
+//! | Concern | Choice |
+//! |---------|--------|
+//! | Storage | Persistent; keyed on `(LimitNs, account)` for usage, `GlobalCap` for the cap |
+//! | Auth | `admin.require_auth()` on every state-changing entrypoint |
+//! | Overflow | `i128::checked_add` on all accumulators; `None` → `Error::Overflow` |
+//! | TTL | Extended on every write (`LIMITS_TTL_LEDGERS`, ~365 days) |
+//! | Zero cap | Rejected as `PerAccountLimitInvalidConfig` |
+//! | No cap set | Uncapped — [`check_and_record`] always returns `Ok(())` |
+//!
+//! ## Storage key layout
+//!
+//! ```text
+//! GlobalCap                     → i128          (the ceiling, optional)
+//! LimitAdmin                    → Address        (who can change the cap)
+//! (LimitNs, account: Address)   → i128          (cumulative usage per account)
+//! ```
+//!
+//! ## Usage flow
+//!
+//! ```text
+//! 1. initialize(env, admin)               – one-time admin setup
+//! 2. set_global_cap(env, admin, cap)      – admin sets cap (cap > 0)
+//! 3. check_and_record(env, acct, amount)  – called on every bet, BEFORE funds move
+//! 4. get_usage(env, acct)                 – read-only query
+//! 5. get_global_cap(env)                  – read-only query
+//! 6. reset_usage(env, admin, acct)        – admin clears an account's usage
+//! 7. remove_global_cap(env, admin)        – admin removes the cap (uncapped)
+//! ```
+//!
+//! ## Error codes (frozen — see `tests/limits_err_stab.rs`)
+//!
+//! | Variant | Code | When raised |
+//! |---------|------|-------------|
+//! | `PerAccountLimitExceeded`     | 677 | Cumulative usage + amount > cap |
+//! | `PerAccountLimitInvalidConfig`| 678 | Admin supplies a cap ≤ 0 |
+
+#![allow(dead_code)]
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+
+use predictify_hybrid::Error;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §1  Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Namespace symbol used as the first element of per-account storage keys.
+/// Frozen: renaming this is a storage migration.
+pub const LIMIT_NS: Symbol = symbol_short!("BtLmNs");
+
+/// TTL extension applied to persistent entries on every write (~365 days).
+pub const LIMITS_TTL_LEDGERS: u32 = 6_307_200;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §2  Storage keys
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Top-level storage keys for the limits module.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LimitsDataKey {
+    /// Optional global per-account cap (`i128`).  Absent means uncapped.
+    GlobalCap,
+    /// Admin address that is permitted to mutate the cap and reset usage.
+    LimitAdmin,
+}
+
+/// Composite key for an individual account's cumulative usage.
+///
+/// Stored as `(LIMIT_NS, account)` so keys are namespaced away from any
+/// future module that might reuse the same env.
+fn usage_key(account: &Address) -> (Symbol, Address) {
+    (LIMIT_NS, account.clone())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §3  Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-account limits manager for the betting subsystem.
+///
+/// All methods are stateless helpers that act on a shared [`Env`].
+pub struct AccountLimits;
+
+impl AccountLimits {
+    // ─────────────────────────────────────────────────────────────────────────
+    // §3.1  Initialisation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Initialise the limits module with an admin address.
+    ///
+    /// **Authorization**: `admin` must call `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`Error::AlreadyInitialized`] if the admin is already set.
+    pub fn initialize(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        if env
+            .storage()
+            .persistent()
+            .has(&LimitsDataKey::LimitAdmin)
+        {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&LimitsDataKey::LimitAdmin, admin);
+        Self::extend_ttl_instance(env, &LimitsDataKey::LimitAdmin);
+        Ok(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §3.2  Cap management
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Set the global per-account cap to `cap`.
+    ///
+    /// `cap` must be strictly positive; zero is rejected as
+    /// [`Error::PerAccountLimitInvalidConfig`].
+    ///
+    /// **Authorization**: the registered admin must call `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] if no admin is registered.
+    /// - [`Error::PerAccountLimitInvalidConfig`] if `cap <= 0`.
+    pub fn set_global_cap(env: &Env, admin: &Address, cap: i128) -> Result<(), Error> {
+        Self::require_admin(env, admin)?;
+
+        if cap <= 0 {
+            return Err(Error::PerAccountLimitInvalidConfig);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&LimitsDataKey::GlobalCap, &cap);
+        Self::extend_ttl_instance(env, &LimitsDataKey::GlobalCap);
+        Ok(())
+    }
+
+    /// Remove the global cap entirely, making the system uncapped.
+    ///
+    /// After this call [`get_global_cap`] returns `None` and
+    /// [`check_and_record`] always succeeds.
+    ///
+    /// **Authorization**: the registered admin must call `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] if no admin is registered.
+    pub fn remove_global_cap(env: &Env, admin: &Address) -> Result<(), Error> {
+        Self::require_admin(env, admin)?;
+        env.storage()
+            .persistent()
+            .remove(&LimitsDataKey::GlobalCap);
+        Ok(())
+    }
+
+    /// Return the current global cap, or `None` if no cap is set (uncapped).
+    pub fn get_global_cap(env: &Env) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&LimitsDataKey::GlobalCap)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §3.3  Usage tracking
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Return the cumulative usage recorded for `account`.
+    ///
+    /// Returns `0` when no usage has been recorded (first bet or after
+    /// [`reset_usage`]).
+    pub fn get_usage(env: &Env, account: &Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&usage_key(account))
+            .unwrap_or(0i128)
+    }
+
+    /// Check whether `amount` would push `account` above the global cap,
+    /// and — if it would not — atomically record the new usage.
+    ///
+    /// This is the **hot path** and must be called **before** any fund
+    /// transfer.  It is intentionally not gated by `require_auth` because
+    /// the caller (the betting entrypoint) already authenticated the user.
+    ///
+    /// # Semantics
+    ///
+    /// * If no cap is set → always returns `Ok(())` without writing.
+    /// * If `current_usage + amount > cap` → returns `Err(PerAccountLimitExceeded)`.
+    /// * Otherwise → persists `current_usage + amount` and returns `Ok(())`.
+    ///
+    /// # Errors
+    /// - [`Error::Overflow`] if `current_usage + amount` overflows `i128`.
+    /// - [`Error::PerAccountLimitExceeded`] if the new total exceeds the cap.
+    pub fn check_and_record(env: &Env, account: &Address, amount: i128) -> Result<(), Error> {
+        let cap = match Self::get_global_cap(env) {
+            Some(c) => c,
+            None => return Ok(()), // uncapped
+        };
+
+        let current = Self::get_usage(env, account);
+        let new_total = current.checked_add(amount).ok_or(Error::Overflow)?;
+
+        if new_total > cap {
+            return Err(Error::PerAccountLimitExceeded);
+        }
+
+        let key = usage_key(account);
+        env.storage().persistent().set(&key, &new_total);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LIMITS_TTL_LEDGERS, LIMITS_TTL_LEDGERS);
+
+        Ok(())
+    }
+
+    /// Reset the recorded usage for `account` to zero.
+    ///
+    /// Useful when an admin needs to clear a stale entry (e.g. after a
+    /// market refund that reduces a user's effective exposure).
+    ///
+    /// **Authorization**: the registered admin must call `require_auth()`.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] if no admin is registered.
+    pub fn reset_usage(env: &Env, admin: &Address, account: &Address) -> Result<(), Error> {
+        Self::require_admin(env, admin)?;
+        let key = usage_key(account);
+        env.storage().persistent().remove(&key);
+        Ok(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §3.4  Admin helpers (private)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Require `caller` to be the registered admin and call `require_auth()`.
+    ///
+    /// Returns `Err(Error::Unauthorized)` if no admin is set or if `caller`
+    /// does not match the registered admin.
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&LimitsDataKey::LimitAdmin)
+            .ok_or(Error::Unauthorized)?;
+
+        if admin != *caller {
+            return Err(Error::Unauthorized);
+        }
+
+        caller.require_auth();
+        Ok(())
+    }
+
+    /// Extend TTL for a top-level limits key.
+    fn extend_ttl_instance(env: &Env, key: &LimitsDataKey) {
+        env.storage()
+            .persistent()
+            .extend_ttl(key, LIMITS_TTL_LEDGERS, LIMITS_TTL_LEDGERS);
+    }
+}

--- a/contracts/betting/tests/limits_err_stab.rs
+++ b/contracts/betting/tests/limits_err_stab.rs
@@ -1,0 +1,75 @@
+//! # Per-account limits — error-code stability tests
+//!
+//! These assertions freeze the numeric discriminants of the two error
+//! variants introduced by the per-account limits module.  Clients (SDKs,
+//! indexers, front-ends) may persist or branch on these values, so any
+//! change to a discriminant is a **visible API break** requiring a
+//! version bump and migration guide.
+//!
+//! ## Stability policy
+//!
+//! Once a discriminant appears here it is **frozen forever**.  Add new
+//! variants with explicit, previously-unused `u32` discriminants and pin
+//! them here in the same commit.  Never reuse a retired discriminant.
+//!
+//! | Variant                        | Code | Module               |
+//! |--------------------------------|------|----------------------|
+//! | `Error::PerAccountLimitExceeded`      | 677  | `betting::limits`    |
+//! | `Error::PerAccountLimitInvalidConfig` | 678  | `betting::limits`    |
+
+#![cfg(test)]
+
+use predictify_hybrid::Error;
+
+/// Both per-account limit error codes are frozen at their original values.
+#[test]
+fn per_account_limit_error_codes_are_stable() {
+    assert_eq!(Error::PerAccountLimitExceeded as u32, 677);
+    assert_eq!(Error::PerAccountLimitInvalidConfig as u32, 678);
+}
+
+/// The two new codes must not collide with any existing betting-path code.
+#[test]
+fn per_account_limit_error_codes_are_unique_among_betting_errors() {
+    let all_betting_codes: &[u32] = &[
+        // user-operation
+        Error::Unauthorized as u32,
+        Error::MarketNotFound as u32,
+        Error::MarketClosed as u32,
+        Error::MarketResolved as u32,
+        Error::MarketNotResolved as u32,
+        Error::NothingToClaim as u32,
+        Error::AlreadyClaimed as u32,
+        Error::InsufficientStake as u32,
+        Error::InvalidOutcome as u32,
+        Error::AlreadyBet as u32,
+        Error::BetsAlreadyPlaced as u32,
+        Error::InsufficientBalance as u32,
+        Error::BetCoolOffActive as u32,
+        // fee / cap
+        Error::FeeExceedsMax as u32,
+        Error::MaxBetCapExceeded as u32,
+        Error::InvalidCap as u32,
+        // batch idempotency
+        Error::IdempotentBatchAlreadyApplied as u32,
+        // general
+        Error::InvalidState as u32,
+        Error::InvalidInput as u32,
+        // overflow
+        Error::Overflow as u32,
+        // NEW – per-account limits
+        Error::PerAccountLimitExceeded as u32,
+        Error::PerAccountLimitInvalidConfig as u32,
+    ];
+
+    for (i, &a) in all_betting_codes.iter().enumerate() {
+        for (j, &b) in all_betting_codes.iter().enumerate() {
+            if i != j {
+                assert_ne!(
+                    a, b,
+                    "duplicate betting error code {a} at positions {i} and {j}"
+                );
+            }
+        }
+    }
+}

--- a/contracts/betting/tests/limits_tests.rs
+++ b/contracts/betting/tests/limits_tests.rs
@@ -1,0 +1,495 @@
+//! # Per-account betting limits — integration tests
+//!
+//! These tests cover the full public API of [`betting::limits::AccountLimits`]:
+//!
+//! | § | Area | What is verified |
+//! |---|------|------------------|
+//! | 1 | Initialisation | One-shot init, duplicate-init guard, auth requirement |
+//! | 2 | Cap management | Set/remove/query cap, zero-cap rejection |
+//! | 3 | Usage tracking | Single account, multi-account isolation, cumulative addition |
+//! | 4 | Enforcement | Under-cap pass, at-cap pass, over-cap rejection |
+//! | 5 | Admin reset | Usage reset clears entry; re-use starts from zero |
+//! | 6 | Uncapped mode | No cap → all amounts accepted |
+//! | 7 | Auth boundaries | State-changing calls without auth must fail |
+//! | 8 | Overflow safety | i128 accumulator checked_add never panics |
+
+#![cfg(test)]
+
+extern crate alloc;
+
+use betting::limits::{AccountLimits, LimitsDataKey, LIMIT_NS, LIMITS_TTL_LEDGERS};
+use predictify_hybrid::Error;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn env() -> Env {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.ledger().with_mut(|li| {
+        li.max_entry_ttl = 100_000_000;
+        li.min_persistent_entry_ttl = 1;
+        li.min_temp_entry_ttl = 1;
+    });
+    e
+}
+
+fn bare_env() -> Env {
+    // No mock_all_auths — used to check that auth IS required
+    let e = Env::default();
+    e.ledger().with_mut(|li| {
+        li.max_entry_ttl = 100_000_000;
+        li.min_persistent_entry_ttl = 1;
+        li.min_temp_entry_ttl = 1;
+    });
+    e
+}
+
+fn admin(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn user(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §1  Initialisation
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initialize_sets_admin() {
+    let env = env();
+    let a = admin(&env);
+
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    // Admin is now stored; set_global_cap succeeds.
+    AccountLimits::set_global_cap(&env, &a, 1_000_000).unwrap();
+    assert_eq!(AccountLimits::get_global_cap(&env), Some(1_000_000));
+}
+
+#[test]
+fn initialize_rejects_duplicate() {
+    let env = env();
+    let a = admin(&env);
+
+    AccountLimits::initialize(&env, &a).unwrap();
+    let second = AccountLimits::initialize(&env, &a);
+    assert_eq!(
+        second,
+        Err(Error::AlreadyInitialized),
+        "second initialize must return AlreadyInitialized"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §2  Cap management
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_global_cap_stores_positive_cap() {
+    let env = env();
+    let a = admin(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+    assert_eq!(AccountLimits::get_global_cap(&env), Some(5_000_000));
+}
+
+#[test]
+fn set_global_cap_rejects_zero() {
+    let env = env();
+    let a = admin(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    let result = AccountLimits::set_global_cap(&env, &a, 0);
+    assert_eq!(result, Err(Error::PerAccountLimitInvalidConfig));
+}
+
+#[test]
+fn set_global_cap_rejects_negative() {
+    let env = env();
+    let a = admin(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    let result = AccountLimits::set_global_cap(&env, &a, -1);
+    assert_eq!(result, Err(Error::PerAccountLimitInvalidConfig));
+}
+
+#[test]
+fn set_global_cap_can_be_updated() {
+    let env = env();
+    let a = admin(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    AccountLimits::set_global_cap(&env, &a, 1_000_000).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 2_000_000).unwrap();
+    assert_eq!(AccountLimits::get_global_cap(&env), Some(2_000_000));
+}
+
+#[test]
+fn remove_global_cap_makes_system_uncapped() {
+    let env = env();
+    let a = admin(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    AccountLimits::set_global_cap(&env, &a, 1_000_000).unwrap();
+    AccountLimits::remove_global_cap(&env, &a).unwrap();
+    assert_eq!(AccountLimits::get_global_cap(&env), None);
+}
+
+#[test]
+fn get_global_cap_returns_none_when_unset() {
+    let env = env();
+    assert_eq!(AccountLimits::get_global_cap(&env), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §3  Usage tracking
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn get_usage_returns_zero_for_fresh_account() {
+    let env = env();
+    let u = user(&env);
+    assert_eq!(AccountLimits::get_usage(&env, &u), 0i128);
+}
+
+#[test]
+fn check_and_record_accumulates_usage() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 10_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 1_000_000).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), 1_000_000);
+
+    AccountLimits::check_and_record(&env, &u, 2_000_000).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), 3_000_000);
+}
+
+#[test]
+fn usage_is_isolated_per_account() {
+    let env = env();
+    let a = admin(&env);
+    let u1 = user(&env);
+    let u2 = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 10_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u1, 3_000_000).unwrap();
+    AccountLimits::check_and_record(&env, &u2, 1_000_000).unwrap();
+
+    assert_eq!(AccountLimits::get_usage(&env, &u1), 3_000_000);
+    assert_eq!(AccountLimits::get_usage(&env, &u2), 1_000_000);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §4  Enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn check_and_record_allows_usage_under_cap() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    let result = AccountLimits::check_and_record(&env, &u, 4_999_999);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn check_and_record_allows_usage_exactly_at_cap() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    let result = AccountLimits::check_and_record(&env, &u, 5_000_000);
+    assert_eq!(result, Ok(()));
+    assert_eq!(AccountLimits::get_usage(&env, &u), 5_000_000);
+}
+
+#[test]
+fn check_and_record_rejects_usage_over_cap_first_bet() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    let result = AccountLimits::check_and_record(&env, &u, 5_000_001);
+    assert_eq!(result, Err(Error::PerAccountLimitExceeded));
+    // Usage must not have been written.
+    assert_eq!(
+        AccountLimits::get_usage(&env, &u),
+        0,
+        "usage must remain 0 after a rejected bet"
+    );
+}
+
+#[test]
+fn check_and_record_rejects_cumulative_over_cap() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 3_000_000).unwrap();
+    // 3_000_000 + 2_000_001 = 5_000_001 > 5_000_000
+    let result = AccountLimits::check_and_record(&env, &u, 2_000_001);
+    assert_eq!(result, Err(Error::PerAccountLimitExceeded));
+    // Usage must stay at the last committed value.
+    assert_eq!(AccountLimits::get_usage(&env, &u), 3_000_000);
+}
+
+#[test]
+fn check_and_record_allows_bet_exactly_filling_remaining_capacity() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 3_000_000).unwrap();
+    // Exactly fills remaining 2_000_000.
+    AccountLimits::check_and_record(&env, &u, 2_000_000).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), 5_000_000);
+}
+
+#[test]
+fn check_and_record_rejects_one_strobe_over_full_cap() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 5_000_000).unwrap();
+    // Cap is now full; any further bet must be rejected.
+    let result = AccountLimits::check_and_record(&env, &u, 1);
+    assert_eq!(result, Err(Error::PerAccountLimitExceeded));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5  Admin reset
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn reset_usage_clears_account_entry() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 10_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 4_000_000).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), 4_000_000);
+
+    AccountLimits::reset_usage(&env, &a, &u).unwrap();
+    assert_eq!(
+        AccountLimits::get_usage(&env, &u),
+        0,
+        "usage must be zero after reset"
+    );
+}
+
+#[test]
+fn after_reset_account_can_bet_again_up_to_cap() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, 5_000_000).unwrap();
+    AccountLimits::reset_usage(&env, &a, &u).unwrap();
+
+    // After reset the full cap is available again.
+    AccountLimits::check_and_record(&env, &u, 5_000_000).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), 5_000_000);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §6  Uncapped mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn check_and_record_always_succeeds_when_uncapped() {
+    let env = env();
+    let u = user(&env);
+    // No cap set at all.
+    for _ in 0..10 {
+        AccountLimits::check_and_record(&env, &u, i128::MAX / 10).unwrap();
+    }
+}
+
+#[test]
+fn check_and_record_succeeds_after_cap_removed() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 1_000_000).unwrap();
+    AccountLimits::remove_global_cap(&env, &a).unwrap();
+
+    // Now uncapped — large bet must pass.
+    AccountLimits::check_and_record(&env, &u, 999_999_999).unwrap();
+}
+
+#[test]
+fn uncapped_mode_does_not_write_usage() {
+    let env = env();
+    let u = user(&env);
+    // No initialize, no cap.
+    AccountLimits::check_and_record(&env, &u, 100_000).unwrap();
+    // Usage must remain 0 because we never persist when uncapped.
+    assert_eq!(AccountLimits::get_usage(&env, &u), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §7  Auth boundaries
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `set_global_cap` must require admin auth.
+///
+/// Using a bare env (no mock_all_auths) with a *different* address than the
+/// registered admin must return `Unauthorized`.
+#[test]
+fn set_global_cap_requires_admin_auth() {
+    let env = env();
+    let a = admin(&env);
+    let stranger = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+
+    let result = AccountLimits::set_global_cap(&env, &stranger, 1_000_000);
+    assert_eq!(
+        result,
+        Err(Error::Unauthorized),
+        "non-admin must not be able to set the cap"
+    );
+}
+
+/// `remove_global_cap` must require admin auth.
+#[test]
+fn remove_global_cap_requires_admin_auth() {
+    let env = env();
+    let a = admin(&env);
+    let stranger = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 1_000_000).unwrap();
+
+    let result = AccountLimits::remove_global_cap(&env, &stranger);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+/// `reset_usage` must require admin auth.
+#[test]
+fn reset_usage_requires_admin_auth() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    let stranger = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, 5_000_000).unwrap();
+    AccountLimits::check_and_record(&env, &u, 1_000_000).unwrap();
+
+    let result = AccountLimits::reset_usage(&env, &stranger, &u);
+    assert_eq!(result, Err(Error::Unauthorized));
+    // Usage must be unchanged.
+    assert_eq!(AccountLimits::get_usage(&env, &u), 1_000_000);
+}
+
+/// `set_global_cap` with no admin initialised must return `Unauthorized`.
+#[test]
+fn set_global_cap_without_initialized_admin_returns_unauthorized() {
+    let env = env();
+    let a = admin(&env);
+    // No initialize call.
+    let result = AccountLimits::set_global_cap(&env, &a, 1_000_000);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+/// `initialize` must require the caller to authenticate.
+///
+/// We use a bare env (no mock_all_auths) and verify that the call panics/
+/// host-errors because `require_auth` fails.
+#[test]
+#[should_panic]
+fn initialize_without_auth_panics() {
+    let env = bare_env();
+    let a = admin(&env);
+    // require_auth will panic in a bare env (no auth mocked).
+    let _ = AccountLimits::initialize(&env, &a);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §8  Overflow safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Accumulating exactly i128::MAX must succeed when the cap is also i128::MAX.
+#[test]
+fn check_and_record_allows_i128_max_exactly() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, i128::MAX).unwrap();
+
+    AccountLimits::check_and_record(&env, &u, i128::MAX).unwrap();
+    assert_eq!(AccountLimits::get_usage(&env, &u), i128::MAX);
+}
+
+/// Adding 1 to i128::MAX usage must return `Error::Overflow` (not panic).
+#[test]
+fn check_and_record_returns_overflow_on_i128_max_plus_one() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    AccountLimits::set_global_cap(&env, &a, i128::MAX).unwrap();
+
+    // Pre-seed usage to i128::MAX.
+    AccountLimits::check_and_record(&env, &u, i128::MAX).unwrap();
+
+    // Now any positive addition must overflow the accumulator.
+    let result = AccountLimits::check_and_record(&env, &u, 1);
+    assert_eq!(
+        result,
+        Err(Error::Overflow),
+        "i128::MAX + 1 must return Overflow, never panic"
+    );
+}
+
+/// checked_add itself returns None at boundary — validates the guard is sound.
+#[test]
+fn checked_add_i128_max_returns_none() {
+    let result = i128::MAX.checked_add(1);
+    assert!(result.is_none(), "i128::MAX + 1 must be None");
+}
+
+/// A cap set to i128::MAX - 1 must reject a bet of exactly 2 after 1 is used.
+#[test]
+fn cap_near_max_enforced_correctly() {
+    let env = env();
+    let a = admin(&env);
+    let u = user(&env);
+    AccountLimits::initialize(&env, &a).unwrap();
+    let cap = i128::MAX - 1;
+    AccountLimits::set_global_cap(&env, &a, cap).unwrap();
+
+    // Bet 1 — fine.
+    AccountLimits::check_and_record(&env, &u, 1).unwrap();
+    // Bet cap again — 1 + (cap) > cap — must be rejected.
+    let result = AccountLimits::check_and_record(&env, &u, cap);
+    assert_eq!(result, Err(Error::PerAccountLimitExceeded));
+}

--- a/contracts/predictify-hybrid/src/err.rs
+++ b/contracts/predictify-hybrid/src/err.rs
@@ -30,6 +30,13 @@ pub enum Error {
     /// a specific market via the `set_min_bet` entrypoint.  This is distinct from
     /// [`Error::InsufficientStake`] (which covers the global/per-event minimum).
     BetBelowMarketMin = 676,
+    /// The cumulative stake for this account would exceed the configured per-account
+    /// global limit.  Returned by [`betting::limits::AccountLimits::check_and_record`]
+    /// before any funds are transferred.
+    PerAccountLimitExceeded = 677,
+    /// An admin supplied an invalid configuration for the per-account limit (e.g. a
+    /// cap value of zero or a negative value).
+    PerAccountLimitInvalidConfig = 678,
     // ===== USER OPERATION ERRORS (100-112) =====
     /// User is not authorized to perform the requested action. Typically returned when
     /// a non-admin attempts to call admin-only functions.


### PR DESCRIPTION
Implements contracts/betting/src/limits.rs with AccountLimits module that caps cumulative per-account stake across all markets.

Changes:
- contracts/betting/src/limits.rs: new AccountLimits module with initialize, set_global_cap, remove_global_cap, get_global_cap, check_and_record, get_usage, reset_usage — all with require_auth on state-changing entrypoints and overflow-safe checked_add
- contracts/betting/src/lib.rs: expose pub mod limits
- contracts/betting/Cargo.toml: register limits_tests and limits_err_stab test targets
- contracts/betting/tests/limits_tests.rs: 30 focused tests covering init, cap management, usage tracking, enforcement, auth boundaries, uncapped mode, and overflow safety
- contracts/betting/tests/limits_err_stab.rs: freeze error discriminants PerAccountLimitExceeded=677 and PerAccountLimitInvalidConfig=678
- contracts/predictify-hybrid/src/err.rs: add two new frozen error variants at discriminants 677 and 678

Closes #1327