### PR TITLE
feat(tokens): add structured lifecycle events for off-chain indexers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,20 +1103,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "limits"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "limits"
@@ -2093,15 +2086,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokens"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [

--- a/contracts/tokens/Cargo.toml
+++ b/contracts/tokens/Cargo.toml
@@ -17,3 +17,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 [[test]]
 name = "limits"
 path = "tests/limits.rs"
+
+[[test]]
+name = "events"
+path = "tests/events.rs"

--- a/contracts/tokens/src/events.rs
+++ b/contracts/tokens/src/events.rs
@@ -1,0 +1,111 @@
+//! Structured lifecycle events for the tokens account-state registry.
+//!
+//! Every event carries a frozen topic [`Symbol`] and a `schema_version: u32`
+//! so off-chain indexers can route on `(topic, schema_version)` and detect a
+//! deliberate ABI change independently of any new event type being added.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+
+use crate::{AccountLimits, AccountStateKind, AccountUsage};
+
+/// Schema version for every event in this module. Frozen at v1.
+pub const TOKENS_EVENT_SCHEMA_VERSION: u32 = 1;
+
+pub const TOPIC_INITIALIZED: Symbol = symbol_short!("tk_init");
+pub const TOPIC_LIMITS_SET: Symbol = symbol_short!("tk_lims");
+pub const TOPIC_ITEM_TRACKED: Symbol = symbol_short!("tk_trkd");
+pub const TOPIC_ITEM_UNTRACKED: Symbol = symbol_short!("tk_untr");
+
+/// Emitted once the contract's admin and initial per-account limits are set.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokensInitializedEvent {
+    pub admin: Address,
+    pub account_limits: AccountLimits,
+    pub schema_version: u32,
+}
+
+/// Emitted whenever the global per-account limits are replaced.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountLimitsSetEvent {
+    pub admin: Address,
+    pub account_limits: AccountLimits,
+    pub schema_version: u32,
+}
+
+/// Emitted after an item is successfully tracked for an account.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ItemTrackedEvent {
+    pub account: Address,
+    pub kind: AccountStateKind,
+    pub usage: AccountUsage,
+    pub schema_version: u32,
+}
+
+/// Emitted after an item is successfully untracked for an account.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ItemUntrackedEvent {
+    pub account: Address,
+    pub kind: AccountStateKind,
+    pub usage: AccountUsage,
+    pub schema_version: u32,
+}
+
+/// Emit a [`TokensInitializedEvent`] under [`TOPIC_INITIALIZED`].
+pub fn emit_initialized(env: &Env, admin: &Address, account_limits: &AccountLimits) {
+    let event = TokensInitializedEvent {
+        admin: admin.clone(),
+        account_limits: *account_limits,
+        schema_version: TOKENS_EVENT_SCHEMA_VERSION,
+    };
+    env.events()
+        .publish((TOPIC_INITIALIZED, TOKENS_EVENT_SCHEMA_VERSION), event);
+}
+
+/// Emit an [`AccountLimitsSetEvent`] under [`TOPIC_LIMITS_SET`].
+pub fn emit_limits_set(env: &Env, admin: &Address, account_limits: &AccountLimits) {
+    let event = AccountLimitsSetEvent {
+        admin: admin.clone(),
+        account_limits: *account_limits,
+        schema_version: TOKENS_EVENT_SCHEMA_VERSION,
+    };
+    env.events()
+        .publish((TOPIC_LIMITS_SET, TOKENS_EVENT_SCHEMA_VERSION), event);
+}
+
+/// Emit an [`ItemTrackedEvent`] under [`TOPIC_ITEM_TRACKED`].
+pub fn emit_item_tracked(
+    env: &Env,
+    account: &Address,
+    kind: AccountStateKind,
+    usage: AccountUsage,
+) {
+    let event = ItemTrackedEvent {
+        account: account.clone(),
+        kind,
+        usage,
+        schema_version: TOKENS_EVENT_SCHEMA_VERSION,
+    };
+    env.events()
+        .publish((TOPIC_ITEM_TRACKED, TOKENS_EVENT_SCHEMA_VERSION), event);
+}
+
+/// Emit an [`ItemUntrackedEvent`] under [`TOPIC_ITEM_UNTRACKED`].
+pub fn emit_item_untracked(
+    env: &Env,
+    account: &Address,
+    kind: AccountStateKind,
+    usage: AccountUsage,
+) {
+    let event = ItemUntrackedEvent {
+        account: account.clone(),
+        kind,
+        usage,
+        schema_version: TOKENS_EVENT_SCHEMA_VERSION,
+    };
+    env.events()
+        .publish((TOPIC_ITEM_UNTRACKED, TOKENS_EVENT_SCHEMA_VERSION), event);
+}

--- a/contracts/tokens/src/lib.rs
+++ b/contracts/tokens/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![no_std]
 
+pub mod events;
 mod limits;
 
 pub use limits::{
@@ -43,7 +44,9 @@ impl TokensContract {
         account_limits: AccountLimits,
     ) -> Result<(), TokenLimitError> {
         admin.require_auth();
-        limits::initialize(&env, &admin, &account_limits)
+        limits::initialize(&env, &admin, &account_limits)?;
+        events::emit_initialized(&env, &admin, &account_limits);
+        Ok(())
     }
 
     /// Replaces the global limits applied independently to every account.
@@ -69,7 +72,9 @@ impl TokensContract {
         account_limits: AccountLimits,
     ) -> Result<(), TokenLimitError> {
         admin.require_auth();
-        limits::set_account_limits(&env, &admin, &account_limits)
+        limits::set_account_limits(&env, &admin, &account_limits)?;
+        events::emit_limits_set(&env, &admin, &account_limits);
+        Ok(())
     }
 
     /// Tracks one item for an account after enforcing its category cap.
@@ -96,7 +101,9 @@ impl TokensContract {
         item_id: BytesN<32>,
     ) -> Result<AccountUsage, TokenLimitError> {
         account.require_auth();
-        limits::track_account_item(&env, &account, &kind, &item_id)
+        let usage = limits::track_account_item(&env, &account, &kind, &item_id)?;
+        events::emit_item_tracked(&env, &account, kind, usage);
+        Ok(usage)
     }
 
     /// Removes one tracked item and releases its occupied capacity.
@@ -120,7 +127,9 @@ impl TokensContract {
         item_id: BytesN<32>,
     ) -> Result<AccountUsage, TokenLimitError> {
         account.require_auth();
-        limits::untrack_account_item(&env, &account, &kind, &item_id)
+        let usage = limits::untrack_account_item(&env, &account, &kind, &item_id)?;
+        events::emit_item_untracked(&env, &account, kind, usage);
+        Ok(usage)
     }
 
     /// Returns the configured global per-account limits.

--- a/contracts/tokens/tests/events.rs
+++ b/contracts/tokens/tests/events.rs
@@ -1,0 +1,110 @@
+#![cfg(test)]
+
+//! Structured lifecycle event tests for the tokens contract.
+//!
+//! `soroban_sdk::testutils::Events::all()` returns the emitted events in
+//! their raw XDR form in this SDK version, so these tests assert on event
+//! *counts* per lifecycle transition rather than decoding payloads — the
+//! payload shape itself is covered by the `#[contracttype]` definitions in
+//! `src/events.rs`.
+
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    Address, BytesN, Env,
+};
+use tokens::{AccountLimits, AccountStateKind, TokensContract, TokensContractClient};
+
+fn limits(bets: u32, positions: u32, subscriptions: u32) -> AccountLimits {
+    AccountLimits {
+        bets,
+        positions,
+        subscriptions,
+    }
+}
+
+fn item_id(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn event_count(env: &Env) -> usize {
+    env.events().all().events().len()
+}
+
+#[test]
+fn initialize_emits_exactly_one_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokensContract, ());
+    let client = TokensContractClient::new(&env, &contract_id);
+
+    assert_eq!(event_count(&env), 0);
+    client.initialize(&admin, &limits(2, 2, 2));
+    assert_eq!(event_count(&env), 1);
+}
+
+#[test]
+fn set_account_limits_emits_exactly_one_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokensContract, ());
+    let client = TokensContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &limits(2, 2, 2));
+
+    client.set_account_limits(&admin, &limits(5, 5, 5));
+    assert_eq!(event_count(&env), 1, "last invocation must publish exactly one event");
+}
+
+#[test]
+fn track_account_item_emits_exactly_one_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokensContract, ());
+    let client = TokensContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &limits(2, 2, 2));
+    let account = Address::generate(&env);
+
+    client.track_account_item(&account, &AccountStateKind::Bet, &item_id(&env, 1));
+    assert_eq!(event_count(&env), 1, "last invocation must publish exactly one event");
+}
+
+#[test]
+fn untrack_account_item_emits_exactly_one_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokensContract, ());
+    let client = TokensContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &limits(2, 2, 2));
+    let account = Address::generate(&env);
+    let id = item_id(&env, 1);
+    client.track_account_item(&account, &AccountStateKind::Position, &id);
+
+    client.untrack_account_item(&account, &AccountStateKind::Position, &id);
+    assert_eq!(event_count(&env), 1, "last invocation must publish exactly one event");
+}
+
+#[test]
+fn full_lifecycle_emits_one_event_per_transition() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokensContract, ());
+    let client = TokensContractClient::new(&env, &contract_id);
+    let account = Address::generate(&env);
+    let id = item_id(&env, 7);
+
+    client.initialize(&admin, &limits(2, 2, 2));
+    assert_eq!(event_count(&env), 1);
+
+    client.set_account_limits(&admin, &limits(3, 3, 3));
+    assert_eq!(event_count(&env), 1);
+
+    client.track_account_item(&account, &AccountStateKind::Subscription, &id);
+    assert_eq!(event_count(&env), 1);
+
+    client.untrack_account_item(&account, &AccountStateKind::Subscription, &id);
+    assert_eq!(event_count(&env), 1);
+}


### PR DESCRIPTION
Closes #1177

## Summary
Adds `contracts/tokens/src/events.rs`: stable, structured events for the tokens account-state registry's lifecycle, for off-chain indexers.

Every event carries a frozen topic `Symbol` and a `schema_version: u32` field so indexers can route on `(topic, schema_version)` and detect a deliberate ABI change independently of new event types being added later:

- `TokensInitializedEvent` (`tk_init`) — admin + initial per-account limits recorded.
- `AccountLimitsSetEvent` (`tk_lims`) — global per-account limits replaced.
- `ItemTrackedEvent` (`tk_trkd`) — an item successfully tracked for an account (carries the resulting `AccountUsage`).
- `ItemUntrackedEvent` (`tk_untr`) — an item successfully untracked for an account (carries the resulting `AccountUsage`).

Wired into `contracts/tokens/src/lib.rs`: each of `initialize`, `set_account_limits`, `track_account_item`, `untrack_account_item` now emits its corresponding event immediately after the underlying state change succeeds (before returning `Ok`).

## Also fixes: broken Cargo.lock
Same pre-existing corruption described in my PR for #1179 in this repo (duplicate `limits` package entries, blocking the whole workspace) — regenerated via `cargo generate-lockfile`. Should be a no-op if #1179's PR merges first.

## Tests
`contracts/tokens/tests/events.rs`: each of the four entrypoints publishes exactly one event on its invocation, plus a full-lifecycle sequence test. Note: `testutils::Events::all()` in the currently-pinned soroban-sdk version reflects only the *last* contract invocation (not a cumulative log across the `Env`'s lifetime, despite some older code elsewhere in this repo assuming otherwise) — tests are written against that actual, current semantics.

## Verification
`cargo test` (in `contracts/tokens`) — all 23 tests pass (5 new + 3 lib unit tests + 15 existing `limits` integration tests, all pre-existing tests unaffected).
