### PR TITLE
feat(markets): add pause/resume mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,20 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,15 +2079,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/markets/src/lib.rs
+++ b/contracts/markets/src/lib.rs
@@ -122,4 +122,53 @@ impl MarketsContract {
         market
     }
 
+    /// @notice Whether the markets subsystem is currently paused.
+    /// @dev Read-only; defaults to `false` (not paused) before `pause_markets` is ever called.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    // -----------------------------------------------------------------------
+    //  Admin
+    // -----------------------------------------------------------------------
+
+    /// @notice Set the admin address once. Required before `pause_markets`/`unpause_markets`.
+    /// @dev Fails with `AlreadyInitialized`-equivalent (`InvalidState`) if the admin is already set.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ContractError::InvalidState);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// @notice Pause the markets subsystem. Admin-only.
+    /// @dev Once paused, other entrypoints are expected to check [`Self::is_paused`] and
+    /// reject state-changing calls with `MarketClosed` while active.
+    pub fn pause_markets(env: Env, admin: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
+    }
+
+    /// @notice Resume the markets subsystem after a pause. Admin-only.
+    pub fn unpause_markets(env: Env, admin: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::InvalidState)?;
+        if *caller != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        Ok(())
+    }
 }

--- a/contracts/markets/tests/pause_resume.rs
+++ b/contracts/markets/tests/pause_resume.rs
@@ -1,0 +1,80 @@
+#![cfg(test)]
+
+extern crate std;
+
+use markets::{ContractError, MarketsContract, MarketsContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn deploy(env: &Env) -> MarketsContractClient<'_> {
+    let contract_id = env.register(MarketsContract, ());
+    MarketsContractClient::new(env, &contract_id)
+}
+
+#[test]
+fn defaults_to_not_paused() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn admin_can_pause_and_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    assert!(!client.is_paused());
+
+    client.pause_markets(&admin);
+    assert!(client.is_paused());
+
+    client.unpause_markets(&admin);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn non_admin_cannot_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_pause_markets(&stranger),
+        Err(Ok(ContractError::Unauthorized))
+    );
+}
+
+#[test]
+fn pause_before_initialize_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    assert_eq!(
+        client.try_pause_markets(&admin),
+        Err(Ok(ContractError::InvalidState))
+    );
+}
+
+#[test]
+fn cannot_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_initialize(&admin),
+        Err(Ok(ContractError::InvalidState))
+    );
+}


### PR DESCRIPTION
Closes #1166

## Summary
The markets contract's own auth-matrix doc comment and its `DataKey::Paused`/`DataKey::Admin` storage keys already described a pause/resume mechanism (`pause_markets`/`unpause_markets`, admin-gated) — but neither entrypoint was ever implemented. The whole contract only had `version()` and `get_market()` before this change, and there wasn't even a way to set an admin address.

Adds:
- `initialize(admin)`: one-time admin bootstrap (required before pausing).
- `pause_markets(admin)` / `unpause_markets(admin)`: admin-gated, toggle `DataKey::Paused`.
- `is_paused()`: read-only check, for other entrypoints to gate against as they're added.

Reuses the existing `ContractError::Unauthorized`/`InvalidState` variants rather than adding new error codes.

## Also fixes: broken Cargo.lock
Same pre-existing corruption described in my PR for #1179 in this repo (duplicate `limits`/`tokens` package entries, blocking the whole workspace) — regenerated via `cargo generate-lockfile`. Should be a no-op if #1179's PR merges first.

## Tests
`contracts/markets/tests/pause_resume.rs`: defaults to not-paused, admin can pause/unpause, a non-admin is rejected, pausing before `initialize` is rejected, and `initialize` can't be called twice.

## Verification
`cargo test` (in `contracts/markets`) — all 4 test binaries pass (1/1, 2/2, 5/5 new, 22/22 existing, including the pre-existing `paused_toggle_roundtrip`/`paused_state_invariant` proptest cases, which operate on the same storage keys and still pass unchanged).
