### PR TITLE
feat(allowlist): enforce per-account membership limits

### DIFF
--- a/contracts/allowlist/Cargo.toml
+++ b/contracts/allowlist/Cargo.toml
@@ -29,3 +29,7 @@ path = "tests/err_stab.rs"
 [[test]]
 name = "proptest"
 path = "tests/proptest.rs"
+
+[[test]]
+name = "limits"
+path = "tests/limits.rs"

--- a/contracts/allowlist/src/err.rs
+++ b/contracts/allowlist/src/err.rs
@@ -31,4 +31,8 @@ pub enum AllowlistError {
     InvalidInput = 9,
     /// Arithmetic overflow occurred.
     Overflow = 10,
+    /// The address has reached its configured per-account membership cap.
+    AccountLimitExceeded = 11,
+    /// Arithmetic underflow occurred while releasing membership capacity.
+    Underflow = 12,
 }

--- a/contracts/allowlist/src/events.rs
+++ b/contracts/allowlist/src/events.rs
@@ -15,8 +15,9 @@
 //! | `alist_deleted`  | An allowlist is deleted     |
 //! | `alist_owner_xf` | Ownership is transferred    |
 //! | `alist_init`     | Contract is initialized     |
+//! | `alist_limit_set` | Per-account cap is updated |
 
-use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{Address, Env, Symbol};
 
 /// Emit an `AllowlistCreated` event.
 ///
@@ -142,4 +143,14 @@ pub fn emit_allowlist_initialized(env: &Env, admin: &Address) {
         admin,
     );
     env.events().publish(topics, env.ledger().timestamp());
+}
+
+/// Emit an `AllowlistAccountLimitSet` event.
+///
+/// Published when the administrator changes the maximum number of allowlists
+/// that may contain one address.
+pub fn emit_account_limit_set(env: &Env, admin: &Address, max_memberships: u32) {
+    let topics = (Symbol::new(env, "alist_limit_set"), admin);
+    env.events()
+        .publish(topics, (max_memberships, env.ledger().timestamp()));
 }

--- a/contracts/allowlist/src/lib.rs
+++ b/contracts/allowlist/src/lib.rs
@@ -8,16 +8,19 @@
 //! # Overview
 //!
 //! The contract supports creating, populating, querying, and deleting
-//! independent allowlists. Every lifecycle transition — creation, address
-//! addition/removal, clear, deletion, and ownership transfer — emits a
-//! distinct event with a stable topic symbol and all relevant payload data.
+//! independent allowlists. An administrator-configured cap bounds how many
+//! allowlists may contain any one address. Every lifecycle transition —
+//! creation, address addition/removal, clear, deletion, ownership transfer,
+//! and limit update — emits a distinct event with a stable topic symbol and
+//! all relevant payload data.
 //!
 //! # Authorization
 //!
 //! - All state-changing entrypoints require `require_auth()` from the
 //!   registered admin address.
 //! - Read-only entrypoints (`is_allowed`, `get_allowlist`, `list_allowlists`,
-//!   `get_admin`, `version`) do not require authentication.
+//!   `get_account_limit`, `get_account_usage`, `get_admin`, `version`) do not
+//!   require authentication.
 //!
 //! # Event Topics
 //!
@@ -30,13 +33,16 @@
 //! | `alist_cleared`     | All addresses cleared                |
 //! | `alist_deleted`     | Entire allowlist deleted             |
 //! | `alist_owner_xf`    | Ownership transferred                |
+//! | `alist_limit_set`   | Per-account membership cap updated   |
 
 #![no_std]
 
 mod err;
 mod events;
+mod limits;
 
 pub use err::AllowlistError;
+pub use limits::{DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT, MAX_CONFIGURABLE_ACCOUNT_LIMIT};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Env, Symbol, Vec,
@@ -106,9 +112,8 @@ impl AllowlistContract {
 
         env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage()
-            .persistent()
-            .set(&DataKey::AllowlistRegistry, &Vec::<Symbol>::new(&env));
+        Self::save_registry(&env, &Vec::<Symbol>::new(&env));
+        limits::initialize(&env);
 
         events::emit_allowlist_initialized(&env, &admin);
 
@@ -157,9 +162,7 @@ impl AllowlistContract {
 
         if !registry.contains(&allowlist_id) {
             registry.push_back(allowlist_id.clone());
-            env.storage()
-                .persistent()
-                .set(&DataKey::AllowlistRegistry, &registry);
+            Self::save_registry(&env, &registry);
         }
 
         events::emit_allowlist_created(&env, &admin, &allowlist_id);
@@ -180,6 +183,9 @@ impl AllowlistContract {
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
     /// - [`AllowlistError::AddressAlreadyInAllowlist`] if the address is already present.
+    /// - [`AllowlistError::AccountLimitExceeded`] if the address has reached
+    ///   its per-account membership cap.
+    /// - [`AllowlistError::Overflow`] if the membership count cannot be incremented.
     pub fn add_address(
         env: Env,
         admin: Address,
@@ -196,6 +202,7 @@ impl AllowlistContract {
             return Err(AllowlistError::AddressAlreadyInAllowlist);
         }
 
+        limits::add_membership(&env, &address)?;
         addrs.push_back(address.clone());
         Self::save_allowlist(&env, &allowlist_id, &addrs);
 
@@ -217,6 +224,7 @@ impl AllowlistContract {
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
     /// - [`AllowlistError::AddressNotInAllowlist`] if the address is not present.
+    /// - [`AllowlistError::Underflow`] if membership usage is inconsistent.
     pub fn remove_address(
         env: Env,
         admin: Address,
@@ -233,6 +241,7 @@ impl AllowlistContract {
             return Err(AllowlistError::AddressNotInAllowlist);
         }
 
+        limits::remove_membership(&env, &address)?;
         let mut filtered: Vec<Address> = Vec::new(&env);
         for a in addrs.iter() {
             if a != address {
@@ -260,6 +269,9 @@ impl AllowlistContract {
     /// - [`AllowlistError::NotInitialized`] if contract not initialized.
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
+    /// - [`AllowlistError::AccountLimitExceeded`] if any new address has
+    ///   reached its per-account membership cap.
+    /// - [`AllowlistError::Overflow`] if a membership count cannot be incremented.
     pub fn add_addresses(
         env: Env,
         admin: Address,
@@ -274,6 +286,7 @@ impl AllowlistContract {
 
         for addr in addresses.iter() {
             if !addrs.contains(&addr) {
+                limits::add_membership(&env, &addr)?;
                 addrs.push_back(addr.clone());
                 events::emit_allowlist_address_added(&env, &admin, &allowlist_id, &addr);
             }
@@ -298,6 +311,7 @@ impl AllowlistContract {
     /// - [`AllowlistError::NotInitialized`] if contract not initialized.
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
+    /// - [`AllowlistError::Underflow`] if membership usage is inconsistent.
     pub fn remove_addresses(
         env: Env,
         admin: Address,
@@ -314,6 +328,7 @@ impl AllowlistContract {
         let mut remaining = Vec::new(&env);
         for a in addrs.iter() {
             if addresses.contains(&a) {
+                limits::remove_membership(&env, &a)?;
                 events::emit_allowlist_address_removed(&env, &admin, &allowlist_id, &a);
             } else {
                 remaining.push_back(a.clone());
@@ -337,6 +352,7 @@ impl AllowlistContract {
     /// - [`AllowlistError::NotInitialized`] if contract not initialized.
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
+    /// - [`AllowlistError::Underflow`] if membership usage is inconsistent.
     pub fn clear_allowlist(
         env: Env,
         admin: Address,
@@ -348,6 +364,10 @@ impl AllowlistContract {
 
         let addrs = Self::load_allowlist(&env, &allowlist_id)?;
         let count: u32 = addrs.len();
+
+        for address in addrs.iter() {
+            limits::remove_membership(&env, &address)?;
+        }
 
         // Replace with empty allowlist (via save_allowlist for TTL extension)
         Self::save_allowlist(&env, &allowlist_id, &Vec::<Address>::new(&env));
@@ -372,6 +392,7 @@ impl AllowlistContract {
     /// - [`AllowlistError::NotInitialized`] if contract not initialized.
     /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
     /// - [`AllowlistError::AllowlistNotFound`] if the allowlist does not exist.
+    /// - [`AllowlistError::Underflow`] if membership usage is inconsistent.
     pub fn delete_allowlist(
         env: Env,
         admin: Address,
@@ -383,6 +404,10 @@ impl AllowlistContract {
 
         let addrs = Self::load_allowlist(&env, &allowlist_id)?;
         let count: u32 = addrs.len();
+
+        for address in addrs.iter() {
+            limits::remove_membership(&env, &address)?;
+        }
 
         // Remove the allowlist data
         env.storage()
@@ -402,9 +427,7 @@ impl AllowlistContract {
                 filtered.push_back(id);
             }
         }
-        env.storage()
-            .persistent()
-            .set(&DataKey::AllowlistRegistry, &filtered);
+        Self::save_registry(&env, &filtered);
 
         events::emit_allowlist_deleted(&env, &admin, &allowlist_id, count);
 
@@ -441,6 +464,37 @@ impl AllowlistContract {
             .set(&DataKey::Admin, &new_admin);
 
         events::emit_allowlist_ownership_transferred(&env, &current_admin, &new_admin);
+
+        Ok(())
+    }
+
+    /// Update the maximum number of allowlists that may contain one address.
+    ///
+    /// The cap applies independently to every address. A value of zero blocks
+    /// new memberships. Lowering the cap does not remove existing memberships;
+    /// accounts at or above the new cap cannot be added to another allowlist
+    /// until enough memberships are removed.
+    ///
+    /// # Authorization
+    /// The `admin` must authenticate via `require_auth()` and be the
+    /// registered admin.
+    ///
+    /// # Errors
+    /// - [`AllowlistError::NotInitialized`] if contract not initialized.
+    /// - [`AllowlistError::Unauthorized`] if caller is not the admin.
+    /// - [`AllowlistError::InvalidInput`] if `max_memberships` exceeds
+    ///   [`MAX_CONFIGURABLE_ACCOUNT_LIMIT`].
+    pub fn set_account_limit(
+        env: Env,
+        admin: Address,
+        max_memberships: u32,
+    ) -> Result<(), AllowlistError> {
+        admin.require_auth();
+        Self::require_initialized(&env)?;
+        Self::require_admin(&env, &admin)?;
+
+        limits::set_account_limit(&env, max_memberships)?;
+        events::emit_account_limit_set(&env, &admin, max_memberships);
 
         Ok(())
     }
@@ -492,6 +546,19 @@ impl AllowlistContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Return the configured maximum memberships per account.
+    pub fn get_account_limit(env: Env) -> u32 {
+        limits::get_account_limit(&env)
+    }
+
+    /// Return the number of allowlists that currently contain `address`.
+    ///
+    /// # Errors
+    /// - [`AllowlistError::Overflow`] if the derived count cannot fit in a `u32`.
+    pub fn get_account_usage(env: Env, address: Address) -> Result<u32, AllowlistError> {
+        limits::get_account_usage(&env, &address)
+    }
+
     // =======================================================================
     // Internal helpers
     // =======================================================================
@@ -537,5 +604,23 @@ impl AllowlistContract {
         env.storage()
             .persistent()
             .extend_ttl(&key, ALLOWLIST_TTL_THRESHOLD, ALLOWLIST_TTL_TO);
+        Self::extend_registry_ttl(env);
+    }
+
+    /// Persist the allowlist registry with the same lifetime as list records.
+    fn save_registry(env: &Env, registry: &Vec<Symbol>) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowlistRegistry, registry);
+        Self::extend_registry_ttl(env);
+    }
+
+    /// Keep the authoritative registry alive whenever allowlist state changes.
+    fn extend_registry_ttl(env: &Env) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::AllowlistRegistry,
+            ALLOWLIST_TTL_THRESHOLD,
+            ALLOWLIST_TTL_TO,
+        );
     }
 }

--- a/contracts/allowlist/src/limits.rs
+++ b/contracts/allowlist/src/limits.rs
@@ -1,0 +1,161 @@
+//! Per-account allowlist-membership limits.
+//!
+//! Every address may belong to only a bounded number of allowlists. The
+//! configured cap applies independently to each address and is checked before
+//! either single-address or batch additions mutate storage.
+//!
+//! Membership counts are cached in persistent storage. If a cache entry has
+//! expired (or the contract was upgraded from a version without counters), the
+//! count is rebuilt from the authoritative allowlist registry before it is
+//! used. This prevents an expired counter from bypassing enforcement.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::{allowlist_storage_key, AllowlistError, DataKey};
+
+/// Default maximum number of allowlists that may contain one address.
+pub const DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT: u32 = 50;
+
+/// Hard upper bound for the configurable per-account membership cap.
+///
+/// The bound prevents an administrator from accidentally making the limit
+/// ineffective while still allowing deployments to choose a suitable cap.
+pub const MAX_CONFIGURABLE_ACCOUNT_LIMIT: u32 = 256;
+
+const ACCOUNT_COUNT_TTL_THRESHOLD: u32 = 100_000;
+const ACCOUNT_COUNT_TTL_TO: u32 = 518_400;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum LimitDataKey {
+    MaxMembershipsPerAccount,
+    AccountMembershipCount(Address),
+}
+
+/// Store the initial default cap during contract initialization.
+pub(crate) fn initialize(env: &Env) {
+    env.storage().instance().set(
+        &LimitDataKey::MaxMembershipsPerAccount,
+        &DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT,
+    );
+}
+
+/// Replace the cap applied independently to every account.
+///
+/// A zero cap is valid and disables new memberships without deleting existing
+/// ones. Existing accounts above a lowered cap retain their memberships but
+/// cannot be added to another allowlist until their usage falls below the cap.
+pub(crate) fn set_account_limit(env: &Env, max_memberships: u32) -> Result<(), AllowlistError> {
+    if max_memberships > MAX_CONFIGURABLE_ACCOUNT_LIMIT {
+        return Err(AllowlistError::InvalidInput);
+    }
+
+    env.storage()
+        .instance()
+        .set(&LimitDataKey::MaxMembershipsPerAccount, &max_memberships);
+    Ok(())
+}
+
+/// Return the configured cap, falling back to the default after an upgrade.
+pub(crate) fn get_account_limit(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&LimitDataKey::MaxMembershipsPerAccount)
+        .unwrap_or(DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT)
+}
+
+/// Return the number of allowlists that currently contain `account`.
+///
+/// A missing cached count is rebuilt from the authoritative registry, which
+/// supports upgrades and persistent-entry expiration without weakening the
+/// limit.
+pub(crate) fn get_account_usage(env: &Env, account: &Address) -> Result<u32, AllowlistError> {
+    let key = LimitDataKey::AccountMembershipCount(account.clone());
+    match env.storage().persistent().get(&key) {
+        Some(count) => Ok(count),
+        None => derive_account_usage(env, account),
+    }
+}
+
+/// Add one membership to an account after enforcing its configured cap.
+pub(crate) fn add_membership(env: &Env, account: &Address) -> Result<u32, AllowlistError> {
+    let current = get_account_usage(env, account)?;
+    let next = current.checked_add(1).ok_or(AllowlistError::Overflow)?;
+
+    if next > get_account_limit(env) {
+        return Err(AllowlistError::AccountLimitExceeded);
+    }
+
+    save_account_usage(env, account, next);
+    Ok(next)
+}
+
+/// Remove one membership and release the corresponding account capacity.
+pub(crate) fn remove_membership(env: &Env, account: &Address) -> Result<u32, AllowlistError> {
+    let current = get_account_usage(env, account)?;
+    let next = current.checked_sub(1).ok_or(AllowlistError::Underflow)?;
+    let key = LimitDataKey::AccountMembershipCount(account.clone());
+
+    if next == 0 {
+        env.storage().persistent().remove(&key);
+    } else {
+        save_account_usage(env, account, next);
+    }
+
+    Ok(next)
+}
+
+fn derive_account_usage(env: &Env, account: &Address) -> Result<u32, AllowlistError> {
+    let registry: Vec<Symbol> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AllowlistRegistry)
+        .unwrap_or_else(|| Vec::new(env));
+    let mut count = 0u32;
+
+    for allowlist_id in registry.iter() {
+        let addresses: Option<Vec<Address>> = env
+            .storage()
+            .persistent()
+            .get(&allowlist_storage_key(env, &allowlist_id));
+        if addresses
+            .map(|members| members.contains(account))
+            .unwrap_or(false)
+        {
+            count = count.checked_add(1).ok_or(AllowlistError::Overflow)?;
+        }
+    }
+
+    Ok(count)
+}
+
+fn save_account_usage(env: &Env, account: &Address, count: u32) {
+    let key = LimitDataKey::AccountMembershipCount(account.clone());
+    env.storage().persistent().set(&key, &count);
+
+    let extend_to = ACCOUNT_COUNT_TTL_TO.min(env.storage().max_ttl());
+    let threshold = ACCOUNT_COUNT_TTL_THRESHOLD.min(extend_to);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, threshold, extend_to);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configurable_limit_validation_accepts_boundaries() {
+        let env = Env::default();
+
+        assert_eq!(set_account_limit(&env, 0), Ok(()));
+        assert_eq!(
+            set_account_limit(&env, MAX_CONFIGURABLE_ACCOUNT_LIMIT),
+            Ok(())
+        );
+        assert_eq!(
+            set_account_limit(&env, MAX_CONFIGURABLE_ACCOUNT_LIMIT + 1),
+            Err(AllowlistError::InvalidInput)
+        );
+    }
+}

--- a/contracts/allowlist/tests/err_stab.rs
+++ b/contracts/allowlist/tests/err_stab.rs
@@ -17,6 +17,8 @@ fn test_error_variant_stability() {
     assert_eq!(AllowlistError::AllowlistEmpty as u32, 8);
     assert_eq!(AllowlistError::InvalidInput as u32, 9);
     assert_eq!(AllowlistError::Overflow as u32, 10);
+    assert_eq!(AllowlistError::AccountLimitExceeded as u32, 11);
+    assert_eq!(AllowlistError::Underflow as u32, 12);
 }
 
 #[test]
@@ -32,4 +34,6 @@ fn test_debug_format_does_not_panic() {
     let _ = format!("{:?}", AllowlistError::AllowlistEmpty);
     let _ = format!("{:?}", AllowlistError::InvalidInput);
     let _ = format!("{:?}", AllowlistError::Overflow);
+    let _ = format!("{:?}", AllowlistError::AccountLimitExceeded);
+    let _ = format!("{:?}", AllowlistError::Underflow);
 }

--- a/contracts/allowlist/tests/limits.rs
+++ b/contracts/allowlist/tests/limits.rs
@@ -1,0 +1,269 @@
+#![cfg(test)]
+
+//! Focused tests for per-account allowlist-membership limits.
+
+use allowlist::{
+    AllowlistContract, AllowlistContractClient, AllowlistError,
+    DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT, MAX_CONFIGURABLE_ACCOUNT_LIMIT,
+};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, Symbol,
+};
+
+struct TestSetup<'a> {
+    env: Env,
+    admin: Address,
+    first: Address,
+    second: Address,
+    client: AllowlistContractClient<'a>,
+}
+
+fn setup() -> TestSetup<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+    let contract_id = env.register(AllowlistContract, ());
+    let client = AllowlistContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    TestSetup {
+        env,
+        admin,
+        first,
+        second,
+        client,
+    }
+}
+
+fn create_list(setup: &TestSetup<'_>, name: &str) -> Symbol {
+    let id = Symbol::new(&setup.env, name);
+    setup.client.create_allowlist(&setup.admin, &id);
+    id
+}
+
+#[test]
+fn initialization_sets_documented_default_limit() {
+    let setup = setup();
+
+    assert_eq!(
+        setup.client.get_account_limit(),
+        DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT
+    );
+    assert_eq!(setup.client.get_account_usage(&setup.first), 0);
+}
+
+#[test]
+fn admin_can_set_zero_and_hard_boundary_but_not_exceed_it() {
+    let setup = setup();
+
+    setup.client.set_account_limit(&setup.admin, &0);
+    assert_eq!(setup.client.get_account_limit(), 0);
+
+    setup
+        .client
+        .set_account_limit(&setup.admin, &MAX_CONFIGURABLE_ACCOUNT_LIMIT);
+    assert_eq!(
+        setup.client.get_account_limit(),
+        MAX_CONFIGURABLE_ACCOUNT_LIMIT
+    );
+
+    assert_eq!(
+        setup
+            .client
+            .try_set_account_limit(&setup.admin, &(MAX_CONFIGURABLE_ACCOUNT_LIMIT + 1),),
+        Err(Ok(AllowlistError::InvalidInput))
+    );
+    assert_eq!(
+        setup.client.get_account_limit(),
+        MAX_CONFIGURABLE_ACCOUNT_LIMIT
+    );
+}
+
+#[test]
+fn only_admin_can_change_account_limit() {
+    let setup = setup();
+
+    assert_eq!(
+        setup.client.try_set_account_limit(&setup.first, &1),
+        Err(Ok(AllowlistError::Unauthorized))
+    );
+    assert_eq!(
+        setup.client.get_account_limit(),
+        DEFAULT_MAX_MEMBERSHIPS_PER_ACCOUNT
+    );
+}
+
+#[test]
+fn setting_limit_captures_admin_as_required_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(AllowlistContract, ());
+    let client = AllowlistContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_account_limit",
+                args: (admin.clone(), 1u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .set_account_limit(&admin, &1);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1);
+    assert_eq!(auths[0].0, admin);
+}
+
+#[test]
+fn setting_limit_without_authentication_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(AllowlistContract, ());
+    let client = AllowlistContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    env.set_auths(&[]);
+
+    assert!(client.try_set_account_limit(&admin, &1).is_err());
+}
+
+#[test]
+fn single_add_enforces_limit_without_mutating_rejected_list() {
+    let setup = setup();
+    let first_list = create_list(&setup, "first");
+    let second_list = create_list(&setup, "second");
+    setup.client.set_account_limit(&setup.admin, &1);
+
+    setup
+        .client
+        .add_address(&setup.admin, &first_list, &setup.first);
+
+    assert_eq!(setup.client.get_account_usage(&setup.first), 1);
+    assert_eq!(
+        setup
+            .client
+            .try_add_address(&setup.admin, &second_list, &setup.first),
+        Err(Ok(AllowlistError::AccountLimitExceeded))
+    );
+    assert!(!setup.client.is_allowed(&second_list, &setup.first));
+    assert_eq!(setup.client.get_account_usage(&setup.first), 1);
+}
+
+#[test]
+fn limits_are_isolated_per_account() {
+    let setup = setup();
+    let first_list = create_list(&setup, "first");
+    let second_list = create_list(&setup, "second");
+    setup.client.set_account_limit(&setup.admin, &1);
+
+    setup
+        .client
+        .add_address(&setup.admin, &first_list, &setup.first);
+    setup
+        .client
+        .add_address(&setup.admin, &second_list, &setup.second);
+
+    assert_eq!(setup.client.get_account_usage(&setup.first), 1);
+    assert_eq!(setup.client.get_account_usage(&setup.second), 1);
+}
+
+#[test]
+fn duplicate_batch_values_do_not_consume_extra_capacity() {
+    let setup = setup();
+    let list = create_list(&setup, "batch");
+    setup.client.set_account_limit(&setup.admin, &1);
+    let addresses = soroban_sdk::vec![&setup.env, setup.first.clone(), setup.first.clone(),];
+
+    setup.client.add_addresses(&setup.admin, &list, &addresses);
+
+    assert_eq!(setup.client.get_allowlist(&list).len(), 1);
+    assert_eq!(setup.client.get_account_usage(&setup.first), 1);
+}
+
+#[test]
+fn failed_batch_add_does_not_partially_mutate_state_or_usage() {
+    let setup = setup();
+    let occupied = create_list(&setup, "occupied");
+    let target = create_list(&setup, "target");
+    setup.client.set_account_limit(&setup.admin, &1);
+    setup
+        .client
+        .add_address(&setup.admin, &occupied, &setup.first);
+    let addresses = soroban_sdk::vec![&setup.env, setup.second.clone(), setup.first.clone()];
+
+    assert_eq!(
+        setup
+            .client
+            .try_add_addresses(&setup.admin, &target, &addresses),
+        Err(Ok(AllowlistError::AccountLimitExceeded))
+    );
+    assert_eq!(setup.client.get_allowlist(&target).len(), 0);
+    assert_eq!(setup.client.get_account_usage(&setup.second), 0);
+    assert_eq!(setup.client.get_account_usage(&setup.first), 1);
+}
+
+#[test]
+fn every_removal_path_releases_capacity() {
+    let setup = setup();
+    setup.client.set_account_limit(&setup.admin, &1);
+    let first = create_list(&setup, "first");
+    let second = create_list(&setup, "second");
+    let third = create_list(&setup, "third");
+    let fourth = create_list(&setup, "fourth");
+
+    setup.client.add_address(&setup.admin, &first, &setup.first);
+    setup
+        .client
+        .remove_address(&setup.admin, &first, &setup.first);
+    setup
+        .client
+        .add_address(&setup.admin, &second, &setup.first);
+
+    let remove = soroban_sdk::vec![&setup.env, setup.first.clone()];
+    setup
+        .client
+        .remove_addresses(&setup.admin, &second, &remove);
+    setup.client.add_address(&setup.admin, &third, &setup.first);
+
+    setup.client.clear_allowlist(&setup.admin, &third);
+    setup
+        .client
+        .add_address(&setup.admin, &fourth, &setup.first);
+
+    setup.client.delete_allowlist(&setup.admin, &fourth);
+    assert_eq!(setup.client.get_account_usage(&setup.first), 0);
+}
+
+#[test]
+fn lowering_limit_preserves_memberships_and_blocks_growth() {
+    let setup = setup();
+    let first = create_list(&setup, "first");
+    let second = create_list(&setup, "second");
+    let third = create_list(&setup, "third");
+    setup.client.set_account_limit(&setup.admin, &2);
+    setup.client.add_address(&setup.admin, &first, &setup.first);
+    setup
+        .client
+        .add_address(&setup.admin, &second, &setup.first);
+
+    setup.client.set_account_limit(&setup.admin, &1);
+
+    assert_eq!(setup.client.get_account_usage(&setup.first), 2);
+    assert!(setup.client.is_allowed(&first, &setup.first));
+    assert!(setup.client.is_allowed(&second, &setup.first));
+    assert_eq!(
+        setup
+            .client
+            .try_add_address(&setup.admin, &third, &setup.first),
+        Err(Ok(AllowlistError::AccountLimitExceeded))
+    );
+}


### PR DESCRIPTION
## Summary

- Enforce a configurable membership cap independently for each address across allowlists.
- Apply enforcement to single and batch additions without partial mutation.
- Release capacity through single removal, batch removal, clear, and delete operations.
- Add authenticated limit management, public limit/usage views, stable errors, an update event, TTL-safe usage recovery, and API documentation.
- Add focused boundary, isolation, authorization, rollback, and lifecycle tests.

## Tests

- `cargo test -p allowlist --test limits --test err_stab --test proptest` — 24 passed
- `cargo check -p allowlist --lib` — passed
- `cargo clippy -p allowlist --lib` — passed with existing event deprecation warnings
- Focused `rustfmt --check` — passed
- `git diff --check` — passed

The full allowlist suite remains blocked by pre-existing compile errors in `allowlist_lifecycle.rs` and `auth_boundary.rs` involving missing client lifetimes and stale `try_*` result shapes. The checked-in lockfile also contains duplicate package entries, so verification used a temporary regenerated lockfile and restored the repository copy unchanged.

Fixes #1347

### Verification
- `PASS: cargo test -p allowlist --test limits --test err_stab --test proptest (24 tests)`
- `PASS: cargo check -p allowlist --lib`
- `PASS: cargo clippy -p allowlist --lib (existing event deprecation warnings only)`
- `PASS: rustfmt checks for focused changed/new files`
- `PASS: git diff --check`
- `BASELINE: cargo test -p allowlist cannot compile existing lifecycle/auth tests due missing client lifetimes and stale try_* result shapes`
- `ENVIRONMENT: wasm32v1-none check unavailable because the target is not installed`
- `NOTE: Cargo verification used a temporary regenerated lockfile because the checked-in Cargo.lock contains duplicate package entries; it was restored unchanged afterward`

### Diagnostics
Recovered command failures: `/bin/zsh -lc "rg --files contracts/allowlist | sort && rg -n \"(build\\.rs|Command::new|std::process|curl|wget|credential|secret|token|rm -|remove_dir|remove_file)\" --glob '*.rs' --glob '*.toml' --glob '*.sh' --glob 'Makefile' --glob 'justfile' --glob 'Justfile' . || true && sed -n '1,260p' contracts/allowlist/src/limits.rs && sed -n '1,300p' contracts/allowlist/src/lib.rs"` (1), `/bin/zsh -lc 'cargo fmt -p allowlist -- --check && cargo test -p allowlist --test limits'` (1), `/bin/zsh -lc 'rustfmt --edition 2021 contracts/allowlist/src/limits.rs contracts/allowlist/tests/limits.rs && cargo test -p allowlist --test limits'` (101), `/bin/zsh -lc 'cargo test -p allowlist --test limits'` (101), `/bin/zsh -lc 'cargo test -p allowlist --test limits'` (101), `/bin/zsh -lc 'mkdir -p /private/tmp/predictify-1347-cargo-home && CARGO_HOME=/private/tmp/predictify-1347-cargo-home cargo test -p allowlist --test limits'` (101), `/bin/zsh -lc 'CARGO_HOME=/private/tmp/predictify-1347-cargo-home cargo test -p allowlist'` (101), `/bin/zsh -lc 'CARGO_HOME=/private/tmp/predictify-1347-cargo-home CARGO_TARGET_DIR=/private/tmp/predictify-1347-target-final cargo check -p allowlist --target wasm32v1-none --lib'` (101), `/bin/zsh -lc 'rustfmt --edition 2021 --check contracts/allowlist/src/err.rs contracts/allowlist/src/limits.rs contracts/allowlist/tests/err_stab.rs contracts/allowlist/tests/limits.rs && git diff --check && git diff --quiet -- Cargo.lock && git diff --quiet -- target/.rustc_info.json && git status --short && git branch --show-current && git diff --numstat'` (1)