### PR TITLE
test(resolution): add auth-context tests for resolve/propose/update_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,20 +1103,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "limits"
@@ -2093,15 +2086,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/resolution/Cargo.toml
+++ b/contracts/resolution/Cargo.toml
@@ -22,3 +22,7 @@ path = "tests/error_tests.rs"
 [[test]]
 name = "ttl_tests"
 path = "tests/ttl.rs"
+
+[[test]]
+name = "auth"
+path = "tests/auth.rs"

--- a/contracts/resolution/tests/auth.rs
+++ b/contracts/resolution/tests/auth.rs
@@ -1,0 +1,131 @@
+//! Auth-context tests for the Resolution contract.
+//!
+//! Every state-changing entrypoint (`resolve`, `propose`, `update_config`) is
+//! covered under two complementary harnesses:
+//!
+//! 1. **Bare env, no mocking** — `require_auth()` panics when no auth is
+//!    mocked, so calling on a fresh [`Env::default()`] must panic. This
+//!    proves the auth gate is present.
+//! 2. **`mock_all_auths()`** — the call must succeed, and [`Env::auths`]
+//!    must report the expected caller as the sole signer. This proves the
+//!    *correct* address is the one being authorized, not an unrelated one.
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use resolution::{ResolutionContract, ResolutionContractClient};
+
+fn deploy(env: &Env) -> ResolutionContractClient<'_> {
+    let contract_id = env.register(ResolutionContract, ());
+    ResolutionContractClient::new(env, &contract_id)
+}
+
+// ---------------------------------------------------------------------------
+// resolve
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn resolve_rejected_without_auth() {
+    let env = Env::default();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.resolve(&admin, &1u64, &2u32);
+}
+
+#[test]
+fn resolve_accepted_with_auth_and_signer_captured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.resolve(&admin, &1u64, &2u32);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "exactly one auth entry expected");
+    assert_eq!(auths[0].0, admin, "admin must be the authorized signer");
+}
+
+// ---------------------------------------------------------------------------
+// propose
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn propose_rejected_without_auth() {
+    let env = Env::default();
+    let client = deploy(&env);
+    let user = Address::generate(&env);
+
+    client.propose(&user, &1u64);
+}
+
+#[test]
+fn propose_accepted_with_auth_and_signer_captured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let user = Address::generate(&env);
+
+    client.propose(&user, &1u64);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "exactly one auth entry expected");
+    assert_eq!(auths[0].0, user, "user must be the authorized signer");
+}
+
+// ---------------------------------------------------------------------------
+// update_config
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn update_config_rejected_without_auth() {
+    let env = Env::default();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.update_config(&admin, &5u32);
+}
+
+#[test]
+fn update_config_accepted_with_auth_and_signer_captured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+
+    client.update_config(&admin, &5u32);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "exactly one auth entry expected");
+    assert_eq!(auths[0].0, admin, "admin must be the authorized signer");
+}
+
+// ---------------------------------------------------------------------------
+// Signer-identity invariant across a mixed-caller sequence
+// ---------------------------------------------------------------------------
+
+/// The auth snapshot must name the exact caller passed to each entrypoint,
+/// not some other in-scope address, even when multiple distinct callers act
+/// on the same contract instance in sequence.
+#[test]
+fn each_entrypoint_captures_its_own_distinct_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let resolver = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    let configurer = Address::generate(&env);
+
+    client.resolve(&resolver, &1u64, &0u32);
+    assert_eq!(env.auths()[0].0, resolver);
+
+    client.propose(&proposer, &2u64);
+    assert_eq!(env.auths()[0].0, proposer);
+
+    client.update_config(&configurer, &3u32);
+    assert_eq!(env.auths()[0].0, configurer);
+}


### PR DESCRIPTION
Closes #1168

## Summary
Adds `contracts/resolution/tests/auth.rs`, testing all three of the resolution contract's state-changing entrypoints (`resolve`, `propose`, `update_config`) under both auth harnesses:

1. **Bare `Env`, no mocking** — `require_auth()` panics when no auth is mocked, so each call must panic (`#[should_panic]`). Proves the auth gate is present.
2. **`mock_all_auths()`** — the call succeeds, and `env.auths()` is inspected to confirm the exact caller passed to the entrypoint is the sole recorded signer. Proves the *correct* address is being authorized, not an unrelated one.

Also adds a sequence test (`each_entrypoint_captures_its_own_distinct_signer`) with three distinct callers acting on the same contract instance in turn, confirming each entrypoint's auth snapshot names only its own caller.

This crate sets `autotests = false`, so I registered the new `auth` test target explicitly in `contracts/resolution/Cargo.toml` (alongside the existing `error_tests`/`ttl_tests` targets).

## Also fixes: broken Cargo.lock
Same pre-existing corruption described in my PR for #1179 in this repo (duplicate `limits` package entries, blocking the whole workspace) — regenerated via `cargo generate-lockfile`. Should be a no-op if #1179's PR merges first.

## Verification
`cargo test` (in `contracts/resolution`) — all 22 tests pass (7 new + 7 `error_tests` + 8 `ttl_tests`, all pre-existing tests unaffected).
