### PR TITLE
test(governance): add invariant property test for vote tallies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +873,7 @@ dependencies = [
 name = "governance"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1096,20 +1104,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "limits"
@@ -2093,15 +2087,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -13,6 +13,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1.4"
 
 [[test]]
 name = "governance_lifecycle"
@@ -25,3 +26,7 @@ path = "tests/events.rs"
 [[test]]
 name = "auth_boundary"
 path = "tests/auth_boundary.rs"
+
+[[test]]
+name = "proptest"
+path = "tests/proptest.rs"

--- a/contracts/governance/tests/proptest.rs
+++ b/contracts/governance/tests/proptest.rs
@@ -1,0 +1,120 @@
+//! Property test for the Governance contract's core tally invariant.
+//!
+//! For an arbitrary sequence of distinct voters casting weighted votes on an
+//! active proposal, the invariant under test is:
+//!
+//! 1. `votes_for` / `votes_against` always equal the sum of weights cast for
+//!    that choice, regardless of the order votes are cast in.
+//! 2. `execute_proposal` finalizes to `Executed` iff `votes_for >
+//!    votes_against`, else `Rejected` — and never anything else.
+//! 3. Once finalized, the proposal is terminal: neither further votes nor a
+//!    second `execute_proposal` call can change its status or tallies.
+
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+
+use governance::{
+    GovernanceContract, GovernanceContractClient, GovernanceError, ProposalStatus, VoteChoice,
+};
+
+const VOTING_PERIOD: u64 = 3_600;
+
+fn deploy(env: &Env) -> (GovernanceContractClient<'_>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(GovernanceContract, ());
+    let client = GovernanceContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin, &VOTING_PERIOD);
+    (client, admin)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Core invariant: tallies always equal the sum of cast weights, and
+    /// finalization is a deterministic, terminal function of those tallies —
+    /// for any valid sequence of distinct-voter, weighted votes.
+    #[test]
+    fn tally_and_finalization_invariant(
+        votes in prop::collection::vec((any::<bool>(), 1u64..1_000), 0..8),
+    ) {
+        let env = Env::default();
+        let (client, admin) = deploy(&env);
+
+        let id = client.create_proposal(&admin, &String::from_str(&env, "prop"));
+
+        let mut expected_for: u64 = 0;
+        let mut expected_against: u64 = 0;
+
+        for (is_for, weight) in &votes {
+            let voter = Address::generate(&env);
+            let choice = if *is_for { VoteChoice::For } else { VoteChoice::Against };
+            client.cast_vote(&voter, &id, &choice, weight);
+
+            if *is_for {
+                expected_for += weight;
+            } else {
+                expected_against += weight;
+            }
+
+            let proposal = client.get_proposal(&id);
+            prop_assert_eq!(proposal.votes_for, expected_for);
+            prop_assert_eq!(proposal.votes_against, expected_against);
+            prop_assert_eq!(proposal.status, ProposalStatus::Active);
+        }
+
+        // A second cast from the SAME voter must be rejected and must never
+        // move the tally, no matter how many other voters preceded it.
+        if let Some((is_for, weight)) = votes.first() {
+            let repeat_voter = Address::generate(&env);
+            let choice = if *is_for { VoteChoice::For } else { VoteChoice::Against };
+            client.cast_vote(&repeat_voter, &id, &choice, weight);
+            if *is_for {
+                expected_for += weight;
+            } else {
+                expected_against += weight;
+            }
+
+            let result = client.try_cast_vote(&repeat_voter, &id, &choice, weight);
+            prop_assert!(matches!(result, Err(Ok(GovernanceError::AlreadyVoted))));
+
+            let proposal = client.get_proposal(&id);
+            prop_assert_eq!(proposal.votes_for, expected_for);
+            prop_assert_eq!(proposal.votes_against, expected_against);
+        }
+
+        // Close the voting window and finalize.
+        env.ledger().with_mut(|l| l.timestamp += VOTING_PERIOD + 1);
+        let final_status = client.execute_proposal(&admin, &id);
+
+        let expected_status = if expected_for > expected_against {
+            ProposalStatus::Executed
+        } else {
+            ProposalStatus::Rejected
+        };
+        prop_assert_eq!(final_status, expected_status);
+
+        let proposal = client.get_proposal(&id);
+        prop_assert_eq!(proposal.status, expected_status);
+        prop_assert_eq!(proposal.votes_for, expected_for);
+        prop_assert_eq!(proposal.votes_against, expected_against);
+
+        // Terminal: neither a repeat finalize nor a new vote can change it.
+        let refinalize = client.try_execute_proposal(&admin, &id);
+        prop_assert!(matches!(refinalize, Err(Ok(GovernanceError::InvalidStateTransition))));
+
+        let late_voter = Address::generate(&env);
+        let late_vote = client.try_cast_vote(&late_voter, &id, &VoteChoice::For, &1);
+        prop_assert!(matches!(late_vote, Err(Ok(GovernanceError::InvalidStateTransition))));
+
+        let proposal = client.get_proposal(&id);
+        prop_assert_eq!(proposal.status, expected_status);
+        prop_assert_eq!(proposal.votes_for, expected_for);
+        prop_assert_eq!(proposal.votes_against, expected_against);
+    }
+}


### PR DESCRIPTION
Closes #1172

## Summary
Adds `contracts/governance/tests/proptest.rs`, a real property test (using the `proptest` crate, matching the convention already established in `markets`/`betting`/`allowlist`) asserting governance's core invariant holds across **arbitrary valid action sequences** of distinct voters casting weighted votes.

Invariant asserted after every vote and after finalization:
- `votes_for` / `votes_against` always equal the sum of weights cast for that choice, regardless of the order votes arrive in.
- `execute_proposal` finalizes to `Executed` iff `votes_for > votes_against`, else `Rejected` — never anything else.
- Once finalized, the proposal is **terminal**: neither a repeat `execute_proposal` call nor a new vote can change its status or tallies (both are rejected with `InvalidStateTransition`).
- A second cast from the same voter is rejected with `AlreadyVoted` and never moves the tally.

Also registers the new test target and adds `proptest = "1.4"` as a dev-dependency in `contracts/governance/Cargo.toml`, same as the existing `markets`/`betting` crates.

## Also fixes: broken Cargo.lock
Same pre-existing corruption described in my PR for #1179 in this repo (duplicate `limits` package entries, blocking the whole workspace) — regenerated via `cargo generate-lockfile`. Needed here regardless since adding the `proptest` dev-dependency touches the lockfile. Should be a no-op if #1179's PR merges first.

## Verification
`cargo test --test proptest` (in `contracts/governance`) — passes, 64 generated cases.

Note: the pre-existing `governance_lifecycle`, `events`, and `auth_boundary` test files in this same crate currently fail to **compile** on `master`, unrelated to this change (soroban-sdk API drift: `Env::register_contract` deprecated/removed signature mismatches, `ContractEvents` missing `.iter()`). I did not touch those files; this PR's new `proptest.rs` test target compiles and passes independently of that pre-existing breakage.
