### PR TITLE
feat(oracles): add migration script sketch (data reshape + upgrade guard)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,20 +1103,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "limits"
@@ -2093,15 +2086,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/oracles/src/lib.rs
+++ b/contracts/oracles/src/lib.rs
@@ -7,15 +7,18 @@
 //! ## State-changing (require admin `require_auth`)
 //! - [`OraclesContract::add_oracle`] — register an oracle address
 //! - [`OraclesContract::remove_oracle`] — deregister an oracle address
+//! - [`OraclesContract::migrate_data`] — versioned data-reshape guard, see [`migrate`]
 //!
 //! ## Read-only (no auth)
 //! - [`OraclesContract::capabilities`] — `u64` bitmap of supported features
 //! - [`OraclesContract::version`] — contract version number
+//! - [`OraclesContract::data_version`] — on-chain data-schema version
 //! - [`OraclesContract::list_oracles`] — enumerate registered oracles
 //! - [`OraclesContract::get_price`] — fetch a raw price from an oracle
 //! - [`OraclesContract::get_price_data`] — fetch full price data from an oracle
 //! - [`OraclesContract::is_oracle_healthy`] — check if an oracle is live
 
+pub mod migrate;
 pub mod views;
 
 pub use views::CapabilityFlag;
@@ -30,6 +33,8 @@ use soroban_sdk::{
 pub enum DataKey {
     /// Stores `Vec<Address>` — the ordered list of registered oracle addresses.
     OracleList,
+    /// Stores `u32` — the oracle registry's on-chain data-schema version.
+    DataVersion,
 }
 
 /// Price data returned by `get_price_data`.
@@ -88,6 +93,13 @@ pub enum Error {
     CapabilityBitmapCorrupt = 221,
     /// A reserved capability bit was unexpectedly set.
     ReservedCapabilitySet = 222,
+    // ===== MIGRATION ERRORS (230-239) =====
+    /// The `expected` version passed to `migrate_data` does not match the
+    /// stored data version.
+    VersionMismatch = 230,
+    /// The `target` version passed to `migrate_data` is not strictly greater
+    /// than the stored data version.
+    InvalidTargetVersion = 231,
 }
 
 /// Minimum TTL ledgers for the oracle registry key.
@@ -226,6 +238,24 @@ impl OraclesContract {
             }),
             None => Err(Error::OracleUnavailable),
         }
+    }
+
+    /// Return the oracle registry's current on-chain data-schema version.
+    pub fn data_version(env: Env) -> u32 {
+        migrate::data_version(&env)
+    }
+
+    /// Migrate the oracle registry's stored data from `expected` to `target`.
+    ///
+    /// Requires `admin` authorization. See [`migrate::migrate_data`] for the
+    /// full guard and reshape semantics.
+    pub fn migrate_data(
+        env: Env,
+        admin: Address,
+        expected: u32,
+        target: u32,
+    ) -> Result<(), Error> {
+        migrate::migrate_data(&env, &admin, expected, target)
     }
 
     /// Check whether a registered oracle reports itself as live.

--- a/contracts/oracles/src/migrate.rs
+++ b/contracts/oracles/src/migrate.rs
@@ -1,0 +1,68 @@
+//! Migration script sketch for the Oracles contract.
+//!
+//! Provides a versioned guard around future on-chain reshapes of the oracle
+//! registry's storage layout. The reshape itself is a no-op stub — each
+//! schema change should add a match arm to [`reshape_oracle_data`].
+//!
+//! # Usage
+//!
+//! Call [`migrate_data`] during a contract upgrade. It checks the stored
+//! data version matches `expected`, applies the reshape, and bumps the
+//! stored version to `target`.
+
+use soroban_sdk::{Address, Env};
+
+use crate::{DataKey, Error};
+
+/// Data-schema version assumed when none has been stored yet.
+const DEFAULT_DATA_VERSION: u32 = 1;
+
+/// Read the oracle registry's current data-schema version.
+///
+/// Defaults to [`DEFAULT_DATA_VERSION`] when no migration has ever run.
+pub fn data_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::DataVersion)
+        .unwrap_or(DEFAULT_DATA_VERSION)
+}
+
+/// Migrate the oracle registry's stored data from `expected` to `target`.
+///
+/// # Arguments
+/// * `env`      - Contract environment.
+/// * `admin`    - Caller; must authenticate via `require_auth()`.
+/// * `expected` - The data version we expect to find stored.
+/// * `target`   - The version to upgrade to; must be strictly greater.
+///
+/// # Errors
+/// * [`Error::VersionMismatch`] if `expected` != the stored data version.
+/// * [`Error::InvalidTargetVersion`] if `target` <= the stored data version.
+///
+/// # Notes
+/// The data reshape itself is a no-op stub — see [`reshape_oracle_data`].
+pub fn migrate_data(env: &Env, admin: &Address, expected: u32, target: u32) -> Result<(), Error> {
+    admin.require_auth();
+
+    let current = data_version(env);
+    if expected != current {
+        return Err(Error::VersionMismatch);
+    }
+    if target <= current {
+        return Err(Error::InvalidTargetVersion);
+    }
+
+    reshape_oracle_data(env, current, target);
+
+    env.storage().instance().set(&DataKey::DataVersion, &target);
+
+    Ok(())
+}
+
+/// Apply data-layout transforms between two oracle-registry schema versions.
+///
+/// Each version pair that changes the stored shape of oracle data should add
+/// a match arm here. The default arm is a no-op.
+fn reshape_oracle_data(_env: &Env, from: u32, to: u32) {
+    let _ = (from, to);
+}

--- a/contracts/oracles/tests/migrate.rs
+++ b/contracts/oracles/tests/migrate.rs
@@ -1,0 +1,80 @@
+#![cfg(test)]
+
+//! Tests for the oracle registry's migration guard (see `src/migrate.rs`).
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use oracles::{Error, OraclesContract, OraclesContractClient};
+
+fn deploy(env: &Env) -> OraclesContractClient<'_> {
+    let contract_id = env.register(OraclesContract, ());
+    OraclesContractClient::new(env, &contract_id)
+}
+
+#[test]
+fn data_version_defaults_to_one() {
+    let env = Env::default();
+    let client = deploy(&env);
+    assert_eq!(client.data_version(), 1);
+}
+
+#[test]
+fn migrate_data_bumps_stored_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.migrate_data(&admin, &1, &2);
+    assert_eq!(client.data_version(), 2);
+
+    client.migrate_data(&admin, &2, &5);
+    assert_eq!(client.data_version(), 5);
+}
+
+#[test]
+fn migrate_data_requires_auth() {
+    let env = Env::default();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    let result = client.try_migrate_data(&admin, &1, &2);
+    assert!(result.is_err(), "migrate_data must require auth");
+}
+
+#[test]
+fn migrate_data_rejects_stale_expected_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    let result = client.try_migrate_data(&admin, &2, &3);
+    match result {
+        Err(Ok(Error::VersionMismatch)) => {}
+        other => panic!("expected VersionMismatch, got {other:?}"),
+    }
+    assert_eq!(client.data_version(), 1, "version must remain unchanged on rejection");
+}
+
+#[test]
+fn migrate_data_rejects_non_increasing_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    let same = client.try_migrate_data(&admin, &1, &1);
+    match same {
+        Err(Ok(Error::InvalidTargetVersion)) => {}
+        other => panic!("expected InvalidTargetVersion for target == current, got {other:?}"),
+    }
+
+    let lower = client.try_migrate_data(&admin, &1, &0);
+    match lower {
+        Err(Ok(Error::InvalidTargetVersion)) => {}
+        other => panic!("expected InvalidTargetVersion for target < current, got {other:?}"),
+    }
+
+    assert_eq!(client.data_version(), 1, "version must remain unchanged on rejection");
+}


### PR DESCRIPTION
Closes #1170

## Summary
Adds `contracts/oracles/src/migrate.rs`, a migration script sketch covering data reshape + upgrade guard, mirroring the pattern already established by the standalone `migrate` crate's `src/migrate.rs` in this same workspace.

- `migrate_data(env, admin, expected, target)` — requires `admin` auth, checks the stored data version equals `expected`, applies the data reshape (currently a no-op extension point — see `reshape_oracle_data`), and bumps the stored version to `target`.
- `data_version(env)` — read-only, returns the current on-chain data-schema version (defaults to `1` before any migration has run).

Wired into `contracts/oracles/src/lib.rs`:
- New `DataKey::DataVersion` storage key.
- Two new `Error` variants: `VersionMismatch` (230), `InvalidTargetVersion` (231).
- Two new public entrypoints: `data_version`, `migrate_data`, delegating to the `migrate` module.
- Module-level doc comment updated to list both.

## Also fixes: broken Cargo.lock
Same pre-existing corruption described in my PR for #1179 in this repo (duplicate `limits` package entries, blocking the whole workspace) — regenerated via `cargo generate-lockfile`. Should be a no-op if #1179's PR merges first.

## Tests
`contracts/oracles/tests/migrate.rs`: default version is 1, successful multi-step migration bumps the version, `migrate_data` requires auth, stale `expected` returns `VersionMismatch`, and both `target == current` / `target < current` return `InvalidTargetVersion` (version left unchanged in all rejection cases).

## Verification
`cargo test --test migrate` (in `contracts/oracles`) — all 5 new tests pass. I also ran the crate's other existing test binaries: `capabilities`, `err_stab`, `gas_snap`, `cap_error_stab`, `auth_snap` all pass unaffected. Three **pre-existing, unrelated** test files already fail to compile/run on `master` before this change — `oracle_tests.rs` and `ttl.rs` panic on a soroban-sdk cross-contract mock-invocation host error, and `storage_docs.rs` fails because `docs/storage.md` was never updated to mention the Instance/Temporary storage tiers. None of these touch the code this PR adds; I did not modify any of those three files.
