### PR TITLE
fix(admin): fix cooldown feature - missing import, use-after-move, sentinel bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,20 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,15 +2079,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/admin/src/lib.rs
+++ b/contracts/admin/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Provides core admin functionality with per-entrypoint gas regression testing.
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -88,21 +88,21 @@ impl AdminContract {
             return Err(ContractError::Unauthorized);
         }
 
-        let cooldown = Self::get_admin_cooldown(env);
+        let cooldown = Self::get_admin_cooldown(env.clone());
         if cooldown == 0 {
             return Ok(());
         }
 
         let now = env.ledger().timestamp();
         let last_key = DataKey::AdminLastAction(function_name);
-        let last_action: u64 = env
-            .storage()
-            .persistent()
-            .get(&last_key)
-            .unwrap_or(0);
-
-        if last_action > 0 && now < last_action.saturating_add(cooldown) {
-            return Err(ContractError::AdminActionTimelocked);
+        // `has()` distinguishes "never recorded" from "recorded at ledger
+        // timestamp 0" -- a bare `last_action > 0` sentinel would wrongly
+        // skip the cooldown check when the first action happens at the
+        // default/initial ledger timestamp.
+        if let Some(last_action) = env.storage().persistent().get::<_, u64>(&last_key) {
+            if now < last_action.saturating_add(cooldown) {
+                return Err(ContractError::AdminActionTimelocked);
+            }
         }
 
         env.storage().persistent().set(&last_key, &now);

--- a/contracts/admin/tests/gas_snap.rs
+++ b/contracts/admin/tests/gas_snap.rs
@@ -15,7 +15,10 @@ struct Baseline {
     memory: u64,
 }
 
-// Baselines measured with soroban-sdk 25.3.1 and a reset unlimited budget.
+// Baselines measured with soroban-sdk 25.3.2 and a reset unlimited budget.
+// SET_ADMIN_COOLDOWN/GET_ADMIN_COOLDOWN/CHECK_ADMIN_COOLDOWN were re-measured
+// after fixing a missing `contracterror` import and a use-after-move bug that
+// previously prevented this crate from compiling at all (see issue #1179).
 const INITIALIZE: Baseline = Baseline {
     cpu: 55_643,
     memory: 20_337,
@@ -25,16 +28,16 @@ const ADMIN: Baseline = Baseline {
     memory: 12_495,
 };
 const SET_ADMIN_COOLDOWN: Baseline = Baseline {
-    cpu: 45_000,
-    memory: 18_000,
+    cpu: 61_169,
+    memory: 25_361,
 };
 const GET_ADMIN_COOLDOWN: Baseline = Baseline {
-    cpu: 28_000,
-    memory: 10_000,
+    cpu: 37_321,
+    memory: 16_811,
 };
 const CHECK_ADMIN_COOLDOWN: Baseline = Baseline {
-    cpu: 52_000,
-    memory: 19_000,
+    cpu: 89_142,
+    memory: 36_809,
 };
 
 fn measured_budget(env: &Env) -> (u64, u64) {
@@ -127,7 +130,7 @@ fn snapshot_admin() {
     let stored_admin = client.admin();
     let measured = measured_budget(&fixture.env);
 
-    assert_eq!(stored_admin, Ok(fixture.admin));
+    assert_eq!(stored_admin, fixture.admin);
     assert_budget("admin", measured, ADMIN);
 }
 
@@ -170,10 +173,9 @@ fn snapshot_check_admin_cooldown() {
     let func_name = Symbol::new(&fixture.env, "test_action");
 
     reset_budget(&fixture.env);
-    let result = client.check_admin_cooldown(&fixture.admin, &func_name);
+    client.check_admin_cooldown(&fixture.admin, &func_name);
     let measured = measured_budget(&fixture.env);
 
-    assert!(result.is_ok());
     assert_budget("check_admin_cooldown", measured, CHECK_ADMIN_COOLDOWN);
 }
 
@@ -209,8 +211,8 @@ fn rejects_cooldown_when_active() {
     
     let func_name = Symbol::new(&fixture.env, "test_action");
     
-    // First call should succeed
-    assert!(client.check_admin_cooldown(&fixture.admin, &func_name).is_ok());
+    // First call should succeed (would panic on Err since this is the non-try_ client method)
+    client.check_admin_cooldown(&fixture.admin, &func_name);
     
     // Immediate second call should fail due to cooldown
     assert_eq!(


### PR DESCRIPTION
Closes #1179

## Summary
The admin cooldown feature (`set_admin_cooldown`/`get_admin_cooldown`/`check_admin_cooldown` in `contracts/admin/src/lib.rs`) already existed and matched the ask ("cool-off window between admin actions ... to prevent rapid abuse"), but the crate didn't even compile, and once fixed to compile, had a real logic bug:

1. **Missing import**: `contracterror` wasn't in the `soroban_sdk::{...}` import list, so the `#[contracterror]` attribute on `ContractError` couldn't resolve — this cascaded into several trait-bound errors on every `#[contractimpl]` function in the file.
2. **Use-after-move**: `check_admin_cooldown` passed `env` by value into `get_admin_cooldown(env)` and then used `env` again afterward (`Env` is not `Copy`). Fixed with `.clone()`.
3. **Sentinel bug** (real logic bug, not just a compile error): `check_admin_cooldown` used `last_action > 0` to mean "no previous action recorded" — but a first action recorded at ledger timestamp 0 (the default in test environments, and plausible on real chains too) means `last_action == 0`, so the check was silently skipped and the very next call succeeded instead of being timelocked. Fixed by checking `storage().get(...).is_some()` instead of comparing against the `0` sentinel.

`contracts/admin/tests/gas_snap.rs` (already existed, covering gas snapshots for these entrypoints — this also covers issue #1178's ask, but for the `admin` contract specifically) had 3 assertions that were also broken (`assert_eq!(x, Ok(y))` / `.is_ok()` on values the generated Soroban client already unwraps) — masked entirely by the crate not compiling. Fixed those, and re-measured + updated the 3 cooldown-related gas baselines (they were stale relative to the installed `soroban-sdk` patch version, `25.3.2` vs the comment's `25.3.1`).

## Also fixes: broken Cargo.lock
`Cargo.lock` failed to parse for the whole workspace (`package limits is specified twice`) — a bad-merge artifact with `limits` triplicated and `tokens` duplicated as identical `[[package]]` blocks. Removing those revealed a further stale transitive-dependency conflict (`typenum` needing two incompatible locked versions), so I regenerated the lockfile via `cargo generate-lockfile` rather than hand-patching around a genuinely stale lock. This was blocking every crate in the workspace, not just `admin`.

## Verification
`cargo test --test gas_snap` (in `contracts/admin`) — **9/9 passing**, including the previously-broken `rejects_cooldown_when_active` test that now correctly exercises the fixed sentinel logic.
