### PR TITLE
feat(storage): add capabilities bitmap flags

### DIFF
--- a/contracts/predictify-hybrid/docs/capabilities.md
+++ b/contracts/predictify-hybrid/docs/capabilities.md
@@ -1,7 +1,31 @@
 # Capabilities
 
 The Predictify Hybrid contract exposes `capabilities()` as a read-only `u64`
-bitmap describing the recovery features supported by the active Wasm.
+bitmap describing the recovery and storage features supported by the active
+Wasm. The call requires no authorization, reads no storage, and emits no
+events. Clients should test individual bits instead of comparing the complete
+bitmap so future feature additions remain backward-compatible.
+
+## Bitmap layout
+
+Recovery features occupy bits 0-10. Storage features use the following stable
+assignments:
+
+| Bit | Constant | Storage feature |
+| ---: | --- | --- |
+| 11 | `TTL_MANAGEMENT` | TTL extension and storage-rent preflight checks |
+| 12 | `DATA_COMPRESSION` | Market-data compression |
+| 13 | `DATA_CLEANUP` | Expired or obsolete market-data cleanup |
+| 14 | `FORMAT_MIGRATION` | Versioned storage-format migration |
+| 15 | `TIER_MIGRATION` | Persistent/temporary tier promotion and demotion |
+| 16 | `USAGE_MONITORING` | Storage-usage monitoring and statistics |
+| 17 | `LAYOUT_OPTIMIZATION` | Per-market layout optimization |
+| 18 | `INTEGRITY_VALIDATION` | Per-market storage integrity validation |
+| 19 | `CONFIGURATION` | Storage configuration reads and updates |
+| 20 | `COST_ANALYTICS` | Cost, efficiency, and recommendation views |
+
+Bits 21-63 are reserved. Assigned bits are never reused for a different
+feature; an unavailable feature is represented by clearing its existing bit.
 
 ## Admin cooldown
 

--- a/contracts/predictify-hybrid/src/capabilities/mod.rs
+++ b/contracts/predictify-hybrid/src/capabilities/mod.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::Env;
 
 pub(crate) mod admin;
+pub mod storage;
 
 /// Recovery feature capability flags (u64 bitmap).
 ///
@@ -8,8 +9,6 @@ pub(crate) mod admin;
 /// Clients can compare the bitmap across contract versions to detect
 /// capability deltas (features added or removed after an upgrade).
 pub mod recovery {
-    use super::*;
-
     /// Per-market timelock before a recovery action can be executed.
     pub const TIMELOCK_GUARD: u64 = 1 << 0;
     /// Admin-initiated market state reconstruction (fix total_staked mismatches, etc.).
@@ -46,12 +45,50 @@ pub mod recovery {
         | INTEGRITY_VALIDATOR;
 }
 
-/// Returns the recovery feature bitmap for the current contract version.
+/// Combined bitmap of all features advertised by this contract version.
+pub const SUPPORTED: u64 = recovery::SUPPORTED | storage::SUPPORTED;
+
+/// Returns the feature bitmap for the current contract version.
 ///
-/// Clients can call this read-only view to discover which recovery
+/// Clients can call this read-only view to discover which recovery and storage
 /// capabilities are available and detect changes after contract upgrades.
 pub fn capabilities(_env: &Env) -> u64 {
-    recovery::SUPPORTED
+    SUPPORTED
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{capabilities, recovery, storage, SUPPORTED};
+    use soroban_sdk::Env;
+
+    #[test]
+    fn subsystem_bitmaps_are_disjoint() {
+        assert_eq!(
+            recovery::SUPPORTED & storage::SUPPORTED,
+            0,
+            "recovery and storage capability bits must not overlap"
+        );
+    }
+
+    #[test]
+    fn capabilities_combines_all_supported_subsystems() {
+        let env = Env::default();
+
+        assert_eq!(capabilities(&env), SUPPORTED);
+        assert_eq!(SUPPORTED, recovery::SUPPORTED | storage::SUPPORTED);
+    }
+
+    #[test]
+    fn unassigned_bits_remain_clear() {
+        const ASSIGNED_BITS: u32 = 21;
+        let reserved_mask = !((1u64 << ASSIGNED_BITS) - 1);
+
+        assert_eq!(
+            SUPPORTED & reserved_mask,
+            0,
+            "bits 21-63 are reserved for future capabilities"
+        );
+    }
 }
 
 /// Returns the fixed cooldown between repeated capability-critical admin actions.

--- a/contracts/predictify-hybrid/src/capabilities/storage.rs
+++ b/contracts/predictify-hybrid/src/capabilities/storage.rs
@@ -1,0 +1,96 @@
+//! Capability flags for the storage subsystem.
+//!
+//! These flags occupy bits 11-20 of the contract-wide `u64` bitmap returned by
+//! `PredictifyHybrid::capabilities()`. Bits 0-10 remain assigned to recovery
+//! features. Once assigned, a bit must not be reused for a different feature.
+
+/// Automatic TTL extension and storage-rent preflight checks.
+pub const TTL_MANAGEMENT: u64 = 1 << 11;
+/// Market-data compression and compressed-record support.
+pub const DATA_COMPRESSION: u64 = 1 << 12;
+/// Removal of expired or obsolete market data.
+pub const DATA_CLEANUP: u64 = 1 << 13;
+/// Versioned storage-format migrations.
+pub const FORMAT_MIGRATION: u64 = 1 << 14;
+/// Promotion and demotion between persistent and temporary storage tiers.
+pub const TIER_MIGRATION: u64 = 1 << 15;
+/// Storage-usage monitoring and statistics views.
+pub const USAGE_MONITORING: u64 = 1 << 16;
+/// Per-market storage-layout optimization.
+pub const LAYOUT_OPTIMIZATION: u64 = 1 << 17;
+/// Per-market storage integrity validation.
+pub const INTEGRITY_VALIDATION: u64 = 1 << 18;
+/// Read and update support for storage configuration.
+pub const CONFIGURATION: u64 = 1 << 19;
+/// Storage cost, efficiency-score, and recommendation views.
+pub const COST_ANALYTICS: u64 = 1 << 20;
+
+/// Bitmap of all storage features supported by this contract build.
+pub const SUPPORTED: u64 = TTL_MANAGEMENT
+    | DATA_COMPRESSION
+    | DATA_CLEANUP
+    | FORMAT_MIGRATION
+    | TIER_MIGRATION
+    | USAGE_MONITORING
+    | LAYOUT_OPTIMIZATION
+    | INTEGRITY_VALIDATION
+    | CONFIGURATION
+    | COST_ANALYTICS;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FLAGS: [u64; 10] = [
+        TTL_MANAGEMENT,
+        DATA_COMPRESSION,
+        DATA_CLEANUP,
+        FORMAT_MIGRATION,
+        TIER_MIGRATION,
+        USAGE_MONITORING,
+        LAYOUT_OPTIMIZATION,
+        INTEGRITY_VALIDATION,
+        CONFIGURATION,
+        COST_ANALYTICS,
+    ];
+
+    #[test]
+    fn bit_positions_are_stable() {
+        assert_eq!(TTL_MANAGEMENT, 1 << 11);
+        assert_eq!(DATA_COMPRESSION, 1 << 12);
+        assert_eq!(DATA_CLEANUP, 1 << 13);
+        assert_eq!(FORMAT_MIGRATION, 1 << 14);
+        assert_eq!(TIER_MIGRATION, 1 << 15);
+        assert_eq!(USAGE_MONITORING, 1 << 16);
+        assert_eq!(LAYOUT_OPTIMIZATION, 1 << 17);
+        assert_eq!(INTEGRITY_VALIDATION, 1 << 18);
+        assert_eq!(CONFIGURATION, 1 << 19);
+        assert_eq!(COST_ANALYTICS, 1 << 20);
+    }
+
+    #[test]
+    fn flags_are_distinct_single_bits() {
+        for (index, flag) in FLAGS.iter().enumerate() {
+            assert!(
+                flag.is_power_of_two(),
+                "flag at index {index} is not a single bit"
+            );
+
+            for other in FLAGS.iter().skip(index + 1) {
+                assert_eq!(flag & other, 0, "storage capability flags overlap");
+            }
+        }
+    }
+
+    #[test]
+    fn supported_bitmap_contains_exactly_the_documented_flags() {
+        let expected = FLAGS
+            .iter()
+            .copied()
+            .fold(0u64, |bitmap, flag| bitmap | flag);
+
+        assert_eq!(SUPPORTED, expected);
+        assert_eq!(SUPPORTED & ((1u64 << 11) - 1), 0);
+        assert_eq!(SUPPORTED & !((1u64 << 21) - 1), 0);
+    }
+}

--- a/contracts/predictify-hybrid/src/lib.rs
+++ b/contracts/predictify-hybrid/src/lib.rs
@@ -87,7 +87,10 @@ mod event_topic_catalog;
 mod storage_tier_audit;
 mod leaderboard;
 mod lists;
-mod capabilities;
+pub mod capabilities;
+
+#[cfg(test)]
+mod storage_capability_tests;
 
 #[cfg(test)]
 mod override_audit_tests;
@@ -5930,13 +5933,15 @@ impl PredictifyHybrid {
 
     /// Return the capability bitmap for the active contract version.
     ///
-    /// Clients can call this entrypoint to learn which feature flags are enabled
-    /// without maintaining a client-side version-to-capability lookup table.
+    /// Clients can call this read-only entrypoint to learn which recovery and
+    /// storage feature flags are enabled without maintaining a client-side
+    /// version-to-capability lookup table. It requires no authorization,
+    /// performs no storage access, and emits no events.
     ///
     /// # What
     ///
-    /// Returns a `u64` bitmask where each bit corresponds to a `CAPABILITY_*`
-    /// constant defined in the [`versioning`] module.
+    /// Returns a `u64` bitmask. Recovery flags occupy bits 0-10 and storage
+    /// flags occupy bits 11-20 as defined in the [`capabilities`] module.
     ///
     /// # How
     ///

--- a/contracts/predictify-hybrid/src/storage_capability_tests.rs
+++ b/contracts/predictify-hybrid/src/storage_capability_tests.rs
@@ -1,0 +1,65 @@
+use crate::{
+    capabilities::{storage, SUPPORTED},
+    PredictifyHybrid, PredictifyHybridClient,
+};
+use soroban_sdk::{
+    testutils::{EnvTestConfig, Events},
+    Env, Symbol,
+};
+
+fn test_env() -> Env {
+    let mut env = Env::default();
+    env.set_config(EnvTestConfig {
+        capture_snapshot_at_drop: false,
+    });
+    env
+}
+
+#[test]
+fn public_view_advertises_storage_capabilities() {
+    let env = test_env();
+    let contract_id = env.register(PredictifyHybrid, ());
+    let client = PredictifyHybridClient::new(&env, &contract_id);
+
+    let bitmap = client.capabilities();
+
+    assert_eq!(bitmap, SUPPORTED);
+    assert_eq!(bitmap & storage::SUPPORTED, storage::SUPPORTED);
+}
+
+#[test]
+fn public_view_requires_no_auth_and_has_no_side_effects() {
+    let env = test_env();
+    let contract_id = env.register(PredictifyHybrid, ());
+    let client = PredictifyHybridClient::new(&env, &contract_id);
+    let sentinel = Symbol::new(&env, "cap_test");
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&sentinel, &7u32);
+    });
+    let events_before = env.events().all().len();
+
+    let first = client.capabilities();
+    let second = client.capabilities();
+
+    assert_eq!(
+        first, second,
+        "the compile-time bitmap must be deterministic"
+    );
+    assert!(
+        env.auths().is_empty(),
+        "capabilities() must not require authorization"
+    );
+    assert_eq!(
+        env.events().all().len(),
+        events_before,
+        "capabilities() must not emit events"
+    );
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage().persistent().get::<_, u32>(&sentinel),
+            Some(7),
+            "capabilities() must not mutate existing contract storage"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

- extend the existing read-only `capabilities()` view with ten storage feature flags on bits 11–20
- expose stable public constants and preserve non-overlap with recovery flags
- document the bitmap layout, reserved bits, and compatibility guidance
- add focused bitmap and public-view tests covering stability, authorization, events, and storage side effects

## Test evidence

- `rustc --test contracts/predictify-hybrid/src/capabilities/storage.rs`: 3 passed
- standalone production compile of the storage capability module: passed
- direct rustfmt checks for changed Rust modules: passed
- `git diff --check`: passed
- broad Cargo verification remains blocked by pre-existing repository defects: duplicate `limits` entries in Cargo.lock, missing `std_reference.wasm`, missing declared test files, and existing Predictify Hybrid compilation errors

Fixes #1340

### Verification
- `PASS: standalone production compile of `capabilities/storage.rs``
- `PASS: focused storage capability tests — 3 passed`
- `PASS: direct rustfmt checks for changed Rust modules`
- `PASS: `git diff --check``
- `BASELINE: workspace Cargo.lock contains duplicate `limits` entries`
- `BASELINE: temporary regenerated-lock `cargo check -p predictify-hybrid --lib` reached 256 unrelated existing errors, including missing `std_reference.wasm``
- `BASELINE: workspace cargo fmt cannot resolve missing `src/gas/gas_test.rs` and `tests/stateful.rs``

### Diagnostics
Recovered command failures: `/bin/zsh -lc "sed -n '1,180p' contracts/predictify-hybrid/src/lib.rs && rg -n \"capabil\" contracts/predictify-hybrid/src/test.rs contracts/predictify-hybrid/src/*test*.rs 2>/dev/null"` (2), `/bin/zsh -lc 'cargo check -p predictify-hybrid --lib'` (101), `/bin/zsh -lc 'rg -n "''^target|test_snapshots|'"\\.tmp|Cargo\\.lock\" .gitignore .git/info/exclude 2>/dev/null || true && sed -n '1,240p' .gitignore"` (1), `/bin/zsh -lc 'cargo fmt -p predictify-hybrid -- --check'` (1), `/bin/zsh -lc 'rustfmt --edition 2021 --check contracts/predictify-hybrid/src/capabilities/mod.rs contracts/predictify-hybrid/src/capabilities/storage.rs contracts/predictify-hybrid/src/storage_capability_tests.rs'` (1), `/bin/zsh -lc 'git restore --source=HEAD -- target/.rustc_info.json && git status --short'` (128), `/bin/zsh -lc 'set -e
lock_backup=$(mktemp /tmp/predictify-lock.XXXXXX)
test_target=$(mktemp -d /tmp/predictify-target.XXXXXX)
mv Cargo.lock "$lock_backup"
restore_lock() {
  mv -f "$lock_backup" Cargo.lock
}
trap restore_lock EXIT
cargo generate-lockfile
CARGO_TARGET_DIR="$test_target" cargo check -p predictify-hybrid --lib'` (101), `/bin/zsh -lc 'set -e
lock_backup=$(mktemp /tmp/predictify-lock.XXXXXX)
test_target=$(mktemp -d /tmp/predictify-target.XXXXXX)
dep_cache=$(mktemp -d /tmp/predictify-cargo-cache.XXXXXX)
mv Cargo.lock "$lock_backup"
restore_lock() {
  mv -f "$lock_backup" Cargo.lock
}
trap restore_lock EXIT
CARGO_HOME="$dep_cache" cargo generate-lockfile
CARGO_HOME="$dep_cache" CARGO_TARGET_DIR="$test_target" cargo check -p predictify-hybrid --lib'` (101)